### PR TITLE
[#636] Add special case handling of cron workflow status

### DIFF
--- a/scripts/service.py
+++ b/scripts/service.py
@@ -175,7 +175,7 @@ class ServiceEndpoint:
         elif "CronWorkflow" in self.response.ref:
             # when users schedule cron workflows that have not executed the moment they are scheduled, the response
             # does contain `CronWorkflowStatus` but its fields are empty. However, the `CronWorkflowStatus` object,
-            # while option on `CronWorkflow`, has *required* fields. Here, we overwrite the response with a special
+            # while optional on `CronWorkflow`, has *required* fields. Here, we overwrite the response with a special
             # case that handles setting the `CronWorkflowStatus` to `None` if the response is empty.
             return f"""
     {signature}

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -179,6 +179,7 @@ class ServiceEndpoint:
             # case that handles setting the `CronWorkflowStatus` to `None` if the response is empty.
             return f"""
     {signature}
+        assert valid_host_scheme(self.host), "The host scheme is required for service usage"
         resp = requests.{self.method}(
             url={req_url},
             params={params},

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -172,6 +172,32 @@ class ServiceEndpoint:
             ret_val = "str(resp.content)"
         elif "Response" in self.response.ref:
             ret_val = f"{self.response}()"
+        elif "CronWorkflow" in self.response.ref:
+            # when users schedule cron workflows that have not executed the moment they are scheduled, the response
+            # does contain `CronWorkflowStatus` but its fields are empty. However, the `CronWorkflowStatus` object,
+            # while option on `CronWorkflow`, has *required* fields. Here, we overwrite the response with a special
+            # case that handles setting the `CronWorkflowStatus` to `None` if the response is empty.
+            return f"""
+    {signature}
+        resp = requests.{self.method}(
+            url={req_url},
+            params={params},
+            headers={headers},
+            data={body},
+            verify=self.verify_ssl
+        )
+
+        if resp.ok:
+            resp_json = resp.json()
+            if "status" in resp_json and resp_json["status"]['active'] is None and resp_json["status"]['lastScheduledTime'] is None and resp_json["status"]['conditions'] is None:
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json['status'] = None
+            return {self.response}(**resp_json)
+        else:
+            raise Exception(f"Server returned status code {{resp.status_code}} with error: {{resp.json()}}")
+            """
         else:
             ret_val = f"{self.response}(**resp.json())"
 

--- a/src/hera/workflows/service.py
+++ b/src/hera/workflows/service.py
@@ -374,7 +374,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflowList(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflowList(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -392,7 +403,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -410,7 +432,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -428,7 +461,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -448,7 +492,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -501,7 +556,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 
@@ -521,7 +587,18 @@ class WorkflowsService:
         )
 
         if resp.ok:
-            return CronWorkflow(**resp.json())
+            resp_json = resp.json()
+            if (
+                "status" in resp_json
+                and resp_json["status"]["active"] is None
+                and resp_json["status"]["lastScheduledTime"] is None
+                and resp_json["status"]["conditions"] is None
+            ):
+                # this is a necessary special case as the status fields cannot be empty on the `CronWorkflowStatus`
+                # object. So, we overwrite the response with a value that allows the response to pass through safely.
+                # See `hera.scripts.service.ServiceEndpoint.__str__` for more details.
+                resp_json["status"] = None
+            return CronWorkflow(**resp_json)
         else:
             raise Exception(f"Server returned status code {resp.status_code} with error: {resp.json()}")
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Hera! 🚀 -->

**Pull Request Checklist**
- [x] Fixes #636 
- [ ] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**
<!-- If not linked to an issue, please describe your changes here -->

Currently, the Argo server does not return cron workflow statuses when a users' cron workflow does not execute _immediately_ post submission. So, `None`s are returned for the independent fields of the cron workflow status. While the status is indeed optional, the fields are not! This PR adds a special case for handling this in the service. I am not sure whether this is a feature or a bug upstream in Argo Workflows.

CC: @iameskild I was able to run your example using the fix in this PR!

<!-- Piece of cake! ✨🍰✨ -->