### PR TITLE
Fix: Use correct parameter names for Create and Lint requests

### DIFF
--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -80,7 +80,7 @@ class CronWorkflow(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.create_cron_workflow(
-            self.namespace, CreateCronWorkflowRequest(workflow=self.build())
+            self.namespace, CreateCronWorkflowRequest(cron_workflow=self.build())
         )
 
     def lint(self) -> TWorkflow:
@@ -88,7 +88,7 @@ class CronWorkflow(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.lint_cron_workflow(
-            self.namespace, LintCronWorkflowRequest(workflow=self.build())
+            self.namespace, LintCronWorkflowRequest(cron_workflow=self.build())
         )
 
 

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -37,7 +37,7 @@ class WorkflowTemplate(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.create_workflow_template(
-            self.namespace, WorkflowTemplateCreateRequest(workflow=self.build())
+            self.namespace, WorkflowTemplateCreateRequest(template=self.build())
         )
 
     def lint(self) -> TWorkflow:
@@ -45,7 +45,7 @@ class WorkflowTemplate(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.lint_workflow_template(
-            self.namespace, WorkflowTemplateLintRequest(workflow=self.build())
+            self.namespace, WorkflowTemplateLintRequest(template=self.build())
         )
 
     def build(self) -> TWorkflow:


### PR DESCRIPTION
When actually trying to create WorkflowTemplate on Argo, the request body will be empty due to the use of the wrong keyword argument "workflow" instead of "template" for the `WorkflowTemplateCreateRequest`.

Similar issue with lint request, both for WorkflowTemplate and CronTemplate.

No tests to add, since they cannot communicate with Argo.