### PR TITLE
Add Quick Start link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Hera
 
+[See the Quick Start guide](https://hera.readthedocs.io/en/latest/getting-started/quick-start/) to start using Hera
+to orchestrate your Argo Workflows!
+
 ```text
 The Argo was constructed by the shipwright Argus,
 and its crew were specially protected by the goddess Hera.


### PR DESCRIPTION
For any users finding this repo, we can signpost them to the "client-facing" docs rather than the README which we should also revise to be specifically for developers of Hera (i.e. how to contribute, install etc).