### PR TITLE
Add pypi-prod env for publish workflow

### DIFF
--- a/.github/workflows/minimal-labels.yml
+++ b/.github/workflows/minimal-labels.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: mheap/github-action-required-labels@v2
         with:
           count: 1
-          labels: semver:major, semver:minor, semver:patch
+          labels: semver:major, semver:minor, semver:patch, type:skip-changelog
           mode: exactly
   type:
     name: Minimal Type Labels

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 ---
 name: PyPI publish
 # Publish once a maintainer clicks publish on a draft release
+# and approves the GitHub actions job
 on:
   release:
     types: [released]
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: pypi-prod
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Release drafter automatically creates draft releases that are visible to maintai
 
 ## Versioning
 
-Each pull-request must be labeled with one of the following labels -
+Each pull-request must be labeled with one of the following labels (unless type:skip-changelog is used) -
 
 - semver:major
 - semver:minor


### PR DESCRIPTION
Added `pypi-prod` environment in https://github.com/argoproj-labs/hera/settings/environments