### PR TITLE
fix image pull policy validation error

### DIFF
--- a/docs/examples/workflows/script_with_image_pull_policy.md
+++ b/docs/examples/workflows/script_with_image_pull_policy.md
@@ -1,0 +1,48 @@
+# Script With Image Pull Policy
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Workflow, script
+    from hera.workflows.models import ImagePullPolicy
+
+
+    @script(image_pull_policy=ImagePullPolicy.always)
+    def task_with_image_pull_policy():
+        print("ok")
+
+
+    with Workflow(generate_name="script-with-image-pull-policy-", entrypoint="task-with-image-pull-policy") as w:
+        task_with_image_pull_policy()
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: script-with-image-pull-policy-
+    spec:
+      entrypoint: task-with-image-pull-policy
+      templates:
+      - name: task-with-image-pull-policy
+        script:
+          command:
+          - python
+          image: python:3.8
+          imagePullPolicy: Always
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            print(''ok'')'
+    ```
+

--- a/examples/workflows/script-with-image-pull-policy.yaml
+++ b/examples/workflows/script-with-image-pull-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: script-with-image-pull-policy-
+spec:
+  entrypoint: task-with-image-pull-policy
+  templates:
+  - name: task-with-image-pull-policy
+    script:
+      command:
+      - python
+      image: python:3.8
+      imagePullPolicy: Always
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        print(''ok'')'

--- a/examples/workflows/script_with_image_pull_policy.py
+++ b/examples/workflows/script_with_image_pull_policy.py
@@ -1,0 +1,11 @@
+from hera.workflows import Workflow, script
+from hera.workflows.models import ImagePullPolicy
+
+
+@script(image_pull_policy=ImagePullPolicy.always)
+def task_with_image_pull_policy():
+    print("ok")
+
+
+with Workflow(generate_name="script-with-image-pull-policy-", entrypoint="task-with-image-pull-policy") as w:
+    task_with_image_pull_policy()

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -136,10 +136,12 @@ class ContainerMixin(BaseMixin):
     termination_message_policy: Optional[TerminationMessagePolicy] = None
     tty: Optional[bool] = None
 
-    def _build_image_pull_policy(self) -> Optional[ImagePullPolicy]:
-        if self.image_pull_policy is None or isinstance(self.image_pull_policy, ImagePullPolicy):
-            return self.image_pull_policy
-        return ImagePullPolicy[self.image_pull_policy.lower()]
+    def _build_image_pull_policy(self) -> Optional[str]:
+        if self.image_pull_policy is None:
+            return None
+        elif isinstance(self.image_pull_policy, ImagePullPolicy):
+            return self.image_pull_policy.value
+        return ImagePullPolicy[self.image_pull_policy.lower()].value
 
     @validator("image", pre=True, always=True)
     def _set_image(cls, v):


### PR DESCRIPTION
Fixes #582 

Basically, the `ScriptTemplate` model expects a str for the imagePullPolicy definition, but hera is returning the `ImagePullPolicy` enum - hence pydantic rejects it and throws an error. The fix is just to return the `.value` of the enum instead of the enum itself.