### PR TITLE
Common arg inference code for steps/tasks

### DIFF
--- a/docs/examples/workflows/script_loops_maps.md
+++ b/docs/examples/workflows/script_loops_maps.md
@@ -1,0 +1,90 @@
+# Script Loops Maps
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Container, Parameter, Steps, Workflow
+    from hera.workflows import DAG, Workflow, script
+
+    @script()
+    def test_key_mapping(key_1: str, key_2: str):  # pragma: no cover
+        print(f"{key_1}:{key_2}")
+
+    with Workflow(
+        generate_name="loops-maps-",
+        entrypoint="loop-map-example",
+    ) as w:
+        with Steps(name="loop-map-example") as loop_map_example:
+            test_key_mapping(
+                with_items=[
+                    {"key_1": "value:1-1", "key_2": "value:2-1"},
+                    {"key_1": "value:1-2", "key_2": "value:2-2"},
+                    {"key_1": "value:1-3", "key_2": "value:2-3"},
+                    {"key_1": "value:1-4", "key_2": "value:2-4"},
+                ],
+            )
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: loops-maps-
+    spec:
+      entrypoint: loop-map-example
+      templates:
+      - name: loop-map-example
+        steps:
+        - - arguments:
+              parameters:
+              - name: key_1
+                value: '{{item.key_1}}'
+              - name: key_2
+                value: '{{item.key_2}}'
+            name: test-key-mapping
+            template: test-key-mapping
+            withItems:
+            - key_1: value:1-1
+              key_2: value:2-1
+            - key_1: value:1-2
+              key_2: value:2-2
+            - key_1: value:1-3
+              key_2: value:2-3
+            - key_1: value:1-4
+              key_2: value:2-4
+      - inputs:
+          parameters:
+          - name: key_1
+          - name: key_2
+        name: test-key-mapping
+        script:
+          command:
+          - python
+          image: python:3.8
+          source: 'import os
+
+            import sys
+
+            sys.path.append(os.getcwd())
+
+            import json
+
+            try: key_1 = json.loads(r''''''{{inputs.parameters.key_1}}'''''')
+
+            except: key_1 = r''''''{{inputs.parameters.key_1}}''''''
+
+            try: key_2 = json.loads(r''''''{{inputs.parameters.key_2}}'''''')
+
+            except: key_2 = r''''''{{inputs.parameters.key_2}}''''''
+
+
+            print(f''{key_1}:{key_2}'')'
+    ```
+

--- a/docs/examples/workflows/script_loops_maps.md
+++ b/docs/examples/workflows/script_loops_maps.md
@@ -8,12 +8,13 @@
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows import Container, Parameter, Steps, Workflow
-    from hera.workflows import DAG, Workflow, script
+    from hera.workflows import Steps, Workflow, script
+
 
     @script()
     def test_key_mapping(key_1: str, key_2: str):  # pragma: no cover
-        print(f"{key_1}:{key_2}")
+        print("{key_1}, {key_2}".format(key_1=key_1, key_2=key_2))
+
 
     with Workflow(
         generate_name="loops-maps-",
@@ -85,6 +86,6 @@
             except: key_2 = r''''''{{inputs.parameters.key_2}}''''''
 
 
-            print(f''{key_1}:{key_2}'')'
+            print(''{key_1}, {key_2}''.format(key_1=key_1, key_2=key_2))'
     ```
 

--- a/examples/workflows/script-loops-maps.yaml
+++ b/examples/workflows/script-loops-maps.yaml
@@ -50,4 +50,4 @@ spec:
         except: key_2 = r''''''{{inputs.parameters.key_2}}''''''
 
 
-        print(f''{key_1}:{key_2}'')'
+        print(''{key_1}, {key_2}''.format(key_1=key_1, key_2=key_2))'

--- a/examples/workflows/script-loops-maps.yaml
+++ b/examples/workflows/script-loops-maps.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: loops-maps-
+spec:
+  entrypoint: loop-map-example
+  templates:
+  - name: loop-map-example
+    steps:
+    - - arguments:
+          parameters:
+          - name: key_1
+            value: '{{item.key_1}}'
+          - name: key_2
+            value: '{{item.key_2}}'
+        name: test-key-mapping
+        template: test-key-mapping
+        withItems:
+        - key_1: value:1-1
+          key_2: value:2-1
+        - key_1: value:1-2
+          key_2: value:2-2
+        - key_1: value:1-3
+          key_2: value:2-3
+        - key_1: value:1-4
+          key_2: value:2-4
+  - inputs:
+      parameters:
+      - name: key_1
+      - name: key_2
+    name: test-key-mapping
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: 'import os
+
+        import sys
+
+        sys.path.append(os.getcwd())
+
+        import json
+
+        try: key_1 = json.loads(r''''''{{inputs.parameters.key_1}}'''''')
+
+        except: key_1 = r''''''{{inputs.parameters.key_1}}''''''
+
+        try: key_2 = json.loads(r''''''{{inputs.parameters.key_2}}'''''')
+
+        except: key_2 = r''''''{{inputs.parameters.key_2}}''''''
+
+
+        print(f''{key_1}:{key_2}'')'

--- a/examples/workflows/script_loops_maps.py
+++ b/examples/workflows/script_loops_maps.py
@@ -1,0 +1,21 @@
+from hera.workflows import Steps, Workflow, script
+
+
+@script()
+def test_key_mapping(key_1: str, key_2: str):  # pragma: no cover
+    print(f"{key_1}:{key_2}")
+
+
+with Workflow(
+    generate_name="loops-maps-",
+    entrypoint="loop-map-example",
+) as w:
+    with Steps(name="loop-map-example") as loop_map_example:
+        test_key_mapping(
+            with_items=[
+                {"key_1": "value:1-1", "key_2": "value:2-1"},
+                {"key_1": "value:1-2", "key_2": "value:2-2"},
+                {"key_1": "value:1-3", "key_2": "value:2-3"},
+                {"key_1": "value:1-4", "key_2": "value:2-4"},
+            ],
+        )

--- a/examples/workflows/script_loops_maps.py
+++ b/examples/workflows/script_loops_maps.py
@@ -3,7 +3,7 @@ from hera.workflows import Steps, Workflow, script
 
 @script()
 def test_key_mapping(key_1: str, key_2: str):  # pragma: no cover
-    print(f"{key_1}:{key_2}")
+    print("{key_1}, {key_2}".format(key_1=key_1, key_2=key_2))
 
 
 with Workflow(


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Hera! 🚀 -->

**Pull Request Checklist**
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->

**Description of PR**
_Copied from [comment](https://github.com/argoproj-labs/hera/pull/660#issuecomment-1570430679)_
>>I think things like "{{item.name}}" are set automatically for Task arguments. Should we expose that to Step as well?

>@elliotgunton can confirm these are set automatically for tasks based on arguments inference. So, Task invocation does not need the arguments field when with_param is passed, or with_item, but Step does for now. We should add the same logic to Step as well: https://github.com/argoproj-labs/hera/blob/main/src/hera/workflows/_mixins.py#L469 Motivation here is to not confuse users with these differences of "sometimes I can set a thing on Task but not on Step"