### PR TITLE
Add missing examples test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,9 @@ init-files:
 	$(MAKE) format
 
 .PHONY: examples
-examples:  ## Generate all the examples
+examples:  ## Generate all the examples, report missing examples
 	@(cd docs && poetry run python generate.py)
+	@poetry run python -m pytest -k test_for_missing_examples --runxfail
 
 .PHONY: regenerate-test-data
 regenerate-test-data:  ## Regenerates the test data from upstream examples and runs tests

--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,11 @@ init-files:
 	$(MAKE) format
 
 .PHONY: examples
-examples:  ## Generate all the examples, report missing examples
+examples:  ## Generate all the examples
 	@(cd docs && poetry run python generate.py)
-	@poetry run python -m pytest -k test_for_missing_examples --runxfail
 
 .PHONY: regenerate-test-data
-regenerate-test-data:  ## Regenerates the test data from upstream examples and runs tests
+regenerate-test-data:  ## Regenerates the test data from upstream examples and runs tests, report missing examples
 	find examples -name "*.yaml" -type f -delete
 	HERA_REGENERATE=1 make test examples
+	@poetry run python -m pytest -k test_for_missing_examples --runxfail

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -6,12 +6,12 @@ import requests
 
 import examples.workflows.upstream as hera_upstream_examples
 
-GITHUB_API_ARGO_EXAMPLES = "https://api.github.com/repos/argoproj/argo-workflows/git/trees/master?recursive=1"
+GITHUB_API_ARGO = "https://api.github.com/repos/argoproj/argo-workflows/git/trees/master?recursive=1"
 
 
 @pytest.mark.xfail(reason="Dev tool test")
 def test_for_missing_examples():
-    repo_json = requests.get(GITHUB_API_ARGO_EXAMPLES).json()
+    repo_json = requests.get(GITHUB_API_ARGO).json()
     argo_examples = [
         file["path"] for file in repo_json["tree"] if "examples/" in file["path"] and ".yaml" in file["path"]
     ]

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -1,11 +1,10 @@
-import requests
-import pkgutil
 import json
-import pytest
+import pkgutil
 
+import pytest
+import requests
 
 import examples.workflows.upstream as hera_upstream_examples
-
 
 GITHUB_API_ARGO_EXAMPLES = "https://api.github.com/repos/argoproj/argo-workflows/git/trees/master?recursive=1"
 

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -1,0 +1,32 @@
+import requests
+import pkgutil
+import json
+import pytest
+
+
+import examples.workflows.upstream as hera_upstream_examples
+
+
+GITHUB_API_ARGO_EXAMPLES = "https://api.github.com/repos/argoproj/argo-workflows/git/trees/master?recursive=1"
+
+
+@pytest.mark.xfail(reason="Dev tool test")
+def test_for_missing_examples():
+    repo_json = requests.get(GITHUB_API_ARGO_EXAMPLES).json()
+    argo_examples = [
+        file["path"] for file in repo_json["tree"] if "examples/" in file["path"] and ".yaml" in file["path"]
+    ]
+
+    argo_examples = map(lambda file: file.removeprefix("examples/").removesuffix(".yaml"), argo_examples)
+
+    hera_examples = [name for _, name, _ in pkgutil.iter_modules(hera_upstream_examples.__path__)]
+    hera_examples = list(map(lambda file: file.replace("__", "/").replace("_", "-"), hera_examples))
+
+    missing = set(argo_examples).difference(hera_examples)
+
+    missing_examples = {
+        example: f"https://github.com/argoproj/argo-workflows/blob/master/examples/{example}.yaml"
+        for example in missing
+    }
+
+    assert len(missing) == 0, f"Missing {len(missing)} examples: {json.dumps(missing_examples, indent=2)}"


### PR DESCRIPTION
For tracking #567 

* Local `make regenerate-test-data` will notify user after running the normal tests
* CI/CD will not fail as the test is marked as `xfail`, and the `ci` make target doesn't have the `regenerate-test-data` as a dependency
* We can later remove the `xfail` so that CI/CD will check for missing examples as part of the regular `test` target when we've reached good coverage (we can change the assertion to e.g. `len(missing) < 10`)