### PR TITLE
Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/❓-i-have-a-question.md
+++ b/.github/ISSUE_TEMPLATE/❓-i-have-a-question.md
@@ -1,0 +1,9 @@
+---
+name: "❓ I have a question"
+about: Please use the GitHub Discussions tab!
+
+---
+
+[👉 Create a new Discussion here! 👈](https://github.com/argoproj-labs/hera/discussions/new/choose)
+
+_Please do not submit a question as an issue - we will create an issue from a discussion if needed!_

--- a/.github/ISSUE_TEMPLATE/🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/🐛-bug-report.md
@@ -1,0 +1,50 @@
+---
+name: "\U0001F41B Bug report"
+about: Help us fix something!
+title: ''
+labels: 'type:bug'
+assignees: ''
+
+---
+
+<h2>Pre-bug-report checklist</h2>
+
+**1. This bug can be reproduced using YAML**
+- [ ] Yes [👉 Please report a bug to the Argo Workflows GitHub 👈](https://github.com/argoproj/argo-workflows/issues/new/choose)
+- [ ] No
+
+**2. This bug occurs when...**
+- [ ] running Hera code without submitting to Argo (e.g. when exporting to YAML)
+- [ ] running Hera code and submitting to Argo
+
+<h2>Bug report</h2>
+
+**Describe the bug**
+_A clear and concise description of what the bug is:_
+
+_Error log if applicable_:
+```
+error: something broke!
+```
+
+**To Reproduce**
+Full Hera code to reproduce the bug:
+```py
+from hera.workflows import Workflow
+
+with Workflow(name="my-workflow") as w:
+    # Add your code here
+```
+
+**Expected behavior**
+_A clear and concise description of what you expected to happen:_
+
+
+**Environment**
+ - OS: [e.g. iOS]
+ - Browser: [e.g. chrome, safari]
+ - Version of Hera: [e.g. 5.1.6, 4.4.2]
+ - Version of Argo: [e.g. 3.4.7]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/🚀-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/🚀-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea for Hera!
+title: ''
+labels: 'type:enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. e.g.. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Thank you for submitting a PR to Hera! 🚀 -->
+
+**Pull Request Checklist**
+- [ ] Fixes #<!--issue number goes here-->
+- [ ] Tests added
+- [ ] Documentation/examples added
+- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
+
+
+**Description of PR**
+<!-- If not linked to an issue, please describe your changes here -->
+
+Currently, ...
+
+This PR adds/changes/fixes...
+
+<!-- Piece of cake! ✨🍰✨ -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 - [ ] Tests added
 - [ ] Documentation/examples added
 - [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
-
+<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->
 
 **Description of PR**
 <!-- If not linked to an issue, please describe your changes here -->


### PR DESCRIPTION
Fixes #457 

Issue templates:
* Hopefully the bug report issue helps people to try out in YAML first before submitting an issue here.
* Used the standard feature request from github
* The "I have a question" issue should increase use of the discussions tab and improve user discovery rather than searching through closed issues

PR template is as short as possible while keeping the essentials.