### PR TITLE
Make suspend template callable, add suspend examples

### DIFF
--- a/docs/examples/workflows/upstream/suspend-template-outputs.md
+++ b/docs/examples/workflows/upstream/suspend-template-outputs.md
@@ -8,8 +8,8 @@
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows import Container, Step, Steps, Suspend, Workflow
-    from hera.workflows.models import ValueFrom, SuppliedValueFrom, SuspendTemplate, Template, Parameter, Outputs
+    from hera.workflows import Container, Step, Steps, Workflow
+    from hera.workflows.models import Outputs, Parameter, SuppliedValueFrom, SuspendTemplate, Template, ValueFrom
 
     with Workflow(
         name="suspend-outputs",

--- a/docs/examples/workflows/upstream/suspend-template-outputs.md
+++ b/docs/examples/workflows/upstream/suspend-template-outputs.md
@@ -23,23 +23,22 @@
             args=["{{inputs.parameters.message}}"],
         )
 
-        w._add_sub(
-            Template(
+        with Steps(name="suspend"):
+            Step(
                 name="approve",
-                suspend=SuspendTemplate(),
-                outputs=Outputs(
-                    parameters=[
-                        Parameter(
-                            name="message",
-                            value_from=ValueFrom(supplied=SuppliedValueFrom()),
-                        )
-                    ]
+                template=Template(
+                    name="approve",
+                    suspend=SuspendTemplate(),
+                    outputs=Outputs(
+                        parameters=[
+                            Parameter(
+                                name="message",
+                                value_from=ValueFrom(supplied=SuppliedValueFrom()),
+                            )
+                        ]
+                    ),
                 ),
             )
-        )
-
-        with Steps(name="suspend"):
-            Step(name="approve", template="approve")
             whalesay(name="release", arguments={"message": "{{steps.approve.outputs.parameters.message}}"})
     ```
 
@@ -63,13 +62,6 @@
           parameters:
           - name: message
         name: whalesay
-      - name: approve
-        outputs:
-          parameters:
-          - name: message
-            valueFrom:
-              supplied: {}
-        suspend: {}
       - name: suspend
         steps:
         - - name: approve
@@ -80,5 +72,12 @@
                 value: '{{steps.approve.outputs.parameters.message}}'
             name: release
             template: whalesay
+      - name: approve
+        outputs:
+          parameters:
+          - name: message
+            valueFrom:
+              supplied: {}
+        suspend: {}
     ```
 

--- a/docs/examples/workflows/upstream/suspend-template-outputs.md
+++ b/docs/examples/workflows/upstream/suspend-template-outputs.md
@@ -1,0 +1,84 @@
+# Suspend-Template-Outputs
+
+> Note: This example is a replication of an Argo Workflow example in Hera. The upstream example can be [found here](https://github.com/argoproj/argo-workflows/blob/master/examples/suspend-template-outputs.yaml).
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Container, Step, Steps, Suspend, Workflow
+    from hera.workflows.models import ValueFrom, SuppliedValueFrom, SuspendTemplate, Template, Parameter, Outputs
+
+    with Workflow(
+        name="suspend-outputs",
+        entrypoint="suspend",
+    ) as w:
+        whalesay = Container(
+            name="whalesay",
+            image="docker/whalesay",
+            command=["cowsay"],
+            inputs=[Parameter(name="message")],
+            args=["{{inputs.parameters.message}}"],
+        )
+
+        w._add_sub(
+            Template(
+                name="approve",
+                suspend=SuspendTemplate(),
+                outputs=Outputs(
+                    parameters=[
+                        Parameter(
+                            name="message",
+                            value_from=ValueFrom(supplied=SuppliedValueFrom()),
+                        )
+                    ]
+                ),
+            )
+        )
+
+        with Steps(name="suspend"):
+            Step(name="approve", template="approve")
+            whalesay(name="release", arguments={"message": "{{steps.approve.outputs.parameters.message}}"})
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      name: suspend-outputs
+    spec:
+      entrypoint: suspend
+      templates:
+      - container:
+          args:
+          - '{{inputs.parameters.message}}'
+          command:
+          - cowsay
+          image: docker/whalesay
+        inputs:
+          parameters:
+          - name: message
+        name: whalesay
+      - name: approve
+        outputs:
+          parameters:
+          - name: message
+            valueFrom:
+              supplied: {}
+        suspend: {}
+      - name: suspend
+        steps:
+        - - name: approve
+            template: approve
+        - - arguments:
+              parameters:
+              - name: message
+                value: '{{steps.approve.outputs.parameters.message}}'
+            name: release
+            template: whalesay
+    ```
+

--- a/docs/examples/workflows/upstream/suspend-template.md
+++ b/docs/examples/workflows/upstream/suspend-template.md
@@ -8,7 +8,7 @@
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows import Container, Step, Steps, Suspend, Workflow
+    from hera.workflows import Container, Steps, Suspend, Workflow
 
     with Workflow(
         generate_name="suspend-template-",
@@ -21,8 +21,8 @@
 
         with Steps(name="suspend"):
             whalesay(name="build")
-            Step(name="approve", template=approve)
-            Step(name="delay", template=delay)
+            approve()
+            delay()
             whalesay(name="release")
     ```
 

--- a/docs/examples/workflows/upstream/suspend-template.md
+++ b/docs/examples/workflows/upstream/suspend-template.md
@@ -1,0 +1,62 @@
+# Suspend-Template
+
+> Note: This example is a replication of an Argo Workflow example in Hera. The upstream example can be [found here](https://github.com/argoproj/argo-workflows/blob/master/examples/suspend-template.yaml).
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Container, Step, Steps, Suspend, Workflow
+
+    with Workflow(
+        generate_name="suspend-template-",
+        entrypoint="suspend",
+    ) as w:
+        whalesay = Container(name="whalesay", image="docker/whalesay", command=["cowsay"], args=["hello world"])
+
+        approve = Suspend(name="approve")
+        delay = Suspend(name="delay", duration=20)
+
+        with Steps(name="suspend"):
+            whalesay(name="build")
+            Step(name="approve", template=approve)
+            Step(name="delay", template=delay)
+            whalesay(name="release")
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: suspend-template-
+    spec:
+      entrypoint: suspend
+      templates:
+      - container:
+          args:
+          - hello world
+          command:
+          - cowsay
+          image: docker/whalesay
+        name: whalesay
+      - name: approve
+        suspend: {}
+      - name: delay
+        suspend:
+          duration: '20'
+      - name: suspend
+        steps:
+        - - name: build
+            template: whalesay
+        - - name: approve
+            template: approve
+        - - name: delay
+            template: delay
+        - - name: release
+            template: whalesay
+    ```
+

--- a/examples/workflows/upstream/suspend-template-outputs.py
+++ b/examples/workflows/upstream/suspend-template-outputs.py
@@ -1,0 +1,33 @@
+from hera.workflows import Container, Step, Steps, Suspend, Workflow
+from hera.workflows.models import ValueFrom, SuppliedValueFrom, SuspendTemplate, Template, Parameter, Outputs
+
+with Workflow(
+    name="suspend-outputs",
+    entrypoint="suspend",
+) as w:
+    whalesay = Container(
+        name="whalesay",
+        image="docker/whalesay",
+        command=["cowsay"],
+        inputs=[Parameter(name="message")],
+        args=["{{inputs.parameters.message}}"],
+    )
+
+    w._add_sub(
+        Template(
+            name="approve",
+            suspend=SuspendTemplate(),
+            outputs=Outputs(
+                parameters=[
+                    Parameter(
+                        name="message",
+                        value_from=ValueFrom(supplied=SuppliedValueFrom()),
+                    )
+                ]
+            ),
+        )
+    )
+
+    with Steps(name="suspend"):
+        Step(name="approve", template="approve")
+        whalesay(name="release", arguments={"message": "{{steps.approve.outputs.parameters.message}}"})

--- a/examples/workflows/upstream/suspend-template-outputs.py
+++ b/examples/workflows/upstream/suspend-template-outputs.py
@@ -1,5 +1,5 @@
-from hera.workflows import Container, Step, Steps, Suspend, Workflow
-from hera.workflows.models import ValueFrom, SuppliedValueFrom, SuspendTemplate, Template, Parameter, Outputs
+from hera.workflows import Container, Step, Steps, Workflow
+from hera.workflows.models import Outputs, Parameter, SuppliedValueFrom, SuspendTemplate, Template, ValueFrom
 
 with Workflow(
     name="suspend-outputs",

--- a/examples/workflows/upstream/suspend-template-outputs.py
+++ b/examples/workflows/upstream/suspend-template-outputs.py
@@ -13,21 +13,20 @@ with Workflow(
         args=["{{inputs.parameters.message}}"],
     )
 
-    w._add_sub(
-        Template(
+    with Steps(name="suspend"):
+        Step(
             name="approve",
-            suspend=SuspendTemplate(),
-            outputs=Outputs(
-                parameters=[
-                    Parameter(
-                        name="message",
-                        value_from=ValueFrom(supplied=SuppliedValueFrom()),
-                    )
-                ]
+            template=Template(
+                name="approve",
+                suspend=SuspendTemplate(),
+                outputs=Outputs(
+                    parameters=[
+                        Parameter(
+                            name="message",
+                            value_from=ValueFrom(supplied=SuppliedValueFrom()),
+                        )
+                    ]
+                ),
             ),
         )
-    )
-
-    with Steps(name="suspend"):
-        Step(name="approve", template="approve")
         whalesay(name="release", arguments={"message": "{{steps.approve.outputs.parameters.message}}"})

--- a/examples/workflows/upstream/suspend-template-outputs.upstream.yaml
+++ b/examples/workflows/upstream/suspend-template-outputs.upstream.yaml
@@ -1,0 +1,42 @@
+# This example uses a suspend template that expects outputs to be provided to it. These outputs may be provided by the CLI
+# with the 'argo node set' command, the API with the '/set' endpoint, or directly via K8s.
+#
+# Example:
+#   argo node set suspend-outputs -p message="Hello, world!" --node-field-selector displayName=approve
+#   argo node set suspend-outputs --message="Test message" --node-field-selector displayName=approve
+#   argo resume suspend-outputs
+
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-outputs
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    steps:
+    - - name: approve
+        template: approve
+    - - name: release
+        template: whalesay
+        arguments:
+          parameters:
+            - name: message
+              value: "{{steps.approve.outputs.parameters.message}}"
+
+  - name: approve
+    suspend: {}
+    outputs:
+      parameters:
+        - name: message
+          valueFrom:
+            supplied: {}
+
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]

--- a/examples/workflows/upstream/suspend-template-outputs.yaml
+++ b/examples/workflows/upstream/suspend-template-outputs.yaml
@@ -15,13 +15,6 @@ spec:
       parameters:
       - name: message
     name: whalesay
-  - name: approve
-    outputs:
-      parameters:
-      - name: message
-        valueFrom:
-          supplied: {}
-    suspend: {}
   - name: suspend
     steps:
     - - name: approve
@@ -32,3 +25,10 @@ spec:
             value: '{{steps.approve.outputs.parameters.message}}'
         name: release
         template: whalesay
+  - name: approve
+    outputs:
+      parameters:
+      - name: message
+        valueFrom:
+          supplied: {}
+    suspend: {}

--- a/examples/workflows/upstream/suspend-template-outputs.yaml
+++ b/examples/workflows/upstream/suspend-template-outputs.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-outputs
+spec:
+  entrypoint: suspend
+  templates:
+  - container:
+      args:
+      - '{{inputs.parameters.message}}'
+      command:
+      - cowsay
+      image: docker/whalesay
+    inputs:
+      parameters:
+      - name: message
+    name: whalesay
+  - name: approve
+    outputs:
+      parameters:
+      - name: message
+        valueFrom:
+          supplied: {}
+    suspend: {}
+  - name: suspend
+    steps:
+    - - name: approve
+        template: approve
+    - - arguments:
+          parameters:
+          - name: message
+            value: '{{steps.approve.outputs.parameters.message}}'
+        name: release
+        template: whalesay

--- a/examples/workflows/upstream/suspend-template.py
+++ b/examples/workflows/upstream/suspend-template.py
@@ -1,0 +1,16 @@
+from hera.workflows import Container, Step, Steps, Suspend, Workflow
+
+with Workflow(
+    generate_name="suspend-template-",
+    entrypoint="suspend",
+) as w:
+    whalesay = Container(name="whalesay", image="docker/whalesay", command=["cowsay"], args=["hello world"])
+
+    approve = Suspend(name="approve")
+    delay = Suspend(name="delay", duration=20)
+
+    with Steps(name="suspend"):
+        whalesay(name="build")
+        Step(name="approve", template=approve)
+        Step(name="delay", template=delay)
+        whalesay(name="release")

--- a/examples/workflows/upstream/suspend-template.py
+++ b/examples/workflows/upstream/suspend-template.py
@@ -1,4 +1,4 @@
-from hera.workflows import Container, Step, Steps, Suspend, Workflow
+from hera.workflows import Container, Steps, Suspend, Workflow
 
 with Workflow(
     generate_name="suspend-template-",
@@ -11,6 +11,6 @@ with Workflow(
 
     with Steps(name="suspend"):
         whalesay(name="build")
-        Step(name="approve", template=approve)
-        Step(name="delay", template=delay)
+        approve()
+        delay()
         whalesay(name="release")

--- a/examples/workflows/upstream/suspend-template.upstream.yaml
+++ b/examples/workflows/upstream/suspend-template.upstream.yaml
@@ -1,0 +1,41 @@
+# This example demonstrates the use of a suspend template. Suspend templates allow a workflow to
+# enter a suspended state at a predetermined point in time in the workflow. Some use cases for this
+# might include: human approval during release process, performing asynchronous/long soak tests,
+# manual judgment of a staging environment before deploying to production. To run this example,
+# submit the workflow and wait until the workflow reaches the second, "approve" step, at which point
+# the workflow will be suspended. To resume the workflow, run:
+# argo resume <workflowname>
+# A suspended template can also be specified with `duration` which will automatically resume the
+# suspended template after the specified amount of time in seconds. In this example it is used to delay
+# a release after an approval.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: suspend-template-
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    steps:
+    - - name: build
+        template: whalesay
+    - - name: approve
+        template: approve
+    - - name: delay
+        template: delay
+    - - name: release
+        template: whalesay
+
+  - name: approve
+    suspend: {}
+
+  - name: delay
+    suspend:
+      duration: "20"    # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+
+  - name: whalesay
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["hello world"]

--- a/examples/workflows/upstream/suspend-template.yaml
+++ b/examples/workflows/upstream/suspend-template.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: suspend-template-
+spec:
+  entrypoint: suspend
+  templates:
+  - container:
+      args:
+      - hello world
+      command:
+      - cowsay
+      image: docker/whalesay
+    name: whalesay
+  - name: approve
+    suspend: {}
+  - name: delay
+    suspend:
+      duration: '20'
+  - name: suspend
+    steps:
+    - - name: build
+        template: whalesay
+    - - name: approve
+        template: approve
+    - - name: delay
+        template: delay
+    - - name: release
+        template: whalesay

--- a/src/hera/workflows/suspend.py
+++ b/src/hera/workflows/suspend.py
@@ -10,7 +10,7 @@ for more on intermediate parameters.
 """
 from typing import List, Optional, Union
 
-from hera.workflows._mixins import TemplateMixin
+from hera.workflows._mixins import CallableTemplateMixin, TemplateMixin
 from hera.workflows.models import (
     Inputs,
     Outputs,
@@ -20,7 +20,10 @@ from hera.workflows.models import (
 from hera.workflows.parameter import Parameter
 
 
-class Suspend(TemplateMixin):
+class Suspend(
+    TemplateMixin,
+    CallableTemplateMixin,
+):
     """The Suspend template allows the user to pause a workflow for a specified length of time
     given by `duration` or indefinitely (i.e. until manually resumed). The Suspend template also
     allows you to specify `intermediate_parameters` which will replicate the given parameters to

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -35,7 +35,7 @@ from hera.workflows.models import (
     PodSecurityContext,
     RetryStrategy,
     Synchronization,
-    Template,
+    Template as _ModelTemplate,
     Time,
     Toleration,
     TTLStrategy,
@@ -71,8 +71,8 @@ class Workflow(
     """The base Workflow class for Hera.
 
     Workflow implements the contextmanager interface so allows usage of `with`, under which
-    any `hera.workflows.protocol.Templatable` object or `hera.workflows.models.Template` object
-    instantiated under the context will be added to the Workflow's list of templates.
+    any `hera.workflows.protocol.Templatable` object instantiated under the context will be
+    added to the Workflow's list of templates.
 
     Workflows can be created directly on your Argo cluster via `create`. They can also be dumped
     to yaml via `to_yaml` or built according to the Argo schema via `build` to get an OpenAPI model
@@ -135,8 +135,8 @@ class Workflow(
     shutdown: Optional[str] = None
     suspend: Optional[bool] = None
     synchronization: Optional[Synchronization] = None
-    template_defaults: Optional[Template] = None
-    templates: List[Union[Template, Templatable]] = []
+    template_defaults: Optional[_ModelTemplate] = None
+    templates: List[Union[_ModelTemplate, Templatable]] = []
     tolerations: Optional[List[Toleration]] = None
     ttl_strategy: Optional[TTLStrategy] = None
     volume_claim_gc: Optional[VolumeClaimGC] = None
@@ -347,7 +347,7 @@ class Workflow(
         """Adds any objects instantiated under the Workflow context manager that conform to the `Templatable` protocol
         or are Argo schema Template objects to the Workflow's list of templates.
         """
-        if not isinstance(node, (Templatable, *get_args(Template))):
+        if not isinstance(node, (Templatable, _ModelTemplate)):
             raise InvalidType(type(node))
         self.templates.append(node)
 


### PR DESCRIPTION
* Fixes ability to add raw model Template in workflow.py

Related to #594 - should we add public API for `workflow.add_template`, otherwise I have to use `workflow._add_sub`