### PR TITLE
Generate yamls only in python 3.8, roundtrip parse before comparing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ OPENAPI_SPEC_URL="https://raw.githubusercontent.com/argoproj/argo-workflows/v3.4
 help: ## Showcase the help instructions for all the available `make` commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: install
+install: ## Run poetry install with default behaviour
+	@poetry env use system
+	@poetry install
+
+.PHONY: install-3.8
+install-3.8: ## Install python3.8 for generating test data
+	@poetry env use 3.8
+	@poetry install
+
 .PHONY: ci
 ci: ## Run all the CI checks
 ci: CI=1
@@ -93,6 +103,7 @@ examples:  ## Generate all the examples
 
 .PHONY: regenerate-test-data
 regenerate-test-data:  ## Regenerates the test data from upstream examples and runs tests, report missing examples
+regenerate-test-data: install-3.8
 	find examples -name "*.yaml" -type f -delete
 	HERA_REGENERATE=1 make test examples
 	@poetry run python -m pytest -k test_for_missing_examples --runxfail

--- a/docs/examples/workflows/global_config.md
+++ b/docs/examples/workflows/global_config.md
@@ -25,7 +25,7 @@
 
 
     with Workflow(generate_name="global-config-", entrypoint="whalesay") as w:
-        whalesay = Container(image="docker/whalesay:latest")
+        whalesay = Container(name="whalesay", image="docker/whalesay:latest")
         say()
     ```
 
@@ -46,6 +46,7 @@
           command:
           - cowsay
           image: docker/whalesay:latest
+        name: whalesay
       - name: say
         script:
           command:

--- a/docs/examples/workflows/map_reduce.md
+++ b/docs/examples/workflows/map_reduce.md
@@ -139,8 +139,8 @@ See the upstream example [here](https://github.com/argoproj/argo-workflows/blob/
             try: num_parts = json.loads(r'''{{inputs.parameters.num_parts}}''')\nexcept:\
             \ num_parts = r'''{{inputs.parameters.num_parts}}'''\n\nimport json\nimport\
             \ os\nimport sys\nos.mkdir('/mnt/out')\npart_ids = list(map_(lambda x: str(x),\
-            \ range(num_parts)))\nfor i, part_id in enumerate(part_ids, start=1):\n  \
-            \  with open('/mnt/out/' + part_id + '.json', 'w') as f:\n        json.dump({'foo':\
+            \ range(num_parts)))\nfor (i, part_id) in enumerate(part_ids, start=1):\n\
+            \    with open('/mnt/out/' + part_id + '.json', 'w') as f:\n        json.dump({'foo':\
             \ i}, f)\njson.dump(part_ids, sys.stdout)"
       - inputs:
           artifacts:

--- a/examples/workflows/global-config.yaml
+++ b/examples/workflows/global-config.yaml
@@ -12,6 +12,7 @@ spec:
       command:
       - cowsay
       image: docker/whalesay:latest
+    name: whalesay
   - name: say
     script:
       command:

--- a/examples/workflows/global_config.py
+++ b/examples/workflows/global_config.py
@@ -15,5 +15,5 @@ def say():
 
 
 with Workflow(generate_name="global-config-", entrypoint="whalesay") as w:
-    whalesay = Container(image="docker/whalesay:latest")
+    whalesay = Container(name="whalesay", image="docker/whalesay:latest")
     say()

--- a/examples/workflows/map-reduce.yaml
+++ b/examples/workflows/map-reduce.yaml
@@ -50,8 +50,8 @@ spec:
         try: num_parts = json.loads(r'''{{inputs.parameters.num_parts}}''')\nexcept:\
         \ num_parts = r'''{{inputs.parameters.num_parts}}'''\n\nimport json\nimport\
         \ os\nimport sys\nos.mkdir('/mnt/out')\npart_ids = list(map_(lambda x: str(x),\
-        \ range(num_parts)))\nfor i, part_id in enumerate(part_ids, start=1):\n  \
-        \  with open('/mnt/out/' + part_id + '.json', 'w') as f:\n        json.dump({'foo':\
+        \ range(num_parts)))\nfor (i, part_id) in enumerate(part_ids, start=1):\n\
+        \    with open('/mnt/out/' + part_id + '.json', 'w') as f:\n        json.dump({'foo':\
         \ i}, f)\njson.dump(part_ids, sys.stdout)"
   - inputs:
       artifacts:

--- a/src/hera/workflows/_unparse.py
+++ b/src/hera/workflows/_unparse.py
@@ -228,7 +228,6 @@ class _Unparser(ast.NodeVisitor):
     def visit_Assign(self, node):
         self.fill()
         for target in node.targets:
-            self.set_precedence(_Precedence.TUPLE, target)
             self.traverse(target)
             self.write(" = ")
         self.traverse(node.value)
@@ -400,7 +399,6 @@ class _Unparser(ast.NodeVisitor):
 
     def _for_helper(self, fill, node):
         self.fill(fill)
-        self.set_precedence(_Precedence.TUPLE, node.target)
         self.traverse(node.target)
         self.write(" in ")
         self.traverse(node.iter)
@@ -676,7 +674,7 @@ class _Unparser(ast.NodeVisitor):
             self.interleave(lambda: self.write(", "), write_item, zip(node.keys, node.values))
 
     def visit_Tuple(self, node):
-        with self.require_parens(_Precedence.TUPLE, node):
+        with self.delimit("(", ")"):
             self.items_view(self.traverse, node.elts)
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}
@@ -946,10 +944,6 @@ def unparse(ast_obj):
 
 def roundtrip(source):
     tree = ast.parse(source)
-    # python 3.11 ast.unparse stopped using brackets around tuples used in assignment,
-    # see https://github.com/python/cpython/commit/51cef8be8c77dff522bec6f95d6853031bf19038
-    # Previous versions will unparse with brackets
-    if sys.version_info[1] >= 11 and hasattr(ast, "unparse"):
+    if hasattr(ast, "unparse"):
         return ast.unparse(tree)
-    # The _for_helper copied in this file has the patch above applied for tuples, so does not use brackets
     return unparse(tree)

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -16,7 +16,7 @@ def test_for_missing_examples():
         file["path"] for file in repo_json["tree"] if "examples/" in file["path"] and ".yaml" in file["path"]
     ]
 
-    argo_examples = map(lambda file: file.removeprefix("examples/").removesuffix(".yaml"), argo_examples)
+    argo_examples = map(lambda file: file[len("examples/") :][: len(".yaml")], argo_examples)
 
     hera_examples = [name for _, name, _ in pkgutil.iter_modules(hera_upstream_examples.__path__)]
     hera_examples = list(map(lambda file: file.replace("__", "/").replace("_", "-"), hera_examples))


### PR DESCRIPTION
* adds install make targets for default system python and 3.8
* regenerate-test-data now depends on install-3.8

**Pull Request Checklist**
- [x] Fixes CI checks for https://github.com/argoproj-labs/hera/pull/606
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title