### PR TITLE
Fix ineffective GlobalConfig Workflow settings

### DIFF
--- a/docs/examples/workflows/global_config.md
+++ b/docs/examples/workflows/global_config.md
@@ -1,0 +1,39 @@
+# Global Config
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.shared import global_config
+    from hera.workflows import Container, Workflow
+
+    global_config.api_version = "argoproj.io/v0beta9000"
+    global_config.namespace = "argo-namespace"
+    global_config.service_account_name = "argo-account"
+
+    with Workflow(generate_name="global-config-", entrypoint="whalesay") as w:
+        whalesay = Container(image="docker/whalesay:latest", command=["cowsay"])
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v0beta9000
+    kind: Workflow
+    metadata:
+      generateName: global-config-
+      namespace: argo-namespace
+    spec:
+      entrypoint: whalesay
+      serviceAccountName: argo-account
+      templates:
+      - container:
+          command:
+          - cowsay
+          image: docker/whalesay:latest
+    ```
+

--- a/examples/workflows/global-config.yaml
+++ b/examples/workflows/global-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v0beta9000
+kind: Workflow
+metadata:
+  generateName: global-config-
+  namespace: argo-namespace
+spec:
+  entrypoint: whalesay
+  serviceAccountName: argo-account
+  templates:
+  - container:
+      command:
+      - cowsay
+      image: docker/whalesay:latest

--- a/examples/workflows/global_config.py
+++ b/examples/workflows/global_config.py
@@ -1,0 +1,9 @@
+from hera.shared import global_config
+from hera.workflows import Container, Workflow
+
+global_config.api_version = "argoproj.io/v0beta9000"
+global_config.namespace = "argo-namespace"
+global_config.service_account_name = "argo-account"
+
+with Workflow(generate_name="global-config-", entrypoint="whalesay") as w:
+    whalesay = Container(image="docker/whalesay:latest", command=["cowsay"])

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -80,7 +80,7 @@ class Workflow(
     """
 
     # Workflow fields - https://argoproj.github.io/argo-workflows/fields/#workflow
-    api_version: Optional[str] = global_config.api_version
+    api_version: Optional[str] = None
     kind: Optional[str] = None
     status: Optional[WorkflowStatus] = None
 
@@ -147,6 +147,12 @@ class Workflow(
     # Hera-specific fields
     workflows_service: Optional[WorkflowsService] = None
 
+    @validator("api_version", pre=True, always=True)
+    def _set_api_version(cls, v):
+        if v is None:
+            return global_config.api_version
+        return v
+
     @validator("workflows_service", pre=True, always=True)
     def _set_workflows_service(cls, v):
         if v is None:
@@ -163,6 +169,12 @@ class Workflow(
     def _set_namespace(cls, v):
         if v is None:
             return global_config.namespace
+        return v
+
+    @validator("service_account_name", pre=True, always=True)
+    def _set_service_account_name(cls, v):
+        if v is None:
+            return global_config.service_account_name
         return v
 
     @validator("image_pull_secrets", pre=True, always=True)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,6 +10,7 @@ import yaml
 
 import examples.workflows as hera_examples
 import examples.workflows.upstream as hera_upstream_examples
+from hera.shared import global_config
 from hera.workflows import (
     CronWorkflow as HeraCronWorkflow,
     Workflow as HeraWorkflow,
@@ -61,6 +62,7 @@ def _transform_cron_workflow(obj):
 )
 def test_hera_output(module_name):
     # GIVEN
+    global_config.reset()
     workflow = importlib.import_module(f"examples.workflows.{module_name}").w
     yaml_path = Path(hera_examples.__file__).parent / f"{module_name.replace('_', '-')}.yaml"
 
@@ -77,6 +79,7 @@ def test_hera_output(module_name):
 @pytest.mark.parametrize("module_name", [name for _, name, _ in pkgutil.iter_modules(hera_upstream_examples.__path__)])
 def test_hera_output_upstream(module_name):
     # GIVEN
+    global_config.reset()
     workflow = importlib.import_module(f"examples.workflows.upstream.{module_name}").w
     yaml_path = Path(hera_upstream_examples.__file__).parent / f"{module_name.replace('_', '-')}.yaml"
     upstream_yaml_path = (


### PR DESCRIPTION
Fixes that the following global settings were not being applied in `Workflow` and derivative classes:
- `GlobalConfig.apiVersion`
- `GlobalConfig.service_account_name`
