### PR TITLE
Fix conditional on task status to string conversion

### DIFF
--- a/docs/examples/workflows/dag_conditional_on_task_status.md
+++ b/docs/examples/workflows/dag_conditional_on_task_status.md
@@ -1,0 +1,93 @@
+# Dag Conditional On Task Status
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import DAG, Workflow, script
+
+
+    @script()
+    def fail_or_succeed():
+        import random
+
+        if random.randint(0, 1) == 0:
+            raise ValueError
+
+
+    @script()
+    def when_succeeded():
+        print("It was a success")
+
+
+    @script()
+    def when_failed():
+        print("It was a failure")
+
+
+    with Workflow(generate_name="dag-conditional-on-task-status-", entrypoint="d") as w:
+        with DAG(name="d") as s:
+            t1 = fail_or_succeed()
+
+            t1.on_failure(when_failed())
+            t1.on_success(when_succeeded())
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: dag-conditional-on-task-status-
+    spec:
+      entrypoint: d
+      templates:
+      - dag:
+          tasks:
+          - name: fail-or-succeed
+            template: fail-or-succeed
+          - depends: fail-or-succeed.Failed
+            name: when-failed
+            template: when-failed
+          - depends: fail-or-succeed.Succeeded
+            name: when-succeeded
+            template: when-succeeded
+        name: d
+      - name: fail-or-succeed
+        script:
+          command:
+          - python
+          image: python:3.8
+          source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport random\n\
+            if random.randint(0, 1) == 0:\n    raise ValueError"
+      - name: when-failed
+        script:
+          command:
+          - python
+          image: python:3.8
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            print(''It was a failure'')'
+      - name: when-succeeded
+        script:
+          command:
+          - python
+          image: python:3.8
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            print(''It was a success'')'
+    ```
+

--- a/examples/workflows/dag-conditional-on-task-status.yaml
+++ b/examples/workflows/dag-conditional-on-task-status.yaml
@@ -22,7 +22,7 @@ spec:
       - python
       image: python:3.8
       source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport random\n\
-        \nif random.randint(0, 1) == 0:\n    raise ValueError\n"
+        if random.randint(0, 1) == 0:\n    raise ValueError"
   - name: when-failed
     script:
       command:
@@ -34,9 +34,7 @@ spec:
 
         sys.path.append(os.getcwd())
 
-        print("It was a failure")
-
-        '
+        print(''It was a failure'')'
   - name: when-succeeded
     script:
       command:
@@ -48,6 +46,4 @@ spec:
 
         sys.path.append(os.getcwd())
 
-        print("It was a success")
-
-        '
+        print(''It was a success'')'

--- a/examples/workflows/dag-conditional-on-task-status.yaml
+++ b/examples/workflows/dag-conditional-on-task-status.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-conditional-on-task-status-
+spec:
+  entrypoint: d
+  templates:
+  - dag:
+      tasks:
+      - name: fail-or-succeed
+        template: fail-or-succeed
+      - depends: fail-or-succeed.Failed
+        name: when-failed
+        template: when-failed
+      - depends: fail-or-succeed.Succeeded
+        name: when-succeeded
+        template: when-succeeded
+    name: d
+  - name: fail-or-succeed
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport random\n\
+        \nif random.randint(0, 1) == 0:\n    raise ValueError\n"
+  - name: when-failed
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        print("It was a failure")
+
+        '
+  - name: when-succeeded
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        print("It was a success")
+
+        '

--- a/examples/workflows/dag_conditional_on_task_status.py
+++ b/examples/workflows/dag_conditional_on_task_status.py
@@ -1,0 +1,27 @@
+from hera.workflows import DAG, Workflow, script
+
+
+@script()
+def fail_or_succeed():
+    import random
+
+    if random.randint(0, 1) == 0:
+        raise ValueError
+
+
+@script()
+def when_succeeded():
+    print("It was a success")
+
+
+@script()
+def when_failed():
+    print("It was a failure")
+
+
+with Workflow(generate_name="dag-conditional-on-task-status-", entrypoint="d") as w:
+    with DAG(name="d") as s:
+        t1 = fail_or_succeed()
+
+        t1.on_failure(when_failed())
+        t1.on_success(when_succeeded())

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -201,7 +201,7 @@ class Task(
         else:
             # Add follow-up dependency
             other.depends += f" {operator} {self.name + condition}"
-        return otherq
+        return other
 
     def __rrshift__(self, other: List[Union[Task, str]]) -> Task:
         """Set `other` as a dependency self."""

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -191,7 +191,7 @@ class Task(
         """Set self as a dependency of `other`."""
         assert issubclass(other.__class__, Task)
 
-        condition = f".{on}" if on else ""
+        condition = f".{on.value}" if on else ""
 
         if other.depends is None:
             # First dependency
@@ -201,7 +201,7 @@ class Task(
         else:
             # Add follow-up dependency
             other.depends += f" {operator} {self.name + condition}"
-        return other
+        return otherq
 
     def __rrshift__(self, other: List[Union[Task, str]]) -> Task:
         """Set `other` as a dependency self."""


### PR DESCRIPTION
The conversion of TaskResult Enum to string creates an incorrect depends field e.g. :  
`depends: fail-or-succeed.TaskResult.Failed` instead of  `depends: fail-or-succeed.Failed`. 
See here this link for more info on [depends](https://argoproj.github.io/argo-workflows/enhanced-depends-logic/).  

This PR fixes the issue by converting to string the value of the Enum instead of the Enum itself. 