### PR TITLE
Make context async-friendly

### DIFF
--- a/src/hera/workflows/_context.py
+++ b/src/hera/workflows/_context.py
@@ -1,11 +1,13 @@
-import threading
-from typing import List, TypeVar, Union
+from contextvars import ContextVar
+from typing import List, Optional, TypeVar, Union
 
 from hera.shared import BaseMixin
 from hera.workflows.exceptions import InvalidType
 from hera.workflows.protocol import Subbable, TTemplate
 
 TNode = TypeVar("TNode", bound="SubNodeMixin")
+
+_pieces = ContextVar("_pieces", default=None)
 
 
 class SubNodeMixin(BaseMixin):
@@ -16,45 +18,65 @@ class SubNodeMixin(BaseMixin):
         return self
 
 
-class _HeraContext(threading.local):
-    def __init__(self) -> None:
-        super().__init__()
-        self._pieces: List[Subbable] = []
+class _HeraContext:
+    """_HeraContext uses a ContextVar under the hood to store the context.
+
+    Note: To avoid the ContextVar being shared, it must be lazily initialized to an empty list at runtime,
+    and not at import time (Context is called at import time if we use the @script decorator for instance)
+    """
 
     def enter(self, p: Subbable) -> None:
         if not isinstance(p, Subbable):
             raise InvalidType(type(p))
-        self._pieces.append(p)
+        if self.pieces is None:
+            self.pieces = []
+        self.pieces.append(p)
 
     def exit(self) -> None:
-        self._pieces.pop()
+        if self.pieces:
+            self.pieces.pop()
+
+    @property
+    def pieces(self) -> Optional[List[Subbable]]:
+        """Get the context local variable for the pieces.
+
+        The variable is None at import time to prevent shared state between contexts
+        """
+        return _pieces.get()
+
+    @pieces.setter
+    def pieces(self, value):
+        _pieces.set(value)
 
     @property
     def active(self) -> bool:
-        return bool(self._pieces)
+        return bool(self.pieces)
 
     def add_sub_node(self, node: Union[SubNodeMixin, TTemplate]) -> None:
-        if self._pieces:
-            try:
-                # here, we are trying to add a node to the last piece of context in the hopes that it is a subbable
-                self._pieces[-1]._add_sub(node)
-            except InvalidType:
-                # if the above fails, it means the user invoked a decorated function e.g. `@script`. Hence,
-                # the object needs to be added as a template to the piece of context at [-1]. This will be the case for
-                # DAGs and Steps
-                self._pieces[-1]._add_sub(node.template)  # type: ignore
+        pieces = self.pieces
+        if not pieces:
+            return
 
-            # when the above does not raise an exception, it means the user invoked a decorated function e.g. `@script`
-            # inside a proper context. Here, we add the object to the overall workflow context, directly as a template,
-            # in case it is not found (based on the name)
-            if hasattr(node, "template") and node.template is not None and not isinstance(node.template, str):
-                found = False
-                for t in self._pieces[0].templates:  # type: ignore
-                    if t.name == node.template.name:
-                        found = True
-                        break
-                if not found:
-                    self._pieces[0]._add_sub(node.template)
+        try:
+            # here, we are trying to add a node to the last piece of context in the hopes that it is a subbable
+            pieces[-1]._add_sub(node)
+        except InvalidType:
+            # if the above fails, it means the user invoked a decorated function e.g. `@script`. Hence,
+            # the object needs to be added as a template to the piece of context at [-1]. This will be the case for
+            # DAGs and Steps
+            pieces[-1]._add_sub(node.template)  # type: ignore
+
+        # when the above does not raise an exception, it means the user invoked a decorated function e.g. `@script`
+        # inside a proper context. Here, we add the object to the overall workflow context, directly as a template,
+        # in case it is not found (based on the name)
+        if hasattr(node, "template") and node.template is not None and not isinstance(node.template, str):
+            found = False
+            for t in pieces[0].templates:  # type: ignore
+                if t.name == node.template.name:
+                    found = True
+                    break
+            if not found:
+                pieces[0]._add_sub(node.template)
 
 
 _context = _HeraContext()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,89 @@
+import asyncio
+
+from hera.workflows import Steps, Workflow, script
+
+
+@script(image="python:3.9")
+def echo(message: str):
+    print(message)
+
+
+@script(image="python:3.10")
+def hello(name: str):
+    print(f"Hello {name}")
+
+
+async def abuild_workflow_wait(event):
+    with Workflow(
+        generate_name="waiter-",
+        entrypoint="steps",
+    ) as w:
+        with Steps(name="steps"):
+            echo(arguments={"message": "hello 0"})
+            await event.wait()
+    return w
+
+
+async def abuild_workflow_set(event):
+    with Workflow(
+        generate_name="setter-",
+        entrypoint="steps",
+    ) as w:
+        with Steps(name="steps"):
+            hello(arguments={"name": "world"})
+
+    event.set()
+    return w
+
+
+def test_async_context():
+    """
+    In this test, we create 2 workflows using async functions and make sure the context isn't leaking.
+
+    In the middle of the first one, we pause by waiting thus never calling the context exit() function;
+    meanwhile the 2nd function will create another workflow, then unblock the first one which will resume.
+    Both workflows have to be complete and not be entangled: they were created in 2 isolated flows.
+    """
+
+    async def main():
+        event = asyncio.Event()
+        t0 = asyncio.create_task(abuild_workflow_wait(event))
+        t1 = asyncio.create_task(abuild_workflow_set(event))
+        rv0 = await t0
+        rv1 = await t1
+
+        return rv0, rv1
+
+    rv = asyncio.run(main())
+
+    assert len(rv) == 2
+    w0, w1 = rv
+
+    assert [x.name for x in w0.templates] == ["steps", "echo"]
+    assert w0.templates[1].image == "python:3.9"
+    assert [x.name for x in w1.templates] == ["steps", "hello"]
+    assert w1.templates[1].image == "python:3.10"
+
+
+def test_sync_context():
+    """
+    Context is not leaking between 2 successive sync workflow creations
+    """
+    with Workflow(
+        generate_name="w0-",
+        entrypoint="steps",
+    ) as w0:
+        with Steps(name="steps"):
+            echo(arguments={"message": "hello 0"})
+
+    with Workflow(
+        generate_name="w1-",
+        entrypoint="steps",
+    ) as w1:
+        with Steps(name="steps"):
+            hello(arguments={"message": "hello 1"})
+
+    assert [x.name for x in w0.templates] == ["steps", "echo"]
+    assert w0.templates[1].image == "python:3.9"
+    assert [x.name for x in w1.templates] == ["steps", "hello"]
+    assert w1.templates[1].image == "python:3.10"


### PR DESCRIPTION
Hi,

The current Workflow context is not async friendly (although of course Hera isn't an async lib), as it relies on threading.local : this means that data may leak in case Hera is used in an async function.

I included a test case which shows the leak and currently fails on the latest Hera version: the second workflow isn't valid because it lacks the script block, which was leaked in the first workflow.

Replacing the use of threading.local by ContextVar solves the issue, although some small adjustments were required.

Note that in any case the official python documentation recommends the usage of ContextVars over threading.local : https://docs.python.org/3/library/contextvars.html

Let me know if anything else is needed,

Thanks!