### PR TITLE
Fix get_parameter for Step

### DIFF
--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -98,13 +98,9 @@ class Step(
 
         obj = next((output for output in parameters if output.name == name), None)
         if obj is not None:
-            obj.value = f"{{{{steps.{self.name}.outputs.parameters.{name}}}}}"
             return Parameter(
                 name=obj.name,
-                value=obj.value,
-                value_from=obj.value_from,
-                global_name=obj.global_name,
-                description=obj.description,
+                value=f"{{{{steps.{self.name}.outputs.parameters.{name}}}}}",
             )
         raise KeyError(f"No output parameter named `{name}` found")
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #550 for `Step`s
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**
<!-- If not linked to an issue, please describe your changes here -->

Currently, using `get_parameter` on a step fails due to the validator as value/value_from are mutually exclusive, e.g. 
```py
            Step(
                name="do-retry",
                template=...
                when=f"{retry_step.get_parameter('retry-param')}==retry",
            )
```

This PR copies the fix for Task from #565 for Step.

Only doing a small fix as the duplicated function code should be addressed in #595 

<!-- Piece of cake! ✨🍰✨ -->