### PR TITLE
Fix for volumes in WorkflowTemplate Spec

### DIFF
--- a/docs/examples/workflows/volume_mounts_wt.md
+++ b/docs/examples/workflows/volume_mounts_wt.md
@@ -1,0 +1,129 @@
+# Volume Mounts Wt
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import (
+        DAG,
+        Parameter,
+        Volume,
+        WorkflowTemplate,
+        models as m,
+        script,
+    )
+
+
+    @script(
+        inputs=Parameter(name="vol"),
+        volume_mounts=[m.VolumeMount(name="{{inputs.parameters.vol}}", mount_path="/mnt/vol")],
+    )
+    def foo():
+        import os
+        import subprocess
+
+        print(os.listdir("/mnt"))
+        print(subprocess.run("cd /mnt && df -h", shell=True, capture_output=True).stdout.decode())
+
+
+    with WorkflowTemplate(
+        generate_name="volumes-",
+        entrypoint="d",
+        volumes=[
+            Volume(name="v1", mount_path="/mnt/v1", size="1Gi"),
+            Volume(name="v2", mount_path="/mnt/v2", size="3Gi"),
+            Volume(name="v3", mount_path="/mnt/v3", size="5Gi"),
+        ],
+    ) as w:
+        with DAG(name="d"):
+            foo(name="v1", arguments=Parameter(name="vol", value="v1"))
+            foo(name="v2", arguments=Parameter(name="vol", value="v2"))
+            foo(name="v3", arguments=Parameter(name="vol", value="v3"))
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      generateName: volumes-
+    spec:
+      entrypoint: d
+      templates:
+      - dag:
+          tasks:
+          - arguments:
+              parameters:
+              - name: vol
+                value: v1
+            name: v1
+            template: foo
+          - arguments:
+              parameters:
+              - name: vol
+                value: v2
+            name: v2
+            template: foo
+          - arguments:
+              parameters:
+              - name: vol
+                value: v3
+            name: v3
+            template: foo
+        name: d
+      - inputs:
+          parameters:
+          - name: vol
+        name: foo
+        script:
+          command:
+          - python
+          image: python:3.8
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            import os
+
+            import subprocess
+
+            print(os.listdir(''/mnt''))
+
+            print(subprocess.run(''cd /mnt && df -h'', shell=True, capture_output=True).stdout.decode())'
+          volumeMounts:
+          - mountPath: /mnt/vol
+            name: '{{inputs.parameters.vol}}'
+      volumeClaimTemplates:
+      - metadata:
+          name: v1
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+      - metadata:
+          name: v2
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 3Gi
+      - metadata:
+          name: v3
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
+    ```
+

--- a/examples/workflows/volume-mounts-wt.yaml
+++ b/examples/workflows/volume-mounts-wt.yaml
@@ -1,0 +1,77 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  generateName: volumes-
+spec:
+  entrypoint: d
+  templates:
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: vol
+            value: v1
+        name: v1
+        template: foo
+      - arguments:
+          parameters:
+          - name: vol
+            value: v2
+        name: v2
+        template: foo
+      - arguments:
+          parameters:
+          - name: vol
+            value: v3
+        name: v3
+        template: foo
+    name: d
+  - inputs:
+      parameters:
+      - name: vol
+    name: foo
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        import os
+
+        import subprocess
+
+        print(os.listdir(''/mnt''))
+
+        print(subprocess.run(''cd /mnt && df -h'', shell=True, capture_output=True).stdout.decode())'
+      volumeMounts:
+      - mountPath: /mnt/vol
+        name: '{{inputs.parameters.vol}}'
+  volumeClaimTemplates:
+  - metadata:
+      name: v1
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: v2
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 3Gi
+  - metadata:
+      name: v3
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi

--- a/examples/workflows/volume_mounts_wt.py
+++ b/examples/workflows/volume_mounts_wt.py
@@ -1,0 +1,35 @@
+from hera.workflows import (
+    DAG,
+    Parameter,
+    Volume,
+    WorkflowTemplate,
+    models as m,
+    script,
+)
+
+
+@script(
+    inputs=Parameter(name="vol"),
+    volume_mounts=[m.VolumeMount(name="{{inputs.parameters.vol}}", mount_path="/mnt/vol")],
+)
+def foo():
+    import os
+    import subprocess
+
+    print(os.listdir("/mnt"))
+    print(subprocess.run("cd /mnt && df -h", shell=True, capture_output=True).stdout.decode())
+
+
+with WorkflowTemplate(
+    generate_name="volumes-",
+    entrypoint="d",
+    volumes=[
+        Volume(name="v1", mount_path="/mnt/v1", size="1Gi"),
+        Volume(name="v2", mount_path="/mnt/v2", size="3Gi"),
+        Volume(name="v3", mount_path="/mnt/v3", size="5Gi"),
+    ],
+) as w:
+    with DAG(name="d"):
+        foo(name="v1", arguments=Parameter(name="vol", value="v1"))
+        foo(name="v2", arguments=Parameter(name="vol", value="v2"))
+        foo(name="v3", arguments=Parameter(name="vol", value="v3"))

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -198,10 +198,8 @@ class Workflow(
                 result.append(secret)
         return result
 
-    def build(self) -> TWorkflow:
-        """Builds the Workflow and its components into an Argo schema Workflow object."""
-        self = self._dispatch_hooks()
-
+    def _build_templates(self) -> List[TTemplate]:
+        """Builds the templates into an Argo schema."""
         templates = []
         for template in self.templates:
             if isinstance(template, HookMixin):
@@ -242,7 +240,13 @@ class Workflow(
                     for claim_name, claim in new_volume_claims_map.items():
                         if claim_name not in current_volume_claims_map:
                             self.volume_claim_templates.append(claim)
+        return templates
 
+    def build(self) -> TWorkflow:
+        """Builds the Workflow and its components into an Argo schema Workflow object."""
+        self = self._dispatch_hooks()
+
+        templates = self._build_templates()
         workflow_claims = self._build_persistent_volume_claims()
         volume_claim_templates = (self.volume_claim_templates or []) + (workflow_claims or [])
         return _ModelWorkflow(


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Hera! 🚀 -->

**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**

Currently, there is bug with the `WorkflowTemplate` class  where volumes are not being  correctly built. Example:

```python
from hera.workflows import WorkflowTemplate, DownwardAPIVolume
from hera.workflows import models as m
from hera.workflows import Script

with WorkflowTemplate(
    name="test",
    volumes=[DownwardAPIVolume(name="podinfo", mount_path="/etc/podinfo", items=[m.DownwardAPIVolumeFile(field_ref=m.ObjectFieldSelector(field_path="metadata.annotations"), path="annotations")])]
) as w:
    Script(name="test", source="test", volume_mounts=[m.VolumeMount(name="podinfo", mount_path="/etc/podinfo")])

print(w.to_yaml())
```
This generates:

```yaml
...
  volumes:
    name: podinfo
```
It should generate:

```yaml
...
  volumes:
  - downwardAPI:
      items:
      - fieldRef:
          fieldPath: metadata.annotations
        path: annotations
    name: podinfo
```
This works as expected for `Workflow` but not for `WorkflowTemplate`, this because for `WorkflowTemplate` `self._build_volumes()` is not being called and volume claims are not being built.

This PR fixes this by generalising the logic used to build templates such that the same code is used for `Workflow` and `WorkflowTemplate`.

<!-- Piece of cake! ✨🍰✨ -->