### PR TITLE
Fix service generator, regen services

### DIFF
--- a/scripts/service.py
+++ b/scripts/service.py
@@ -91,6 +91,8 @@ class ServiceEndpoint:
         self.url = self.parse_url(url)
         self.method = method
         self.name = name
+        # these need to be sorted as they are used to create the function signature. Required parameters must be
+        # prioritized. Note that we set `reverse=True` since `False` will be sorted before `True`
         self.params = sorted(params, key=lambda p: p.required, reverse=True)
         self.response = response
         self.summary = summary

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -91,7 +91,7 @@ class ServiceEndpoint:
         self.url = self.parse_url(url)
         self.method = method
         self.name = name
-        self.params = params
+        self.params = sorted(params, key=lambda p: p.required, reverse=True)
         self.response = response
         self.summary = summary
         self.consumes = consumes
@@ -126,8 +126,16 @@ class ServiceEndpoint:
         if len(path_params) == 0:
             req_url = f"os.path.join(self.host, '{self.url}')"
         else:
-            req_url_params = ", ".join([f"{p.field}={p.name}" for p in path_params])
-            req_url = f"os.path.join(self.host, '{self.url}').format({req_url_params})"
+            # note that here we have a condition on `namespace` because `namespace` can be a global configuration. So,
+            # we either take it from the endpoint (prioritized just in case users rely on the service to use
+            # generated models but not Hera models) or from the global configuration
+            req_url_params = []
+            for p in path_params:
+                if p.name == "namespace":
+                    req_url_params.append("namespace=namespace if namespace is not None else self.namespace")
+                else:
+                    req_url_params.append(f"{p.field}={p.name}")
+            req_url = f"os.path.join(self.host, '{self.url}').format({', '.join(req_url_params)})"
 
         # query params
         query_params = [p for p in self.params if p.in_ == "query"]
@@ -304,6 +312,11 @@ def parse_parameter(parameter: dict, models_type: str) -> Parameter:
     name_ = parse_builtin(name_)
     name_ = name_.lower()
 
+    # a lot of endpoints use a parameter called `namespace`. The Hera service uses `namespace` as an optional keyword
+    # because it's actually set on the service itself. Here, we check for `namespace` and intentionally make
+    # it optional
+    if name_ == "namespace":
+        return Parameter(name_, name, in_, type_, False)
     return Parameter(name_, name, in_, type_, required)
 
 

--- a/src/hera/events/service.py
+++ b/src/hera/events/service.py
@@ -43,7 +43,7 @@ class EventsService:
 
     def list_event_sources(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -55,7 +55,9 @@ class EventsService:
         continue_: Optional[str] = None,
     ) -> EventSourceList:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/event-sources/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/event-sources/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -77,9 +79,11 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def create_event_source(self, namespace: str, req: CreateEventSourceRequest) -> EventSource:
+    def create_event_source(self, req: CreateEventSourceRequest, namespace: Optional[str] = None) -> EventSource:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/event-sources/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/event-sources/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -93,10 +97,10 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_event_source(self, namespace: str, name: str) -> EventSource:
+    def get_event_source(self, name: str, namespace: Optional[str] = None) -> EventSource:
         resp = requests.get(
             url=os.path.join(self.host, "api/v1/event-sources/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -109,10 +113,12 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def update_event_source(self, namespace: str, name: str, req: UpdateEventSourceRequest) -> EventSource:
+    def update_event_source(
+        self, name: str, req: UpdateEventSourceRequest, namespace: Optional[str] = None
+    ) -> EventSource:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/event-sources/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -129,8 +135,8 @@ class EventsService:
 
     def delete_event_source(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         grace_period_seconds: Optional[str] = None,
         uid: Optional[str] = None,
         resource_version: Optional[str] = None,
@@ -140,7 +146,7 @@ class EventsService:
     ) -> EventSourceDeletedResponse:
         resp = requests.delete(
             url=os.path.join(self.host, "api/v1/event-sources/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={
                 "deleteOptions.gracePeriodSeconds": grace_period_seconds,
@@ -160,10 +166,10 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def receive_event(self, namespace: str, discriminator: str, req: Item) -> EventResponse:
+    def receive_event(self, discriminator: str, req: Item, namespace: Optional[str] = None) -> EventResponse:
         resp = requests.post(
             url=os.path.join(self.host, "api/v1/events/{namespace}/{discriminator}").format(
-                namespace=namespace, discriminator=discriminator
+                discriminator=discriminator, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -194,7 +200,7 @@ class EventsService:
 
     def list_sensors(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -206,7 +212,9 @@ class EventsService:
         continue_: Optional[str] = None,
     ) -> SensorList:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/sensors/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/sensors/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -228,9 +236,11 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def create_sensor(self, namespace: str, req: CreateSensorRequest) -> Sensor:
+    def create_sensor(self, req: CreateSensorRequest, namespace: Optional[str] = None) -> Sensor:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/sensors/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/sensors/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -244,9 +254,11 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_sensor(self, namespace: str, name: str, resource_version: Optional[str] = None) -> Sensor:
+    def get_sensor(self, name: str, namespace: Optional[str] = None, resource_version: Optional[str] = None) -> Sensor:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(namespace=namespace, name=name),
+            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(
+                name=name, namespace=namespace if namespace is not None else self.namespace
+            ),
             params={"getOptions.resourceVersion": resource_version},
             headers={"Authorization": f"Bearer {self.token}"},
             data=None,
@@ -258,9 +270,11 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def update_sensor(self, namespace: str, name: str, req: UpdateSensorRequest) -> Sensor:
+    def update_sensor(self, name: str, req: UpdateSensorRequest, namespace: Optional[str] = None) -> Sensor:
         resp = requests.put(
-            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(namespace=namespace, name=name),
+            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(
+                name=name, namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -276,8 +290,8 @@ class EventsService:
 
     def delete_sensor(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         grace_period_seconds: Optional[str] = None,
         uid: Optional[str] = None,
         resource_version: Optional[str] = None,
@@ -286,7 +300,9 @@ class EventsService:
         dry_run: Optional[list] = None,
     ) -> DeleteSensorResponse:
         resp = requests.delete(
-            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(namespace=namespace, name=name),
+            url=os.path.join(self.host, "api/v1/sensors/{namespace}/{name}").format(
+                name=name, namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "deleteOptions.gracePeriodSeconds": grace_period_seconds,
                 "deleteOptions.preconditions.uid": uid,
@@ -307,7 +323,7 @@ class EventsService:
 
     def watch_event_sources(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -319,7 +335,9 @@ class EventsService:
         continue_: Optional[str] = None,
     ) -> EventSourceWatchEvent:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/stream/event-sources/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/stream/event-sources/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -343,7 +361,7 @@ class EventsService:
 
     def event_sources_logs(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         name: Optional[str] = None,
         event_source_type: Optional[str] = None,
         event_name: Optional[str] = None,
@@ -360,7 +378,9 @@ class EventsService:
         insecure_skip_tls_verify_backend: Optional[bool] = None,
     ) -> EventsourceLogEntry:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/stream/event-sources/{namespace}/logs").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/stream/event-sources/{namespace}/logs").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "name": name,
                 "eventSourceType": event_source_type,
@@ -389,7 +409,7 @@ class EventsService:
 
     def watch_events(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -401,7 +421,9 @@ class EventsService:
         continue_: Optional[str] = None,
     ) -> Event:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/stream/events/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/stream/events/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -425,7 +447,7 @@ class EventsService:
 
     def watch_sensors(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -437,7 +459,9 @@ class EventsService:
         continue_: Optional[str] = None,
     ) -> SensorWatchEvent:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/stream/sensors/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/stream/sensors/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -461,7 +485,7 @@ class EventsService:
 
     def sensors_logs(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         name: Optional[str] = None,
         trigger_name: Optional[str] = None,
         grep: Optional[str] = None,
@@ -477,7 +501,9 @@ class EventsService:
         insecure_skip_tls_verify_backend: Optional[bool] = None,
     ) -> SensorLogEntry:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/stream/sensors/{namespace}/logs").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/stream/sensors/{namespace}/logs").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "name": name,
                 "triggerName": trigger_name,
@@ -533,12 +559,12 @@ class EventsService:
 
     def get_artifact_file(
         self,
-        namespace: str,
         id_discriminator: str,
         id_: str,
         node_id: str,
         artifact_name: str,
         artifact_discriminator: str,
+        namespace: Optional[str] = None,
     ) -> str:
         """Get an artifact."""
         resp = requests.get(
@@ -546,12 +572,12 @@ class EventsService:
                 self.host,
                 "artifact-files/{namespace}/{idDiscriminator}/{id}/{nodeId}/{artifactDiscriminator}/{artifactName}",
             ).format(
-                namespace=namespace,
                 idDiscriminator=id_discriminator,
                 id=id_,
                 nodeId=node_id,
                 artifactName=artifact_name,
                 artifactDiscriminator=artifact_discriminator,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -581,11 +607,14 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_output_artifact(self, namespace: str, name: str, node_id: str, artifact_name: str) -> str:
+    def get_output_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an output artifact."""
         resp = requests.get(
             url=os.path.join(self.host, "artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
-                namespace=namespace, name=name, nodeId=node_id, artifactName=artifact_name
+                name=name,
+                nodeId=node_id,
+                artifactName=artifact_name,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -615,11 +644,14 @@ class EventsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_input_artifact(self, namespace: str, name: str, node_id: str, artifact_name: str) -> str:
+    def get_input_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an input artifact."""
         resp = requests.get(
             url=os.path.join(self.host, "input-artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
-                namespace=namespace, name=name, nodeId=node_id, artifactName=artifact_name
+                name=name,
+                nodeId=node_id,
+                artifactName=artifact_name,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},

--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -80,7 +80,7 @@ class CronWorkflow(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.create_cron_workflow(
-            self.namespace, CreateCronWorkflowRequest(cron_workflow=self.build())
+            CreateCronWorkflowRequest(cron_workflow=self.build()), namespace=self.namespace
         )
 
     def lint(self) -> TWorkflow:
@@ -88,7 +88,7 @@ class CronWorkflow(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.lint_cron_workflow(
-            self.namespace, LintCronWorkflowRequest(cron_workflow=self.build())
+            LintCronWorkflowRequest(cron_workflow=self.build()), namespace=self.namespace
         )
 
 

--- a/src/hera/workflows/service.py
+++ b/src/hera/workflows/service.py
@@ -342,7 +342,7 @@ class WorkflowsService:
 
     def list_cron_workflows(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -354,7 +354,9 @@ class WorkflowsService:
         continue_: Optional[str] = None,
     ) -> CronWorkflowList:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -376,9 +378,11 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def create_cron_workflow(self, namespace: str, req: CreateCronWorkflowRequest) -> CronWorkflow:
+    def create_cron_workflow(self, req: CreateCronWorkflowRequest, namespace: Optional[str] = None) -> CronWorkflow:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -392,9 +396,11 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def lint_cron_workflow(self, namespace: str, req: LintCronWorkflowRequest) -> CronWorkflow:
+    def lint_cron_workflow(self, req: LintCronWorkflowRequest, namespace: Optional[str] = None) -> CronWorkflow:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/lint").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/lint").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -408,10 +414,12 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_cron_workflow(self, namespace: str, name: str, resource_version: Optional[str] = None) -> CronWorkflow:
+    def get_cron_workflow(
+        self, name: str, namespace: Optional[str] = None, resource_version: Optional[str] = None
+    ) -> CronWorkflow:
         resp = requests.get(
             url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={"getOptions.resourceVersion": resource_version},
             headers={"Authorization": f"Bearer {self.token}"},
@@ -424,10 +432,12 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def update_cron_workflow(self, namespace: str, name: str, req: UpdateCronWorkflowRequest) -> CronWorkflow:
+    def update_cron_workflow(
+        self, name: str, req: UpdateCronWorkflowRequest, namespace: Optional[str] = None
+    ) -> CronWorkflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -444,8 +454,8 @@ class WorkflowsService:
 
     def delete_cron_workflow(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         grace_period_seconds: Optional[str] = None,
         uid: Optional[str] = None,
         resource_version: Optional[str] = None,
@@ -455,7 +465,7 @@ class WorkflowsService:
     ) -> CronWorkflowDeletedResponse:
         resp = requests.delete(
             url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={
                 "deleteOptions.gracePeriodSeconds": grace_period_seconds,
@@ -475,10 +485,12 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def resume_cron_workflow(self, namespace: str, name: str, req: CronWorkflowResumeRequest) -> CronWorkflow:
+    def resume_cron_workflow(
+        self, name: str, req: CronWorkflowResumeRequest, namespace: Optional[str] = None
+    ) -> CronWorkflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/{name}/resume").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -493,10 +505,12 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def suspend_cron_workflow(self, namespace: str, name: str, req: CronWorkflowSuspendRequest) -> CronWorkflow:
+    def suspend_cron_workflow(
+        self, name: str, req: CronWorkflowSuspendRequest, namespace: Optional[str] = None
+    ) -> CronWorkflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/cron-workflows/{namespace}/{name}/suspend").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -555,7 +569,7 @@ class WorkflowsService:
 
     def list_workflow_templates(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -567,7 +581,9 @@ class WorkflowsService:
         continue_: Optional[str] = None,
     ) -> WorkflowTemplateList:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -589,9 +605,13 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def create_workflow_template(self, namespace: str, req: WorkflowTemplateCreateRequest) -> WorkflowTemplate:
+    def create_workflow_template(
+        self, req: WorkflowTemplateCreateRequest, namespace: Optional[str] = None
+    ) -> WorkflowTemplate:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -605,9 +625,13 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def lint_workflow_template(self, namespace: str, req: WorkflowTemplateLintRequest) -> WorkflowTemplate:
+    def lint_workflow_template(
+        self, req: WorkflowTemplateLintRequest, namespace: Optional[str] = None
+    ) -> WorkflowTemplate:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}/lint").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}/lint").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -622,11 +646,11 @@ class WorkflowsService:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
     def get_workflow_template(
-        self, namespace: str, name: str, resource_version: Optional[str] = None
+        self, name: str, namespace: Optional[str] = None, resource_version: Optional[str] = None
     ) -> WorkflowTemplate:
         resp = requests.get(
             url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={"getOptions.resourceVersion": resource_version},
             headers={"Authorization": f"Bearer {self.token}"},
@@ -640,11 +664,11 @@ class WorkflowsService:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
     def update_workflow_template(
-        self, namespace: str, name: str, req: WorkflowTemplateUpdateRequest
+        self, name: str, req: WorkflowTemplateUpdateRequest, namespace: Optional[str] = None
     ) -> WorkflowTemplate:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -661,8 +685,8 @@ class WorkflowsService:
 
     def delete_workflow_template(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         grace_period_seconds: Optional[str] = None,
         uid: Optional[str] = None,
         resource_version: Optional[str] = None,
@@ -672,7 +696,7 @@ class WorkflowsService:
     ) -> WorkflowTemplateDeleteResponse:
         resp = requests.delete(
             url=os.path.join(self.host, "api/v1/workflow-templates/{namespace}/{name}").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={
                 "deleteOptions.gracePeriodSeconds": grace_period_seconds,
@@ -694,7 +718,7 @@ class WorkflowsService:
 
     def list_workflows(
         self,
-        namespace: str,
+        namespace: Optional[str] = None,
         label_selector: Optional[str] = None,
         field_selector: Optional[str] = None,
         watch: Optional[bool] = None,
@@ -707,7 +731,9 @@ class WorkflowsService:
         fields: Optional[str] = None,
     ) -> WorkflowList:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "listOptions.labelSelector": label_selector,
                 "listOptions.fieldSelector": field_selector,
@@ -730,9 +756,11 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def create_workflow(self, namespace: str, req: WorkflowCreateRequest) -> Workflow:
+    def create_workflow(self, req: WorkflowCreateRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -746,9 +774,11 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def lint_workflow(self, namespace: str, req: WorkflowLintRequest) -> Workflow:
+    def lint_workflow(self, req: WorkflowLintRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}/lint").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}/lint").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -762,9 +792,11 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def submit_workflow(self, namespace: str, req: WorkflowSubmitRequest) -> Workflow:
+    def submit_workflow(self, req: WorkflowSubmitRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.post(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}/submit").format(namespace=namespace),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}/submit").format(
+                namespace=namespace if namespace is not None else self.namespace
+            ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
             data=req.json(
@@ -779,10 +811,16 @@ class WorkflowsService:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
     def get_workflow(
-        self, namespace: str, name: str, resource_version: Optional[str] = None, fields: Optional[str] = None
+        self,
+        name: str,
+        namespace: Optional[str] = None,
+        resource_version: Optional[str] = None,
+        fields: Optional[str] = None,
     ) -> Workflow:
         resp = requests.get(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}").format(namespace=namespace, name=name),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}").format(
+                name=name, namespace=namespace if namespace is not None else self.namespace
+            ),
             params={"getOptions.resourceVersion": resource_version, "fields": fields},
             headers={"Authorization": f"Bearer {self.token}"},
             data=None,
@@ -796,8 +834,8 @@ class WorkflowsService:
 
     def delete_workflow(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         grace_period_seconds: Optional[str] = None,
         uid: Optional[str] = None,
         resource_version: Optional[str] = None,
@@ -807,7 +845,9 @@ class WorkflowsService:
         force: Optional[bool] = None,
     ) -> WorkflowDeleteResponse:
         resp = requests.delete(
-            url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}").format(namespace=namespace, name=name),
+            url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}").format(
+                name=name, namespace=namespace if namespace is not None else self.namespace
+            ),
             params={
                 "deleteOptions.gracePeriodSeconds": grace_period_seconds,
                 "deleteOptions.preconditions.uid": uid,
@@ -829,8 +869,8 @@ class WorkflowsService:
 
     def workflow_logs(
         self,
-        namespace: str,
         name: str,
+        namespace: Optional[str] = None,
         pod_name: Optional[str] = None,
         container: Optional[str] = None,
         follow: Optional[bool] = None,
@@ -847,7 +887,7 @@ class WorkflowsService:
     ) -> V1alpha1LogEntry:
         resp = requests.get(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/log").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={
                 "podName": pod_name,
@@ -874,10 +914,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def resubmit_workflow(self, namespace: str, name: str, req: WorkflowResubmitRequest) -> Workflow:
+    def resubmit_workflow(self, name: str, req: WorkflowResubmitRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/resubmit").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -892,10 +932,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def resume_workflow(self, namespace: str, name: str, req: WorkflowResumeRequest) -> Workflow:
+    def resume_workflow(self, name: str, req: WorkflowResumeRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/resume").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -910,10 +950,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def retry_workflow(self, namespace: str, name: str, req: WorkflowRetryRequest) -> Workflow:
+    def retry_workflow(self, name: str, req: WorkflowRetryRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/retry").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -928,10 +968,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def set_workflow(self, namespace: str, name: str, req: WorkflowSetRequest) -> Workflow:
+    def set_workflow(self, name: str, req: WorkflowSetRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/set").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -946,10 +986,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def stop_workflow(self, namespace: str, name: str, req: WorkflowStopRequest) -> Workflow:
+    def stop_workflow(self, name: str, req: WorkflowStopRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/stop").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -964,10 +1004,10 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def suspend_workflow(self, namespace: str, name: str, req: WorkflowSuspendRequest) -> Workflow:
+    def suspend_workflow(self, name: str, req: WorkflowSuspendRequest, namespace: Optional[str] = None) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/suspend").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -982,10 +1022,12 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def terminate_workflow(self, namespace: str, name: str, req: WorkflowTerminateRequest) -> Workflow:
+    def terminate_workflow(
+        self, name: str, req: WorkflowTerminateRequest, namespace: Optional[str] = None
+    ) -> Workflow:
         resp = requests.put(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/terminate").format(
-                namespace=namespace, name=name
+                name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -1002,9 +1044,9 @@ class WorkflowsService:
 
     def pod_logs(
         self,
-        namespace: str,
         name: str,
         pod_name: str,
+        namespace: Optional[str] = None,
         container: Optional[str] = None,
         follow: Optional[bool] = None,
         previous: Optional[bool] = None,
@@ -1021,7 +1063,7 @@ class WorkflowsService:
         """DEPRECATED: Cannot work via HTTP if podName is an empty string. Use WorkflowLogs."""
         resp = requests.get(
             url=os.path.join(self.host, "api/v1/workflows/{namespace}/{name}/{podName}/log").format(
-                namespace=namespace, name=name, podName=pod_name
+                name=name, podName=pod_name, namespace=namespace if namespace is not None else self.namespace
             ),
             params={
                 "logOptions.container": container,
@@ -1049,12 +1091,12 @@ class WorkflowsService:
 
     def get_artifact_file(
         self,
-        namespace: str,
         id_discriminator: str,
         id_: str,
         node_id: str,
         artifact_name: str,
         artifact_discriminator: str,
+        namespace: Optional[str] = None,
     ) -> str:
         """Get an artifact."""
         resp = requests.get(
@@ -1062,12 +1104,12 @@ class WorkflowsService:
                 self.host,
                 "artifact-files/{namespace}/{idDiscriminator}/{id}/{nodeId}/{artifactDiscriminator}/{artifactName}",
             ).format(
-                namespace=namespace,
                 idDiscriminator=id_discriminator,
                 id=id_,
                 nodeId=node_id,
                 artifactName=artifact_name,
                 artifactDiscriminator=artifact_discriminator,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -1097,11 +1139,14 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_output_artifact(self, namespace: str, name: str, node_id: str, artifact_name: str) -> str:
+    def get_output_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an output artifact."""
         resp = requests.get(
             url=os.path.join(self.host, "artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
-                namespace=namespace, name=name, nodeId=node_id, artifactName=artifact_name
+                name=name,
+                nodeId=node_id,
+                artifactName=artifact_name,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},
@@ -1131,11 +1176,14 @@ class WorkflowsService:
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
-    def get_input_artifact(self, namespace: str, name: str, node_id: str, artifact_name: str) -> str:
+    def get_input_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an input artifact."""
         resp = requests.get(
             url=os.path.join(self.host, "input-artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
-                namespace=namespace, name=name, nodeId=node_id, artifactName=artifact_name
+                name=name,
+                nodeId=node_id,
+                artifactName=artifact_name,
+                namespace=namespace if namespace is not None else self.namespace,
             ),
             params=None,
             headers={"Authorization": f"Bearer {self.token}"},

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -331,13 +331,17 @@ class Workflow(
         """Creates the Workflow on the Argo cluster."""
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
-        return self.workflows_service.create_workflow(self.namespace, WorkflowCreateRequest(workflow=self.build()))
+        return self.workflows_service.create_workflow(
+            WorkflowCreateRequest(workflow=self.build()), namespace=self.namespace
+        )
 
     def lint(self) -> TWorkflow:
         """Lints the Workflow using the Argo cluster."""
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
-        return self.workflows_service.lint_workflow(self.namespace, WorkflowLintRequest(workflow=self.build()))
+        return self.workflows_service.lint_workflow(
+            WorkflowLintRequest(workflow=self.build()), namespace=self.namespace
+        )
 
     def _add_sub(self, node: Any):
         """Adds any objects instantiated under the Workflow context manager that conform to the `Templatable` protocol

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -37,7 +37,7 @@ class WorkflowTemplate(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.create_workflow_template(
-            self.namespace, WorkflowTemplateCreateRequest(template=self.build())
+            WorkflowTemplateCreateRequest(template=self.build()), namespace=self.namespace
         )
 
     def lint(self) -> TWorkflow:
@@ -45,7 +45,7 @@ class WorkflowTemplate(Workflow):
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"
         return self.workflows_service.lint_workflow_template(
-            self.namespace, WorkflowTemplateLintRequest(template=self.build())
+            WorkflowTemplateLintRequest(template=self.build()), namespace=self.namespace
         )
 
     def build(self) -> TWorkflow:


### PR DESCRIPTION
Fixes: #556 

As mentioned in the issue, the service does not use the namespace set on the service itself. This PR fixes that by:
- making service generation aware that there is a namespace flag on the service, and hence forces the `namespace` `Parameter` (not Hera `Parameter`) object to set the namespace to optional
- adds sorting to the `ServiceEndpoint` so that required params are set first on the endpoint
- adds a check for nullity of namespace on the endpoint itself, and relies on the service class namespace if it's not passed

CC: @KathrynFowler91