### PR TITLE
[#513] Add source args inference to callable template mixin to support source kwargs in regular Py call

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ with Workflow(
     entrypoint="steps",
 ) as w:
     with Steps(name="steps"):
-        echo(arguments={"message": "A"})
+        echo(message="A")
 
 w.create()
 
@@ -126,10 +126,10 @@ with Workflow(
     entrypoint="diamond",
 ) as w:
     with DAG(name="diamond"):
-        A = echo(name="A", arguments={"message": "A"})
-        B = echo(name="B", arguments={"message": "B"})
-        C = echo(name="C", arguments={"message": "C"})
-        D = echo(name="D", arguments={"message": "D"})
+        A = echo(name="A", message="A")
+        B = echo(name="B", message="B")
+        C = echo(name="C", message="C")
+        D = echo(name="D", message="D")
         A >> [B, C] >> D
 
 w.create()
@@ -214,10 +214,10 @@ with Workflow(
         inputs=[Parameter(name="message")],
     )
     with DAG(name="diamond"):
-        A = echo(name="A", arguments={"message": "A"})
-        B = echo(name="B", arguments={"message": "B"})
-        C = echo(name="C", arguments={"message": "C"})
-        D = echo(name="D", arguments={"message": "D"})
+        A = echo(name="A", message="A")
+        B = echo(name="B", message="B")
+        C = echo(name="C", message="C")
+        D = echo(name="D", message="D")
         A >> [B, C] >> D
 
 w.create()

--- a/docs/examples/workflows/dag_diamond_with_callable_decorators.md
+++ b/docs/examples/workflows/dag_diamond_with_callable_decorators.md
@@ -22,10 +22,10 @@
 
     with Workflow(generate_name="dag-diamond-", entrypoint="diamond") as w:
         with DAG(name="diamond"):
-            A = echo(name="A", arguments={"message": "A"})
-            B = echo(name="B", arguments={"message": "B"})
-            C = echo(name="C", arguments={"message": "C"})
-            D = echo(name="D", arguments={"message": "D"})
+            A = echo(name="A", message="A")
+            B = echo(name="B", message="B")
+            C = echo(name="C", message="C")
+            D = echo(name="D", message="D")
             A >> [B, C] >> D
     ```
 

--- a/docs/examples/workflows/script_artifact_passing.md
+++ b/docs/examples/workflows/script_artifact_passing.md
@@ -48,7 +48,6 @@
               artifacts:
               - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
                 name: message
-                path: /tmp/hello_world.txt
             name: consume-artifact
             template: print-message
       - name: whalesay

--- a/docs/examples/workflows/script_artifact_passing.md
+++ b/docs/examples/workflows/script_artifact_passing.md
@@ -26,11 +26,8 @@
 
     with Workflow(generate_name="artifact-passing-", entrypoint="artifact-example") as w:
         with Steps(name="artifact-example") as s:
-            whalesay(name="generate-artifact")
-            print_message(
-                name="consume-artifact",
-                arguments=[Artifact(name="message", from_="{{steps.generate-artifact.outputs.artifacts.hello-art}}")],
-            )
+            ga = whalesay(name="generate-artifact")
+            print_message(name="consume-artifact", message=ga.get_artifact("hello-art"))
     ```
 
 === "YAML"
@@ -47,11 +44,7 @@
         steps:
         - - name: generate-artifact
             template: whalesay
-        - - arguments:
-              artifacts:
-              - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
-                name: message
-            name: consume-artifact
+        - - name: consume-artifact
             template: print-message
       - name: whalesay
         outputs:

--- a/docs/examples/workflows/script_variations.md
+++ b/docs/examples/workflows/script_variations.md
@@ -25,7 +25,7 @@
     with Workflow(generate_name="fv-test-", entrypoint="d") as w:
         with DAG(name="d"):
             hello_world()
-            multiline_function(arguments={"test": "test string", "another_test": "another test string"})
+            multiline_function(test="test string", another_test="another test string")
     ```
 
 === "YAML"

--- a/docs/examples/workflows/script_with_default_params.md
+++ b/docs/examples/workflows/script_with_default_params.md
@@ -18,10 +18,10 @@
 
     with Workflow(generate_name="script-default-params-", entrypoint="d") as w:
         with DAG(name="d"):
-            foo(name="b-unset-c-unset", arguments={"a": 1})
-            foo(name="b-set-c-unset", arguments={"a": 1, "b": 2})
-            foo(name="b-unset-c-set", arguments={"a": 1, "c": 2})
-            foo(name="b-set-c-set", arguments={"a": 1, "b": 2, "c": 3})
+            foo(name="b-unset-c-unset", a=1)
+            foo(name="b-set-c-unset", a=1, b=2)
+            foo(name="b-unset-c-set", a=1, c=2)
+            foo(name="b-set-c-set", a=1, b=2, c=3)
     ```
 
 === "YAML"

--- a/docs/examples/workflows/upstream/dag_diamond.md
+++ b/docs/examples/workflows/upstream/dag_diamond.md
@@ -21,10 +21,10 @@
             inputs=[Parameter(name="message")],
         )
         with DAG(name="diamond"):
-            A = echo(name="A", arguments={"message": "A"})
-            B = echo(name="B", arguments={"message": "B"})
-            C = echo(name="C", arguments={"message": "C"})
-            D = echo(name="D", arguments={"message": "D"})
+            A = echo(name="A", message="A")
+            B = echo(name="B", message="B")
+            C = echo(name="C", message="C")
+            D = echo(name="D", message="D")
             A >> [B, C] >> D
     ```
 

--- a/docs/examples/workflows/upstream/dag_nested.md
+++ b/docs/examples/workflows/upstream/dag_nested.md
@@ -19,17 +19,17 @@
 
     with Workflow(generate_name="dag-nested-", entrypoint="diamond") as w:
         with DAG(name="nested-diamond", inputs=[Parameter(name="message")]) as nested_diamond:
-            A = echo(name="A", arguments={"message": "{{inputs.parameters.message}}A"})
-            B = echo(name="B", arguments={"message": "{{inputs.parameters.message}}B"})
-            C = echo(name="C", arguments={"message": "{{inputs.parameters.message}}C"})
-            D = echo(name="D", arguments={"message": "{{inputs.parameters.message}}D"})
+            A = echo(name="A", message="{{inputs.parameters.message}}A")
+            B = echo(name="B", message="{{inputs.parameters.message}}B")
+            C = echo(name="C", message="{{inputs.parameters.message}}C")
+            D = echo(name="D", message="{{inputs.parameters.message}}D")
             A >> [B, C] >> D
 
         with DAG(name="diamond") as diamond:
-            A = nested_diamond(name="A", arguments={"message": "A"})
-            B = nested_diamond(name="B", arguments={"message": "B"})
-            C = nested_diamond(name="C", arguments={"message": "C"})
-            D = nested_diamond(name="D", arguments={"message": "D"})
+            A = nested_diamond(name="A", message="A")
+            B = nested_diamond(name="B", message="B")
+            C = nested_diamond(name="C", message="C")
+            D = nested_diamond(name="D", message="D")
             A >> [B, C] >> D
     ```
 

--- a/docs/examples/workflows/upstream/loops.md
+++ b/docs/examples/workflows/upstream/loops.md
@@ -22,7 +22,7 @@
         with Steps(name="loop-example"):
             whalesay(
                 name="print-message",
-                arguments={"message": "{{item}}"},
+                message="{{item}}",
                 with_items=["hello world", "goodbye world"],
             )
     ```

--- a/docs/examples/workflows/upstream/loops_dag.md
+++ b/docs/examples/workflows/upstream/loops_dag.md
@@ -22,9 +22,9 @@
             inputs=[Parameter(name="message")],
         )
         with DAG(name="loops-dag"):
-            A = echo(name="A", arguments={"message": "A"})
-            B = echo(name="B", arguments={"message": "{{item}}"}, with_items=["foo", "bar", "baz"])
-            C = echo(name="C", arguments={"message": "C"})
+            A = echo(name="A", message="A")
+            B = echo(name="B", message="{{item}}", with_items=["foo", "bar", "baz"])
+            C = echo(name="C", message="C")
             A >> B >> C
     ```
 

--- a/docs/examples/workflows/upstream/parallelism_nested_dag.md
+++ b/docs/examples/workflows/upstream/parallelism_nested_dag.md
@@ -20,17 +20,17 @@
 
     with Workflow(generate_name="parallelism-nested-dag-", entrypoint="A") as w:
         with DAG(name="B", inputs=Parameter(name="msg")) as B:
-            c1 = one_job(name="c1", arguments={"msg": "{{inputs.parameters.msg}} c1"})
-            c2 = one_job(name="c2", arguments={"msg": "{{inputs.parameters.msg}} c2"})
-            c3 = one_job(name="c3", arguments={"msg": "{{inputs.parameters.msg}} c3"})
+            c1 = one_job(name="c1", msg="{{inputs.parameters.msg}} c1")
+            c2 = one_job(name="c2", msg="{{inputs.parameters.msg}} c2")
+            c3 = one_job(name="c3", msg="{{inputs.parameters.msg}} c3")
             c1 >> [c2, c3]
 
         with DAG(name="A", parallelism=2) as A:
-            b1 = B(name="b1", arguments={"msg": "1"})
-            b2 = B(name="b2", arguments={"msg": "2"})
-            b3 = B(name="b3", arguments={"msg": "3"})
-            b4 = B(name="b4", arguments={"msg": "4"})
-            b5 = B(name="b5", arguments={"msg": "5"})
+            b1 = B(name="b1", msg="1")
+            b2 = B(name="b2", msg="2")
+            b3 = B(name="b3", msg="3")
+            b4 = B(name="b4", msg="4")
+            b5 = B(name="b5", msg="5")
             b1 >> [b2, b3, b4] >> b5
     ```
 

--- a/examples/workflows/dag_diamond_with_callable_decorators.py
+++ b/examples/workflows/dag_diamond_with_callable_decorators.py
@@ -4,7 +4,6 @@ from hera.workflows import (
     script,
 )
 
-
 @script(add_cwd_to_sys_path=False, image="python:alpine3.6")
 def echo(message):
     print(message)
@@ -12,8 +11,9 @@ def echo(message):
 
 with Workflow(generate_name="dag-diamond-", entrypoint="diamond") as w:
     with DAG(name="diamond"):
-        A = echo(name="A", arguments={"message": "A"})
-        B = echo(name="B", arguments={"message": "B"})
-        C = echo(name="C", arguments={"message": "C"})
-        D = echo(name="D", arguments={"message": "D"})
+        A = echo(name="A", message="A")
+        B = echo(name="B", message="B")
+        C = echo(name="C", message="C")
+        D = echo(name="D", message="D")
         A >> [B, C] >> D
+

--- a/examples/workflows/dag_diamond_with_callable_decorators.py
+++ b/examples/workflows/dag_diamond_with_callable_decorators.py
@@ -4,6 +4,7 @@ from hera.workflows import (
     script,
 )
 
+
 @script(add_cwd_to_sys_path=False, image="python:alpine3.6")
 def echo(message):
     print(message)
@@ -16,4 +17,3 @@ with Workflow(generate_name="dag-diamond-", entrypoint="diamond") as w:
         C = echo(name="C", message="C")
         D = echo(name="D", message="D")
         A >> [B, C] >> D
-

--- a/examples/workflows/script-artifact-passing.yaml
+++ b/examples/workflows/script-artifact-passing.yaml
@@ -13,7 +13,6 @@ spec:
           artifacts:
           - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
             name: message
-            path: /tmp/hello_world.txt
         name: consume-artifact
         template: print-message
   - name: whalesay

--- a/examples/workflows/script-artifact-passing.yaml
+++ b/examples/workflows/script-artifact-passing.yaml
@@ -9,11 +9,7 @@ spec:
     steps:
     - - name: generate-artifact
         template: whalesay
-    - - arguments:
-          artifacts:
-          - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
-            name: message
-        name: consume-artifact
+    - - name: consume-artifact
         template: print-message
   - name: whalesay
     outputs:

--- a/examples/workflows/script_artifact_passing.py
+++ b/examples/workflows/script_artifact_passing.py
@@ -16,8 +16,5 @@ def print_message():
 
 with Workflow(generate_name="artifact-passing-", entrypoint="artifact-example") as w:
     with Steps(name="artifact-example") as s:
-        whalesay(name="generate-artifact")
-        print_message(
-            name="consume-artifact",
-            arguments=[Artifact(name="message", from_="{{steps.generate-artifact.outputs.artifacts.hello-art}}")],
-        )
+        ga = whalesay(name="generate-artifact")
+        print_message(name="consume-artifact", message=ga.get_artifact("hello-art"))

--- a/examples/workflows/script_variations.py
+++ b/examples/workflows/script_variations.py
@@ -15,4 +15,4 @@ def multiline_function(test: str, another_test: str):  # pragma: no cover
 with Workflow(generate_name="fv-test-", entrypoint="d") as w:
     with DAG(name="d"):
         hello_world()
-        multiline_function(arguments={"test": "test string", "another_test": "another test string"})
+        multiline_function(test="test string", another_test="another test string")

--- a/examples/workflows/script_with_default_params.py
+++ b/examples/workflows/script_with_default_params.py
@@ -8,7 +8,7 @@ def foo(a, b=42, c=None):
 
 with Workflow(generate_name="script-default-params-", entrypoint="d") as w:
     with DAG(name="d"):
-        foo(name="b-unset-c-unset", arguments={"a": 1})
-        foo(name="b-set-c-unset", arguments={"a": 1, "b": 2})
-        foo(name="b-unset-c-set", arguments={"a": 1, "c": 2})
-        foo(name="b-set-c-set", arguments={"a": 1, "b": 2, "c": 3})
+        foo(name="b-unset-c-unset", a=1)
+        foo(name="b-set-c-unset", a=1, b=2)
+        foo(name="b-unset-c-set", a=1, c=2)
+        foo(name="b-set-c-set", a=1, b=2, c=3)

--- a/examples/workflows/upstream/dag_diamond.py
+++ b/examples/workflows/upstream/dag_diamond.py
@@ -11,8 +11,8 @@ with Workflow(
         inputs=[Parameter(name="message")],
     )
     with DAG(name="diamond"):
-        A = echo(name="A", arguments={"message": "A"})
-        B = echo(name="B", arguments={"message": "B"})
-        C = echo(name="C", arguments={"message": "C"})
-        D = echo(name="D", arguments={"message": "D"})
+        A = echo(name="A", message="A")
+        B = echo(name="B", message="B")
+        C = echo(name="C", message="C")
+        D = echo(name="D", message="D")
         A >> [B, C] >> D

--- a/examples/workflows/upstream/dag_nested.py
+++ b/examples/workflows/upstream/dag_nested.py
@@ -9,15 +9,15 @@ echo = Container(
 
 with Workflow(generate_name="dag-nested-", entrypoint="diamond") as w:
     with DAG(name="nested-diamond", inputs=[Parameter(name="message")]) as nested_diamond:
-        A = echo(name="A", arguments={"message": "{{inputs.parameters.message}}A"})
-        B = echo(name="B", arguments={"message": "{{inputs.parameters.message}}B"})
-        C = echo(name="C", arguments={"message": "{{inputs.parameters.message}}C"})
-        D = echo(name="D", arguments={"message": "{{inputs.parameters.message}}D"})
+        A = echo(name="A", message="{{inputs.parameters.message}}A")
+        B = echo(name="B", message="{{inputs.parameters.message}}B")
+        C = echo(name="C", message="{{inputs.parameters.message}}C")
+        D = echo(name="D", message="{{inputs.parameters.message}}D")
         A >> [B, C] >> D
 
     with DAG(name="diamond") as diamond:
-        A = nested_diamond(name="A", arguments={"message": "A"})
-        B = nested_diamond(name="B", arguments={"message": "B"})
-        C = nested_diamond(name="C", arguments={"message": "C"})
-        D = nested_diamond(name="D", arguments={"message": "D"})
+        A = nested_diamond(name="A", message="A")
+        B = nested_diamond(name="B", message="B")
+        C = nested_diamond(name="C", message="C")
+        D = nested_diamond(name="D", message="D")
         A >> [B, C] >> D

--- a/examples/workflows/upstream/loops.py
+++ b/examples/workflows/upstream/loops.py
@@ -12,6 +12,6 @@ with Workflow(generate_name="loops-", entrypoint="loop-example") as w:
     with Steps(name="loop-example"):
         whalesay(
             name="print-message",
-            arguments={"message": "{{item}}"},
+            message="{{item}}",
             with_items=["hello world", "goodbye world"],
         )

--- a/examples/workflows/upstream/loops_dag.py
+++ b/examples/workflows/upstream/loops_dag.py
@@ -12,7 +12,7 @@ with Workflow(
         inputs=[Parameter(name="message")],
     )
     with DAG(name="loops-dag"):
-        A = echo(name="A", arguments={"message": "A"})
-        B = echo(name="B", arguments={"message": "{{item}}"}, with_items=["foo", "bar", "baz"])
-        C = echo(name="C", arguments={"message": "C"})
+        A = echo(name="A", message="A")
+        B = echo(name="B", message="{{item}}", with_items=["foo", "bar", "baz"])
+        C = echo(name="C", message="C")
         A >> B >> C

--- a/examples/workflows/upstream/parallelism_nested_dag.py
+++ b/examples/workflows/upstream/parallelism_nested_dag.py
@@ -10,15 +10,15 @@ one_job = Container(
 
 with Workflow(generate_name="parallelism-nested-dag-", entrypoint="A") as w:
     with DAG(name="B", inputs=Parameter(name="msg")) as B:
-        c1 = one_job(name="c1", arguments={"msg": "{{inputs.parameters.msg}} c1"})
-        c2 = one_job(name="c2", arguments={"msg": "{{inputs.parameters.msg}} c2"})
-        c3 = one_job(name="c3", arguments={"msg": "{{inputs.parameters.msg}} c3"})
+        c1 = one_job(name="c1", msg="{{inputs.parameters.msg}} c1")
+        c2 = one_job(name="c2", msg="{{inputs.parameters.msg}} c2")
+        c3 = one_job(name="c3", msg="{{inputs.parameters.msg}} c3")
         c1 >> [c2, c3]
 
     with DAG(name="A", parallelism=2) as A:
-        b1 = B(name="b1", arguments={"msg": "1"})
-        b2 = B(name="b2", arguments={"msg": "2"})
-        b3 = B(name="b3", arguments={"msg": "3"})
-        b4 = B(name="b4", arguments={"msg": "4"})
-        b5 = B(name="b5", arguments={"msg": "5"})
+        b1 = B(name="b1", msg="1")
+        b2 = B(name="b2", msg="2")
+        b3 = B(name="b3", msg="3")
+        b4 = B(name="b4", msg="4")
+        b5 = B(name="b5", msg="5")
         b1 >> [b2, b3, b4] >> b5

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -54,6 +54,7 @@ from hera.workflows.models import (
     VolumeMount,
 )
 from hera.workflows.parameter import MISSING, Parameter
+from hera.workflows.protocol import Templatable
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import Volume, _BaseVolume
@@ -670,6 +671,45 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
     when: Optional[str] = None
     with_sequence: Optional[Sequence] = None
 
+    @property
+    def _subtype(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def id(self) -> str:
+        """ID of this node."""
+        return f"{{{{{self._subtype}.{self.name}.id}}}}"
+
+    @property
+    def ip(self) -> str:
+        """IP of this node."""
+        return f"{{{{{self._subtype}.{self.name}.ip}}}}"
+
+    @property
+    def status(self) -> str:
+        """Status of this node."""
+        return f"{{{{{self._subtype}.{self.name}.status}}}}"
+
+    @property
+    def exit_code(self) -> str:
+        """ExitCode holds the exit code of a script template."""
+        return f"{{{{{self._subtype}.{self.name}.exitCode}}}}"
+
+    @property
+    def started_at(self) -> str:
+        """Time at which this node started."""
+        return f"{{{{{self._subtype}.{self.name}.startedAt}}}}"
+
+    @property
+    def finished_at(self) -> str:
+        """Time at which this node completed."""
+        return f"{{{{{self._subtype}.{self.name}.finishedAt}}}}"
+
+    @property
+    def result(self) -> str:
+        """Result holds the result (stdout) of a script template."""
+        return f"{{{{{self._subtype}.{self.name}.outputs.result}}}}"
+
     @root_validator(pre=False)
     def _check_values(cls, values):
         def one(xs: List):
@@ -679,6 +719,147 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
         if not one([values.get("template"), values.get("template_ref"), values.get("inline")]):
             raise ValueError("exactly one of ['template', 'template_ref', 'inline'] must be present")
         return values
+
+    def _get_parameters_as(self, name: str, subtype: str) -> Parameter:
+        """Returns a `Parameter` that represents all the outputs of the specified subtype.
+
+        Parameters
+        ----------
+        name: str
+            The name of the parameter to search for.
+        subtype: str
+            The inheritor subtype field, used to construct the output artifact `from_` reference.
+
+        Returns
+        -------
+        Parameter
+            The parameter, named based on the given `name`, along with a value that references all outputs.
+        """
+        return Parameter(name=name, value=f"{{{{{subtype}.{self.name}.outputs.parameters}}}}")
+
+    def _get_parameter(self, name: str, subtype: str) -> Parameter:
+        """Attempts to find the specified parameter in the outputs for the specified subtype.
+
+        Notes
+        -----
+        This is specifically designed to be invoked by inheritors.
+
+        Parameters
+        ----------
+        name: str
+            The name of the parameter to search for.
+        subtype: str
+            The inheritor subtype field, used to construct the output artifact `from_` reference.
+
+        Returns
+        -------
+        Parameter
+            The parameter if found.
+
+        Raises
+        ------
+        ValueError
+            When no outputs can be constructed/no outputs are set.
+        KeyError
+            When the artifact is not found.
+        NotImplementedError
+            When something else other than an `Parameter` is found for the specified name.
+        """
+        if isinstance(self.template, str):
+            raise ValueError(f"Cannot get output parameters when the template was set via a name: {self.template}")
+
+        # here, we build the template early to verify that we can get the outputs
+        if isinstance(self.template, Templatable):
+            template = self.template._build_template()
+        else:
+            template = self.template
+
+        # at this point, we know that the template is a `Template` object
+        if template.outputs is None:  # type: ignore
+            raise ValueError(f"Cannot get output parameters when the template has no outputs: {template}")
+        if template.outputs.parameters is None:  # type: ignore
+            raise ValueError(f"Cannot get output parameters when the template has no output parameters: {template}")
+        parameters = template.outputs.parameters  # type: ignore
+
+        obj = next((output for output in parameters if output.name == name), None)
+        if obj is not None:
+            return Parameter(
+                name=obj.name,
+                value=f"{{{{{subtype}.{self.name}.outputs.parameters.{name}}}}}",
+            )
+        raise KeyError(f"No output parameter named `{name}` found")
+
+    def _get_artifact(self, name: str, subtype: str) -> Artifact:
+        """Attempts to find the specified artifact in the outputs for the specified subtype.
+
+        Notes
+        -----
+        This is specifically designed to be invoked by inheritors.
+
+        Parameters
+        ----------
+        name: str
+            The name of the artifact to search for.
+        subtype: str
+            The inheritor subtype field, used to construct the output artifact `from_` reference.
+
+        Returns
+        -------
+        Artifact
+            The artifact if found.
+
+        Raises
+        ------
+        ValueError
+            When no outputs can be constructed/no outputs are set.
+        KeyError
+            When the artifact is not found.
+        NotImplementedError
+            When something else other than an `Artifact` is found for the specified name.
+        """
+        if isinstance(self.template, str):
+            raise ValueError(f"Cannot get output parameters when the template was set via a name: {self.template}")
+
+        # here, we build the template early to verify that we can get the outputs
+        if isinstance(self.template, Templatable):
+            template = self.template._build_template()
+        else:
+            template = cast(Template, self.template)
+
+        # at this point, we know that the template is a `Template` object
+        if template.outputs is None:  # type: ignore
+            raise ValueError(f"Cannot get output artifacts when the template has no outputs: {template}")
+        elif template.outputs.artifacts is None:  # type: ignore
+            raise ValueError(f"Cannot get output artifacts when the template has no output artifacts: {template}")
+        artifacts = cast(List[ModelArtifact], template.outputs.artifacts)
+
+        obj = next((output for output in artifacts if output.name == name), None)
+        if obj is not None:
+            return Artifact(name=name, path=obj.path, from_=f"{{{{{subtype}.{self.name}.outputs.artifacts.{name}}}}}")
+        raise KeyError(f"No output artifact named `{name}` found")
+
+    def get_parameters_as(self, name: str) -> Parameter:
+        """Returns a `Parameter` that represents all the outputs of this subnode.
+
+        Parameters
+        ----------
+        name: str
+            The name of the parameter to search for.
+
+        Returns
+        -------
+        Parameter
+            The parameter, named based on the given `name`, along with a value that references all outputs.
+        """
+        return self._get_parameters_as(name=name, subtype=self._subtype)
+
+    def get_artifact(self, name: str) -> Artifact:
+        """Gets an artifact from the outputs of this subnode"""
+        return self._get_artifact(name=name, subtype=self._subtype)
+
+    def get_parameter(self, name: str) -> Parameter:
+        """Gets a parameter from the outputs of this subnode"""
+        return self._get_parameter(name=name, subtype=self._subtype)
 
 
 def _get_params_from_source(source: Callable) -> Optional[List[Parameter]]:

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -988,7 +988,7 @@ def _get_source_params_from_kwargs(
         The list of parameters inferred from the source.
     """
     s_args = _get_args_names_from_source(source)
-    params = []
+    params: List[Union[Parameter, Artifact]] = []
     for arg in s_args:
         if isinstance(arg, Artifact) or isinstance(arg, Parameter):
             params.append(arg)

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -936,7 +936,7 @@ def _get_source_params_from_kwargs(
     artifact_names: Set[str],
     source: Callable,
     kwargs: dict,
-) -> List[Parameter]:
+) -> List[Union[Parameter, Artifact]]:
     """Finds any args of the given `source` callable and returns them as `Parameter`s.
 
     Parameters
@@ -954,12 +954,14 @@ def _get_source_params_from_kwargs(
 
     Returns
     -------
-    List[Parameter]
+    List[Union[Parameter, Artifact]]
         The list of parameters inferred from the source.
     """
     s_args = _get_args_names_from_source(source)
     params = []
     for arg in s_args:
-        if arg in kwargs and arg not in parameter_names and arg not in artifact_names:
+        if isinstance(arg, Artifact) or isinstance(arg, Parameter):
+            params.append(arg)
+        elif arg in kwargs and arg not in parameter_names and arg not in artifact_names:
             params.append(Parameter(name=arg, value=kwargs[arg]))
     return params

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -487,9 +487,7 @@ class CallableTemplateMixin(ArgumentsMixin):
                 arguments += self._get_deduped_params_from_items(parameter_names, kwargs["with_items"])
 
             if "source" in kwargs:
-                arguments += self._get_source_params_from_kwargs(
-                    parameter_names, artifact_names, kwargs["source"], kwargs
-                )
+                arguments += _get_source_params_from_kwargs(parameter_names, artifact_names, kwargs["source"], kwargs)
 
             # it is possible for the user to pass `arguments` via `kwargs` along with `with_param`. The `with_param`
             # additional parameters are inferred and have to be added to the `kwargs['arguments']` for otherwise
@@ -512,9 +510,7 @@ class CallableTemplateMixin(ArgumentsMixin):
                 arguments += self._get_deduped_params_from_items(parameter_names, kwargs["with_items"])
 
             if "source" in kwargs:
-                arguments += self._get_source_params_from_kwargs(
-                    parameter_names, artifact_names, kwargs["source"], kwargs
-                )
+                arguments += _get_source_params_from_kwargs(parameter_names, artifact_names, kwargs["source"], kwargs)
 
             # it is possible for the user to pass `arguments` via `kwargs` along with `with_param`. The `with_param`
             # additional parameters are inferred and have to be added to the `kwargs['arguments']` for otherwise
@@ -548,20 +544,6 @@ class CallableTemplateMixin(ArgumentsMixin):
     def _get_artifact_names(self, arguments: List) -> Set[str]:
         artifacts = [arg for arg in arguments if isinstance(arg, ModelArtifact) or isinstance(arg, Artifact)]
         return {a.name for a in artifacts}
-
-    def _get_source_params_from_kwargs(
-        self,
-        parameter_names: Set[str],
-        artifact_names: Set[str],
-        source: Callable,
-        kwargs: dict,
-    ) -> List[Parameter]:
-        s_args = _get_args_names_from_source(source)
-        params = []
-        for arg in s_args:
-            if arg in kwargs and arg not in parameter_names and arg not in artifact_names:
-                params.append(Parameter(name=arg, value=kwargs[arg]))
-        return params
 
     def _get_deduped_params_from_source(
         self, parameter_names: Set[str], artifact_names: Set[str], source: Callable
@@ -947,3 +929,37 @@ def _get_params_from_items(with_items: List[Any]) -> Optional[List[Parameter]]:
         else:
             return [Parameter(name=n, value=f"{{{{item.{n}}}}}") for n in el.keys()]
     return [Parameter(name=n, value=f"{{{{item.{n}}}}}") for n in with_items[0].keys()]
+
+
+def _get_source_params_from_kwargs(
+    parameter_names: Set[str],
+    artifact_names: Set[str],
+    source: Callable,
+    kwargs: dict,
+) -> List[Parameter]:
+    """Finds any args of the given `source` callable and returns them as `Parameter`s.
+
+    Parameters
+    ----------
+    parameter_names: Set[str]
+        Already existing parameters to verify the source args against. If any parameter name matches an arg, then the
+        new arg parameter is *not* added.
+    artifact_names: Set[str]
+        Already existing artifacts to verify the source args against. If any artifact name matches an arg, then the
+        new arg parameter is *not* added.
+    source: Callable
+        The source callable to inspect.
+    kwargs: dict
+        The kwargs to inspect for args of the source callable.
+
+    Returns
+    -------
+    List[Parameter]
+        The list of parameters inferred from the source.
+    """
+    s_args = _get_args_names_from_source(source)
+    params = []
+    for arg in s_args:
+        if arg in kwargs and arg not in parameter_names and arg not in artifact_names:
+            params.append(Parameter(name=arg, value=kwargs[arg]))
+    return params

--- a/src/hera/workflows/artifact.py
+++ b/src/hera/workflows/artifact.py
@@ -73,6 +73,15 @@ class Artifact(BaseModel):
         artifact.name = name
         return artifact
 
+    def as_argument(self, name: Optional[str] = None) -> _ModelArtifact:
+        artifact = self._build_artifact()
+        # if we're using this artifact as an argument then the input of that step/task sets the path of the argument
+        # content, not the artifact itself. The rest of the fields are ok to use as-is
+        artifact.name = name or artifact.name
+        artifact.path = None
+        artifact.sub_path = None
+        return artifact
+
 
 class ArtifactoryArtifact(_ModelArtifactoryArtifact, Artifact):
     def _build_artifact(self) -> _ModelArtifact:

--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -75,7 +75,7 @@ class CronWorkflow(Workflow):
             status=self.cron_status,
         )
 
-    def create(self) -> TWorkflow:
+    def create(self) -> TWorkflow:  # type: ignore
         """Creates the CronWorkflow on the Argo cluster."""
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"

--- a/src/hera/workflows/parameter.py
+++ b/src/hera/workflows/parameter.py
@@ -65,14 +65,14 @@ class Parameter(_ModelParameter):
             value_from=self.value_from,
         )
 
-    def as_argument(self) -> _ModelParameter:
+    def as_argument(self, name: Optional[str] = None) -> _ModelParameter:
         """Assembles the parameter for use as an argument of a step or a task"""
         # Setting a default value when used as an argument is a no-op so we exclude it as it would get overwritten by
         # `value` or `value_from` (one of which is required)
         # Overwrite ref: https://github.com/argoproj/argo-workflows/blob/781675ddcf6f1138d697cb9c71dae484daa0548b/workflow/common/util.go#L126-L139
         # One of value/value_from required ref: https://github.com/argoproj/argo-workflows/blob/ab178bb0b36a5ce34b4c1302cf4855879a0e8cf5/workflow/validate/validate.go#L794-L798
         return _ModelParameter(
-            name=self.name,
+            name=name or self.name,
             global_name=self.global_name,
             description=self.description,
             enum=self.enum,

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -20,7 +20,6 @@ from hera.workflows.models import (
     Template as _ModelTemplate,
     WorkflowStep as _ModelWorkflowStep,
 )
-from hera.workflows.parameter import Parameter
 from hera.workflows.protocol import Steppable, Templatable
 
 
@@ -31,78 +30,14 @@ class Step(
     ParameterMixin,
     ItemMixin,
 ):
-    """Step is used to run a given template. Must be instantiated under a Steps or Parallel context,
-    or outside of a Workflow.
+    """
+    Step is used to run a given template. Must be instantiated under a Steps or Parallel context, or
+    outside a Workflow.
     """
 
     @property
-    def id(self) -> str:
-        return f"{{{{steps.{self.name}.id}}}}"
-
-    @property
-    def ip(self) -> str:
-        return f"{{{{steps.{self.name}.ip}}}}"
-
-    @property
-    def status(self) -> str:
-        return f"{{{{steps.{self.name}.status}}}}"
-
-    @property
-    def exit_code(self) -> str:
-        return f"{{{{steps.{self.name}.exitCode}}}}"
-
-    @property
-    def started_at(self) -> str:
-        return f"{{{{steps.{self.name}.startedAt}}}}"
-
-    @property
-    def finished_at(self) -> str:
-        return f"{{{{steps.{self.name}.finishedAt}}}}"
-
-    @property
-    def result(self) -> str:
-        return f"{{{{steps.{self.name}.outputs.result}}}}"
-
-    def get_parameters_as(self, name):
-        """Gets all the output parameters from this task"""
-        return Parameter(name=name, value=f"{{{{steps.{self.name}.outputs.parameters}}}}")
-
-    def get_parameter(self, name: str) -> Parameter:
-        """Returns a Parameter from the task's outputs based on the name.
-
-        Parameters
-        ----------
-        name: str
-            The name of the parameter to extract as an output.
-
-        Returns
-        -------
-        Parameter
-            Parameter with the same name
-        """
-        if isinstance(self.template, str):
-            raise ValueError(f"Cannot get output parameters when the template was set via a name: {self.template}")
-
-        # here, we build the template early to verify that we can get the outputs
-        if isinstance(self.template, Templatable):
-            template = self.template._build_template()
-        else:
-            template = self.template
-
-        # at this point, we know that the template is a `Template` object
-        if template.outputs is None:  # type: ignore
-            raise ValueError(f"Cannot get output parameters when the template has no outputs: {template}")
-        if template.outputs.parameters is None:  # type: ignore
-            raise ValueError(f"Cannot get output parameters when the template has no output parameters: {template}")
-        parameters = template.outputs.parameters  # type: ignore
-
-        obj = next((output for output in parameters if output.name == name), None)
-        if obj is not None:
-            return Parameter(
-                name=obj.name,
-                value=f"{{{{steps.{self.name}.outputs.parameters.{name}}}}}",
-            )
-        raise KeyError(f"No output parameter named `{name}` found")
+    def _subtype(self) -> str:
+        return "steps"
 
     def _build_as_workflow_step(self) -> _ModelWorkflowStep:
         _template = None

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -21,7 +21,6 @@ from hera.workflows.models import (
     Template,
 )
 from hera.workflows.operator import Operator
-from hera.workflows.parameter import Parameter
 from hera.workflows.protocol import Templatable
 from hera.workflows.workflow_status import WorkflowStatus
 
@@ -119,73 +118,8 @@ class Task(
         return task_names
 
     @property
-    def id(self) -> str:
-        return f"{{{{tasks.{self.name}.id}}}}"
-
-    @property
-    def ip(self) -> str:
-        return f"{{{{tasks.{self.name}.ip}}}}"
-
-    @property
-    def status(self) -> str:
-        return f"{{{{tasks.{self.name}.status}}}}"
-
-    @property
-    def exit_code(self) -> str:
-        return f"{{{{tasks.{self.name}.exitCode}}}}"
-
-    @property
-    def started_at(self) -> str:
-        return f"{{{{tasks.{self.name}.startedAt}}}}"
-
-    @property
-    def finished_at(self) -> str:
-        return f"{{{{tasks.{self.name}.finishedAt}}}}"
-
-    @property
-    def result(self) -> str:
-        return f"{{{{tasks.{self.name}.outputs.result}}}}"
-
-    def get_parameters_as(self, name: str) -> Parameter:
-        """Gets all the output parameters from this task"""
-        return Parameter(name=name, value=f"{{{{tasks.{self.name}.outputs.parameters}}}}")
-
-    def get_parameter(self, name: str) -> Parameter:
-        """Returns a Parameter from the task's outputs based on the name.
-
-        Parameters
-        ----------
-        name: str
-            The name of the parameter to extract as an output.
-
-        Returns
-        -------
-        Parameter
-            Parameter with the same name
-        """
-        if isinstance(self.template, str):
-            raise ValueError(f"Cannot get output parameters when the template was set via a name: {self.template}")
-
-        # here, we build the template early to verify that we can get the outputs
-        if isinstance(self.template, Templatable):
-            template = self.template._build_template()
-        else:
-            template = self.template
-
-        # at this point, we know that the template is a `Template` object
-        if template.outputs is None:  # type: ignore
-            raise ValueError(f"Cannot get output parameters when the template has no outputs: {template}")
-        if template.outputs.parameters is None:  # type: ignore
-            raise ValueError(f"Cannot get output parameters when the template has no output parameters: {template}")
-        parameters = template.outputs.parameters  # type: ignore
-
-        obj = next((output for output in parameters if output.name == name), None)
-        if obj is not None:
-            return Parameter(
-                name=obj.name,
-                value=f"{{{{tasks.{self.name}.outputs.parameters.{name}}}}}",
-            )
-        raise KeyError(f"No output parameter named `{name}` found")
+    def _subtype(self) -> str:
+        return "tasks"
 
     def next(self, other: Task, operator: Operator = Operator.and_, on: Optional[TaskResult] = None) -> Task:
         """Set self as a dependency of `other`."""

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -31,7 +31,7 @@ class WorkflowTemplate(Workflow):
         if v is not None:
             raise ValueError("status is not a valid field on a WorkflowTemplate")
 
-    def create(self) -> TWorkflow:
+    def create(self) -> TWorkflow:  # type: ignore
         """Creates the WorkflowTemplate on the Argo cluster."""
         assert self.workflows_service, "workflow service not initialized"
         assert self.namespace, "workflow namespace not defined"


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Hera! 🚀 -->

**Pull Request Checklist**
- [x] Fixes #513
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**
<!-- If not linked to an issue, please describe your changes here -->

Currently, users are forced to use the `arguments` keyword to set up the parameters to be set for a Python source executed on Argo. 

This PR adds the possibility to set source callable kwargs as input to the callable, effectively removing the need for using `arguments` for simple function calls. This also accepts parameters/artifacts to be set the same way!

<!-- Piece of cake! ✨🍰✨ -->