### PR TITLE
Fix types in script decorator

### DIFF
--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Set, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, TypeVar, Union, cast
 
 from pydantic import root_validator, validator
 
@@ -57,6 +57,11 @@ from hera.workflows.parameter import MISSING, Parameter
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import Volume, _BaseVolume
+
+if TYPE_CHECKING:
+    from hera.workflows.steps import Step
+    from hera.workflows.task import Task
+
 
 InputsT = Optional[
     Union[
@@ -461,7 +466,7 @@ class ArgumentsMixin(BaseMixin):
 
 
 class CallableTemplateMixin(ArgumentsMixin):
-    def __call__(self, *args, **kwargs) -> Optional[SubNodeMixin]:
+    def __call__(self, *args, **kwargs) -> Union[Step, Task]:
         if "name" not in kwargs:
             kwargs["name"] = self.name  # type: ignore
 

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -9,11 +9,10 @@ import inspect
 import textwrap
 from abc import abstractmethod
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, Unpack, get_type_hints
-from typing_extensions import TypeVarTuple, ParamSpec
-
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from pydantic import root_validator, validator
+from typing_extensions import ParamSpec
 
 from hera.expr import g
 from hera.shared import BaseMixin, global_config
@@ -233,6 +232,7 @@ def _get_parameters_from_callable(source: Callable) -> Optional[List[Parameter]]
 FuncIns = ParamSpec("FuncIns")  # For input types of given func to script decorator
 FuncR = TypeVar("FuncR")  # For return type of given func to script decorator
 
+
 def script(**script_kwargs):
     """A decorator that wraps a function into a Script object.
 
@@ -251,6 +251,7 @@ def script(**script_kwargs):
     Callable
         Function that wraps a given function into a `Script`.
     """
+
     def script_wrapper(
         func: Callable[FuncIns, FuncR],
     ) -> Union[Callable[FuncIns, FuncR], Callable[..., Union[Task, Step]]]:


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Hera! 🚀 -->

**Pull Request Checklist**
- [x] Tests added - manual testing of typing system with screenshots
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**
<!-- If not linked to an issue, please describe your changes here -->

Currently, using a function decorated with a `@script` decorator loses type information when in a steps context or when used outside of a workflow e.g. in tests.

This PR fixes the type information in the script decorator.

Tested with functions such as:

```py
@script()
def hello_world():  # no args
    print("Hello world")

@script()
def hello(message: str): # one str arg
    print(f"Hello {message}")

@script()
def echo_a_dict(my_dict: Dict[str, str]): # dict arg
    for k, v in my_dict.items():
        print(f"{k}={v}")

@script()
def echo_multiple(message: str, times: int):  # multiple args, different types
    print(message * times)

@script()
def return_str(message: str) -> str:  # has a return type
    return f"Your message: '{message}'"
```



See screenshots:

Under a steps context we can see we'll get back a Task or a Step. Currently not able to infer types of the Script kwargs that are passed through the decorator. The closest we can get I think is to check for missing values/correctness described [here](https://stackoverflow.com/questions/68995170/pydantic-get-a-fields-type-hint) - we need the types of the `Script` class members which I think are only available at runtime.

![under-steps](https://github.com/argoproj-labs/hera/assets/17798778/1657cd0e-3e0e-46ff-b315-2764a2254739)

Outside of a steps we can get the full type info of the underlying function (note that the chosen hint isn't automatic)

![out-of-steps](https://github.com/argoproj-labs/hera/assets/17798778/8d91f97c-5746-4a9c-8d48-939e5ba401d9)

Func with no args

![no-args](https://github.com/argoproj-labs/hera/assets/17798778/6eb8b569-4335-43cb-b041-1b81f711c7ab)

Func with multiple args, different types

![echo-multiple](https://github.com/argoproj-labs/hera/assets/17798778/3eec199c-7f3b-45c6-94d6-45518f6695f2)

Func with return type 

![return-type](https://github.com/argoproj-labs/hera/assets/17798778/0eb702b0-ede7-4870-a976-9b16b1ecb18c)

Hover over at any location

![hovering-over](https://github.com/argoproj-labs/hera/assets/17798778/3d29316e-233d-421d-8ce9-b3741223ba93)

Automatic intellisense within a Steps context (!!!) (Note it shows `depends` which is from `Task` only, because `hello_step` has a type of `Union[Step, Task, None]`, so it seems like a best effort by pylance)

![intellisense](https://github.com/argoproj-labs/hera/assets/17798778/2d4503b7-755e-4794-801a-dcd44272b013)