### PR TITLE
Script.resources is not the same as ModelTemplate.resource

### DIFF
--- a/docs/examples/workflows/script_with_resources.md
+++ b/docs/examples/workflows/script_with_resources.md
@@ -1,0 +1,51 @@
+# Script With Resources
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Resources, Workflow, script
+
+
+    @script(resources=Resources(memory_request="5Gi"))
+    def task_with_memory_request():
+        print("ok")
+
+
+    with Workflow(generate_name="script-with-resources-", entrypoint="task-with-memory-request") as w:
+        task_with_memory_request()
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: script-with-resources-
+    spec:
+      entrypoint: task-with-memory-request
+      templates:
+      - name: task-with-memory-request
+        script:
+          command:
+          - python
+          image: python:3.8
+          resources:
+            requests:
+              memory: 5Gi
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            print("ok")
+
+            '
+    ```
+

--- a/examples/workflows/script-with-resources.yaml
+++ b/examples/workflows/script-with-resources.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: script-with-resources-
+spec:
+  entrypoint: task-with-memory-request
+  templates:
+  - name: task-with-memory-request
+    script:
+      command:
+      - python
+      image: python:3.8
+      resources:
+        requests:
+          memory: 5Gi
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        print("ok")
+
+        '

--- a/examples/workflows/script_with_resources.py
+++ b/examples/workflows/script_with_resources.py
@@ -1,0 +1,10 @@
+from hera.workflows import Resources, Workflow, script
+
+
+@script(resources=Resources(memory_request="5Gi"))
+def task_with_memory_request():
+    print("ok")
+
+
+with Workflow(generate_name="script-with-resources-", entrypoint="task-with-memory-request") as w:
+    task_with_memory_request()

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -166,7 +166,6 @@ class Script(
                 pod_spec_patch=self.pod_spec_patch,
                 priority=self.priority,
                 priority_class_name=self.priority_class_name,
-                resource=self._build_resources(),
                 retry_strategy=self.retry_strategy,
                 scheduler_name=self.scheduler_name,
                 script=self._build_script(),


### PR DESCRIPTION
This looks like a possible typo. I don't believe `self._build_resources(),` should be passed to the ModelTemplate constructor as resource.

The following code currently fails with a pydantic error, but works correctly with the constructor argument removed.

```python
from hera.workflows import Task, Workflow, Resources, script


@script(resources=Resources(memory_request='5Gi'))
def task_with_lots_of_memory():
    print('ok')


with Workflow(
    name="test",
    entrypoint='main',
) as test_wf:

    with DAG(name='main', ) as main:
        this_should_pass: Task = task_with_lots_of_memory()

if __name__ == "__main__":
    print(test_wf.to_yaml())
```

Error:
```
pydantic.error_wrappers.ValidationError: 1 validation error for Template
resource -> action
  field required (type=value_error.missing)
```