### PR TITLE
Remove comments from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,10 @@
-<!-- Thank you for submitting a PR to Hera! 🚀 -->
-
 **Pull Request Checklist**
 - [ ] Fixes #<!--issue number goes here-->
 - [ ] Tests added
 - [ ] Documentation/examples added
 - [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title
-<!-- Also remember to sign off commits or the DCO check will fail on your PR! -->
 
 **Description of PR**
-<!-- If not linked to an issue, please describe your changes here -->
-
 Currently, ...
 
 This PR adds/changes/fixes...
-
-<!-- Piece of cake! ✨🍰✨ -->


### PR DESCRIPTION
I noticed unless users clear the comments out manually, they will be added in the commit message, which makes it a bit noisy. Removing for now.