### PR TITLE
Add missing typing extensions to docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+typing_extensions
 mkdocs
 mkdocs-material
 mkdocs-include-markdown-plugin


### PR DESCRIPTION
RTD build is failing with an error that suggests the package `typing_extensions` is missing. This adds the package