### PR TITLE
Get any Artifacts/Parameters contained in function kwargs

### DIFF
--- a/docs/examples/workflows/script_artifact_passing.md
+++ b/docs/examples/workflows/script_artifact_passing.md
@@ -44,7 +44,12 @@
         steps:
         - - name: generate-artifact
             template: whalesay
-        - - name: consume-artifact
+        - - arguments:
+              artifacts:
+              - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
+                name: message
+                path: /tmp/hello_world.txt
+            name: consume-artifact
             template: print-message
       - name: whalesay
         outputs:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -39,7 +39,7 @@ with Workflow(
     workflows_service=WorkflowsService(host="https://localhost:2746")
 ) as w:
     with Steps(name="steps"):
-        echo(arguments={"message": "Hello world!"})
+        echo(message="Hello world!")
 
 w.create()
 ```
@@ -78,7 +78,7 @@ with Workflow(
     namespace="argo",
 ) as w:
     with Steps(name="steps"):
-        echo(arguments={"message": "Hello world!"})
+        echo(message="Hello world!")
 
 w.create()
 ```

--- a/docs/getting-started/walk-through/hello-world.md
+++ b/docs/getting-started/walk-through/hello-world.md
@@ -18,7 +18,7 @@ with Workflow(
     workflows_service=WorkflowsService(host="https://localhost:2746")
 ) as w:
     with Steps(name="steps"):
-        echo(arguments={"message": "Hello world!"})
+        echo(message="Hello world!")
 
 w.create()
 ```
@@ -95,19 +95,17 @@ automatically arranges your templates in the order that you add them, with each 
 with Steps(name="steps"):
 ```
 
-To invoke the `echo` template, you can call it, passing values to its arguments through the `arguments` kwarg, which is
-a dictionary of the _function_ kwargs to values. This is because under a `Steps` or `DAG` context manager, the `script`
-decorator converts a call of the function into a `Script` object, to which you must pass `Script` initialization kwargs.
+To invoke the `echo` template, you can call it exactly like a normal function, however you must always pass values to
+its arguments via keyword arguments
 
 ```py
-echo(arguments={"message": "Hello world!"})
+echo(message="Hello world!")
 ```
 
-> For advanced users: the exact mechanism of the `script` decorator is to create a `Script` object when declared, so
-> that when your function is invoked you have to pass its arguments through the `arguments` kwarg as a dictionary, and
-> the `Script` objects `__call__` function is invoked with the `arguments` kwarg. The `__call__` function on a
-> `CallableTemplateMixin` automatically creates a `Step` or a `Task` depending on whether the context manager is a
-> `Steps` or a `DAG`.
+> For advanced users: kwargs must be used because under a `Steps` or `DAG` context manager, the `script` decorator
+> converts a call of the function into a `Script` object, so you can also pass `Script` initialization kwargs - if any
+> of these clash with your function kwargs you will get a warning log when running your code. See
+> [Passing Function kwargs](parameters.md#passing-function-kwargs) for more details.
 
 ## Submitting the Workflow
 

--- a/docs/getting-started/walk-through/parameters.md
+++ b/docs/getting-started/walk-through/parameters.md
@@ -50,8 +50,8 @@ Note that when reusing a function in multiple steps, you must give unique names 
 
 ```py
 with Steps(name="steps"):
-        add_values(name="first", arguments={"a": 1, "b": 2})
-        add_values(name="second", arguments={"a": "1", "b": "2"})  # "1" and "2" will be treated as ints
+        add_values(name="first", a=1, b=2)
+        add_values(name="second", a="1", "b"="2")  # "1" and "2" will be treated as ints
 ```
 
 <details>
@@ -81,9 +81,9 @@ def echo_a_dict(my_dict: Dict[str, str]):
         print(f"{k}={v}")
 ```
 
-Then in the snippet below, during the compilation of the workflow, `arguments` will serialize the `dict` value of
-`my_dict` via `json.dumps`. Then during the script execution on Argo, `json.loads` will load the `dict` and the function
-will run as expected.
+Then in the snippet below, during the compilation of the workflow, `my_dict` will be serialized via `json.dumps`. Then
+during the script execution on Argo, `json.loads` will load the serialized `dict`, passing it to `my_dict` and the
+function will run as expected.
 
 ```py
 with Workflow(
@@ -92,11 +92,9 @@ with Workflow(
 ) as w:
     with Steps(name="steps"):
         echo_a_dict(
-            arguments={
-                "my_dict": {
-                    "my_key": "my_value",
-                    "my_second_key": "my_second_value",
-                }
+            my_dict={
+                "my_key": "my_value",
+                "my_second_key": "my_second_value",
             }
         )
 
@@ -115,7 +113,7 @@ my_second_key=my_second_value
 Currently, custom types are only supported in the "script runner" experimental feature. See an example usage
 [here](../../examples/workflows/callable_script.md). Please note this is an experimental feature so support is limited for now.
 
-## Passing Parameters
+## Passing Parameters Between Steps and Tasks
 
 ### The `result` Output Parameter
 
@@ -137,7 +135,7 @@ def repeat_back(message: str):
 
 Let's say we want to get the stdout from running the `hello` Script template. We have to assign the `Step` object
 returned from the function call to a variable, then we can access its `result` member, passing it to the `repeat_back`
-template.
+template's `message` kwarg.
 
 ```py
 with Workflow(
@@ -145,8 +143,8 @@ with Workflow(
     entrypoint="steps",
 ) as w:
     with Steps(name="steps"):
-        hello_step = hello(arguments={"message": "world!"})
-        repeat_back(arguments={"message": hello_step.result})
+        hello_step = hello(message="world!")
+        repeat_back(message=hello_step.result)
 
 w.create()
 ```
@@ -197,7 +195,7 @@ The output parameter will also show up in the UI under the node's INPUTS/OUTPUTS
 
 Now that we have a `hello_to_file` function, let's use its output in our `repeat_back` function. Under a `Steps`
 context, we can assign the `Step` object returned from the `hello_to_file` function, and use its `get_parameter`
-function, and get the `Parameter`'s `value`.
+function and again we can pass it directly to `repeat_back`'s `message` kwarg.
 
 ```py
 with Workflow(
@@ -206,28 +204,10 @@ with Workflow(
 ) as w:
     with Steps(name="steps"):
         hello_world_step = hello_to_file()
-        repeat_back(
-            arguments={"message": hello_world_step.get_parameter("hello-output").value}
-        )
+        repeat_back(message=hello_world_step.get_parameter("hello-output"))
 ```
 
-If you prefer, `arguments` can accept a single `Parameter`, and we can use the `with_name` function for convenience to
-specify the right name for `repeat_back`:
-
-```py
-with Workflow(
-    generate_name="hello-world-parameter-passing-",
-    entrypoint="steps",
-) as w:
-    with Steps(name="steps"):
-        hello_world_step = hello_to_file()
-        repeat_back(
-            arguments=hello_world_step.get_parameter("hello-output").with_name("message")
-        )
-```
-
-
-Both of these Workflows will produce logs like
+This Workflow will produce logs like
 
 ```console
 hello-world-parameter-passing-vq7pm-hello-to-file-3540104653: time="2023-05-26T12:12:13.803Z" level=info msg="sub-process exited" argo=true error="<nil>"
@@ -235,3 +215,34 @@ hello-world-parameter-passing-vq7pm-hello-to-file-3540104653: time="2023-05-26T1
 hello-world-parameter-passing-vq7pm-repeat-back-3418430710: You just said: 'Hello World!'
 hello-world-parameter-passing-vq7pm-repeat-back-3418430710: time="2023-05-26T12:12:24.106Z" level=info msg="sub-process exited" argo=true error="<nil>"
 ```
+
+## Passing Function `kwargs`
+
+You'll have seen that Hera allows you to call your function as normal with the caveat of having to use `kwargs`. This is
+because you can also pass `kwargs` that go to the created `Script` object, for example, the `when` Script kwarg to
+conditionally run certain steps. When you want to pass parameters into your Steps or Tasks, Hera will convert any
+function kwargs into Parameters or Artifacts.
+
+Example 1 (basic data types): a basic data type `kwarg` to a function call under a `Steps` or `DAG` context like
+`echo(message="hello")` will create a Parameter with name "message" and value "hello" passed into the `echo` function.
+
+Example 2 (`Parameters`): when passing output parameters through a `kwarg` to a function like
+`message=prev_step.get_parameter("parameter-name")`, Hera will create a parameter called "message" with a value of
+`{{steps.prev-step.outputs.parameters.parameter-name}}` for the given `Script` object.
+
+Example 3 (`Artifacts`): when passing output artifacts through a `kwarg` to a function like
+`message=prev_step.get_artifact("artifact-name")`, Hera will create an artifact called "message" with a "from" value of
+`{{steps.prev-step.outputs.artifacts.artifact-name}}`.
+
+### A Note on `kwarg` Name Clashing
+
+Where a function has been decorated with `@script`, Hera inspects the kwargs during function calls, and if any assigned
+kwarg values (that are not Script kwargs) are a `Parameter` or `Artifact`, they are used to create an input argument
+that takes the name of the `kwarg` and the dynamic value of the Parameter/Artifact (i.e. the value during the workflow,
+which looks like `{{steps.prev-step.outputs.parameters.parameter-name}}` in YAML, see examples above).
+
+If the function takes a kwarg that name-clashes with any Step or Task field (except `arguments` or `with_param`) then
+you will get an error. If you are unable to rename them, then their values *must* be passed in via the `arguments` or
+`with_param` Script kwarg. If your function has a kwarg named `arguments` or `with_param`, Hera *will not error* and
+will instead silently treat them as Script kwargs. Be aware that you will only get a warning log coming from the site of
+the decoration of the function.

--- a/examples/workflows/script-artifact-passing.yaml
+++ b/examples/workflows/script-artifact-passing.yaml
@@ -9,7 +9,12 @@ spec:
     steps:
     - - name: generate-artifact
         template: whalesay
-    - - name: consume-artifact
+    - - arguments:
+          artifacts:
+          - from: '{{steps.generate-artifact.outputs.artifacts.hello-art}}'
+            name: message
+            path: /tmp/hello_world.txt
+        name: consume-artifact
         template: print-message
   - name: whalesay
     outputs:

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -77,7 +77,6 @@ OutputsT = Optional[
         List[Union[Parameter, ModelParameter, Artifact, ModelArtifact]],
     ]
 ]
-ArgumentT = Union[Parameter, ModelParameter, Artifact, ModelArtifact]
 ArgumentsT = Optional[
     Union[
         ModelArguments,
@@ -474,14 +473,14 @@ class CallableTemplateMixin(ArgumentsMixin):
         if "name" not in kwargs:
             kwargs["name"] = self.name  # type: ignore
 
+        arguments = self._get_arguments(**kwargs)
+        parameter_names = self._get_parameter_names(arguments)
+        artifact_names = self._get_artifact_names(arguments)
+
         # when the `source` is set via an `@script` decorator, it does not come in with the `kwargs` so we need to
         # set it here in order for the following logic to capture it
         if "source" not in kwargs and hasattr(self, "source"):
             kwargs["source"] = self.source  # type: ignore
-
-        arguments = self._get_arguments(**kwargs)
-        parameter_names = self._get_parameter_names(arguments)
-        artifact_names = self._get_artifact_names(arguments)
         if "source" in kwargs and "with_param" in kwargs:
             arguments += self._get_deduped_params_from_source(parameter_names, artifact_names, kwargs["source"])
         elif "source" in kwargs and "with_items" in kwargs:
@@ -491,8 +490,8 @@ class CallableTemplateMixin(ArgumentsMixin):
             arguments += _get_source_params_from_kwargs(parameter_names, artifact_names, kwargs["source"], kwargs)
 
         # it is possible for the user to pass `arguments` via `kwargs` along with `with_param`. The `with_param`
-        # additional parameters are inferred and have to be added to the `kwargs['arguments']` for otherwise
-        # the task will miss adding them when building the final arguments
+        # additional parameters are inferred and have to be added to the `kwargs['arguments']` otherwise
+        # the step/task will miss adding them when building the final arguments
         kwargs["arguments"] = arguments
 
         try:
@@ -507,14 +506,51 @@ class CallableTemplateMixin(ArgumentsMixin):
 
         raise InvalidTemplateCall("Container is not under a Steps, Parallel, or DAG context")
 
+    def _extract_function_argo_arguments(self, **kwargs) -> List:
+        """Returns a list of Parameters and Artifacts extracted from kwargs that belong to the function.
+
+        We inspect the kwargs in a function call, and where assigned values are a Parameter
+        or Artifact, we append them to the arguments list with names replaced. If the
+        function takes a kwarg that name-clashes with any Step or Task field (except "arguments",
+        which are dealt with above), then we raise an error, as `arguments` should be used as a
+        workaround if the function kwarg cannot be renamed.
+
+        Example 1 (artifacts): a kwarg to a function like
+        `message=prev_step.get_artifact("artifact-name")` should
+        pass through a new artifact called "message" with a "from" value of
+        "{{steps.prev-step.outputs.artifacts.artifact-name}}".
+
+        Example 2 (parameters): a kwarg to a function like
+        `message=prev_step.get_parameter("parameter-name")` should
+        pass through a new parameter called "message" with a value of
+        "{{steps.prev-step.outputs.parameters.artifact-name}}".
+
+        Example 3 (basic data types): a kwarg to a function like
+        `message="hello"` should pass through a Parameter with
+        name "message" and value "hello"
+        """
+        from hera.workflows.script import ARGUMENT_TYPE_KWARGS, CLASHING_KWARGS
+
+        arguments = []
+        for arg_name, arg_value in kwargs.items():
+            if isinstance(arg_value, (Parameter, ModelParameter, Artifact, ModelArtifact)):
+                if arg_name not in CLASHING_KWARGS:
+                    # replace names for each argo argument so that this  step/task receives them with correct names
+                    arg_value.name = arg_name
+                    arguments.append(arg_value)
+                elif arg_name not in ARGUMENT_TYPE_KWARGS:
+                    raise ValueError(
+                        f"'{arg_name}' clashes with Step/Task kwargs. Rename '{arg_name}' or "
+                        "pass your Parameter/Artifact through 'arguments' or 'with_param'"
+                    )
+            elif arg_name not in CLASHING_KWARGS:
+                # Append arguments with implied basic data types
+                arguments.append(Parameter(name=arg_name, value=arg_value))
+
+        return arguments
+
     def _get_arguments(self, **kwargs) -> List:
         """Returns a list of arguments from the kwargs given to the template call"""
-        from hera.workflows.steps import Step
-        from hera.workflows.task import Task
-
-        # We must import Step and Task and construct this list in the function as top-level imports of
-        # Step and Task produce a circular import
-        CLASHING_KWARGS = list(Step.__fields__.keys()) + list(Task.__fields__.keys())
 
         # these are the already set parameters. If a user has already set a parameter argument, then Hera
         # uses the user-provided value rather than the inferred value
@@ -526,25 +562,7 @@ class CallableTemplateMixin(ArgumentsMixin):
             self.arguments if isinstance(self.arguments, List) else [self.arguments] + kwargs_arguments
         )  # type: ignore
 
-        # We inspect the kwargs in a function call, and where assigned values are a Parameter
-        # or Artifact, we append them to the arguments list with names replaced. If the
-        # function takes a kwarg that name-clashes with any Step or Task field (except "arguments",
-        # which are dealt with above), then we raise an error, as `arguments` should be used as a
-        # workaround if the function kwarg cannot be renamed.
-        #
-        # e.g. a kwarg `message=prev_step.get_artifact("artifact-name")`` should
-        # pass through a new artifact called "message" with a "from" value of
-        # "{{steps.prev-step.outputs.artifacts.artifact-name}}".
-        for name, argo_argument in kwargs.items():
-            if isinstance(argo_argument, ArgumentT):
-                if name not in CLASHING_KWARGS:
-                    # replace names for each argo argument so that this step receives them with correct names
-                    argo_argument.name = name
-                    arguments.append(argo_argument)
-                elif name in CLASHING_KWARGS and name != "arguments":
-                    raise ValueError(
-                        f"{name} clashes with Step/Task kwargs. Rename {name} or pass your Parameter/Artifact through 'arguments'"
-                    )
+        arguments += self._extract_function_argo_arguments(**kwargs)
 
         return list(filter(lambda x: x is not None, arguments))
 

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -515,19 +515,19 @@ class CallableTemplateMixin(ArgumentsMixin):
         which are dealt with above), then we raise an error, as `arguments` should be used as a
         workaround if the function kwarg cannot be renamed.
 
-        Example 1 (artifacts): a kwarg to a function like
-        `message=prev_step.get_artifact("artifact-name")` should
-        pass through a new artifact called "message" with a "from" value of
-        "{{steps.prev-step.outputs.artifacts.artifact-name}}".
+        Example 1 (basic data types): a kwarg to a function like
+        `message="hello"` will pass through a Parameter with
+        name "message" and value "hello"
 
         Example 2 (parameters): a kwarg to a function like
-        `message=prev_step.get_parameter("parameter-name")` should
+        `message=prev_step.get_parameter("parameter-name")` will
         pass through a new parameter called "message" with a value of
-        "{{steps.prev-step.outputs.parameters.artifact-name}}".
+        "{{steps.prev-step.outputs.parameters.parameter-name}}".
 
-        Example 3 (basic data types): a kwarg to a function like
-        `message="hello"` should pass through a Parameter with
-        name "message" and value "hello"
+        Example 3 (artifacts): a kwarg to a function like
+        `message=prev_step.get_artifact("artifact-name")` will
+        pass through a new artifact called "message" with a "from" value of
+        "{{steps.prev-step.outputs.artifacts.artifact-name}}".
         """
         from hera.workflows.script import ARGUMENT_TYPE_KWARGS, CLASHING_KWARGS
 

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -535,9 +535,10 @@ class CallableTemplateMixin(ArgumentsMixin):
         for arg_name, arg_value in kwargs.items():
             if isinstance(arg_value, (Parameter, ModelParameter, Artifact, ModelArtifact)):
                 if arg_name not in CLASHING_KWARGS:
-                    # replace names for each argo argument so that this  step/task receives them with correct names
-                    arg_value.name = arg_name
-                    arguments.append(arg_value)
+                    # replace names for each argo argument so that this step/task receives them with correct names
+                    arg_copy = arg_value.copy(deep=True)
+                    arg_copy.name = arg_name
+                    arguments.append(arg_copy)
                 elif arg_name not in ARGUMENT_TYPE_KWARGS:
                     raise ValueError(
                         f"'{arg_name}' clashes with Step/Task kwargs. Rename '{arg_name}' or "

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -49,7 +49,13 @@ from hera.workflows.parameter import MISSING, Parameter
 from hera.workflows.steps import Step
 from hera.workflows.task import Task
 
-CLASHING_KWARGS = list(Step.__fields__.keys()) + list(Task.__fields__.keys())
+CLASHING_KWARGS = set(Step.__fields__.keys()).union(set(Task.__fields__.keys()))
+
+# We specify these two kwargs as they can accept input with type [Model]Parameter
+# and [Model]Artifact. When checking for function kwargs of these types, if the kwarg
+# has the name "arguments" or "with_param", it is always interpreted as a field of Script,
+# *not* of the function. The user will get a warning log from the function defintion (not
+# during the call) as this is implicit behaviour that we cannot guard against at runtime.
 ARGUMENT_TYPE_KWARGS = ("arguments", "with_param")
 
 

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -1,0 +1,112 @@
+from typing import Any
+
+import pytest
+
+from hera.workflows import Parameter, Step, Steps, Workflow, script
+
+
+@script()
+def print_message(continue_on: str = "name-clash-arg"):
+    print(continue_on)
+
+
+def test_script_arg_building_name_clash():
+    # WHEN - we have a name clash with a non-arguments-taking parameter
+    with pytest.raises(ValueError) as e:
+        with Workflow(generate_name="name-clash-", entrypoint="name-clash-example"):
+            with Steps(name="name-clash-example"):
+                print_message(name="print-message", continue_on=Parameter(name="dummy-name", value="dummy-value"))
+
+    # THEN - we raise the ValueError containing the message
+    assert (
+        "'continue_on' clashes with Step/Task kwargs. Rename 'continue_on' or pass your Parameter/Artifact through 'arguments' or 'with_param'"
+        in str(e)
+    )
+
+
+def test_script_arg_building_using_with_param():
+    # WHEN - we use with_param to pass in a value for the "continue_on" name clashing arg
+    with Workflow(generate_name="name-clash-", entrypoint="name-clash-example"):
+        with Steps(name="name-clash-example"):
+            # Test passes a Parameter to with_param rather than a Dict
+            print_message_step: Step = print_message(
+                name="print-message", with_param=Parameter(name="dummy-name", value="test-value")
+            )
+
+            # THEN - with_param is populated with the test-value, and continue_on uses {{item}}
+            assert print_message_step._build_with_param() == "test-value"
+            assert (
+                print_message_step.arguments
+                and print_message_step.arguments[0].name == "continue_on"
+                and print_message_step.arguments[0].value == "{{item}}"
+            )
+
+
+def test_script_arg_building_using_arguments():
+    # WHEN - we use arguments to pass in a value for the "continue_on" name clashing arg
+    with Workflow(generate_name="name-clash-", entrypoint="name-clash-example"):
+        with Steps(name="name-clash-example"):
+            print_message_step: Step = print_message(
+                name="print-message", arguments=Parameter(name="continue_on", value="test-value")
+            )
+
+            # THEN - "continue_on" has the value "test-value"
+            assert (
+                print_message_step.arguments
+                and print_message_step.arguments[0].name == "continue_on"
+                and print_message_step.arguments[0].value == "test-value"
+            )
+
+
+@script()
+def print_message_with_param(with_param: Any = {"key": "name-clash-arg"}):
+    print(with_param)
+
+
+@pytest.mark.parametrize(
+    "with_param_value,expected_built_value",
+    [
+        (Parameter(name="dummy-name", value='{"serialized": "dict"}'), '{"serialized": "dict"}'),
+        ({"unserialized": "dict"}, '{"unserialized": "dict"}'),
+    ],
+)
+def test_script_arg_building_with_param_name_clash_parameter(with_param_value, expected_built_value):
+    # WHEN - we have a name clash with "with_param"
+    with Workflow(generate_name="with-param-name-clash-", entrypoint="name-clash-example"):
+        with Steps(name="name-clash-example"):
+            print_message_step: Step = print_message_with_param(name="print-message", with_param=with_param_value)
+
+            # THEN - the "with_param" behaviour takes precedence no matter the type of with_param
+            assert print_message_step._build_with_param() == expected_built_value
+            assert (
+                print_message_step.arguments
+                and print_message_step.arguments[0].name == "with_param"
+                and print_message_step.arguments[0].value == "{{item}}"
+            )
+
+
+@script()
+def print_message_arguments(arguments: Any = {"key": "name-clash-arg"}):
+    print(arguments)
+
+
+@pytest.mark.parametrize(
+    "arguments_value,expected_name,expected_value",
+    [
+        (Parameter(name="dummy-name", value='{"serialized": "dict"}'), "dummy-name", '{"serialized": "dict"}'),
+        ({"unserialized": "dict"}, "unserialized", "dict"),
+    ],
+)
+def test_script_arg_building_arguments_name_clash_parameter(arguments_value, expected_name, expected_value):
+    # WHEN - we have a name clash with "arguments"
+    with Workflow(generate_name="arguments-name-clash-", entrypoint="name-clash-example"):
+        with Steps(name="name-clash-example"):
+            print_message_step: Step = print_message_with_param(name="print-message", arguments=arguments_value)
+
+            # THEN - the "arguments" behaviour follows usual rules for Parameters and dicts
+            built_args = print_message_step._build_arguments()
+            assert (
+                built_args.parameters
+                and built_args.parameters[0].name == expected_name
+                and built_args.parameters[0].value == expected_value
+            )


### PR DESCRIPTION
Adds kwarg scanning for Artifacts/Parameters that aren't the standard
`arguments` or `with_param` when calling a function decorated with `@script`