### PR TITLE
Minor fix to CronWorkflow update

### DIFF
--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -74,7 +74,7 @@ class CronWorkflow(Workflow):
             return self.create()
         return self.workflows_service.update_cron_workflow(
             self.name,
-            UpdateCronWorkflowRequest(template=template),
+            UpdateCronWorkflowRequest(cron_workflow=template),
             namespace=self.namespace,
         )
 

--- a/tests/test_unit/test_cron_workflow.py
+++ b/tests/test_unit/test_cron_workflow.py
@@ -28,7 +28,7 @@ def test_cron_workflow_update_existing_cw():
     cw.get.assert_called_once()
     cw.workflows_service.update_cron_workflow.assert_called_once_with(
         "my-cw",
-        UpdateCronWorkflowRequest(template=cw.build()),
+        UpdateCronWorkflowRequest(cron_workflow=cw.build()),
         namespace="my-namespace",
     )
     assert got_cw == cw.build()


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
In my previous PR #681, I'm using the wrong parameter when calling `UpdateCronWorkflowRequest`; it should've been `cron_workflow` and not `template`.


To validate that this change is needed, I used this simple example. Without the fix from this PR, you will likely receive the following error message:

```
hera.exceptions.InternalServerError: Server returned status code 500 with message: `runtime error: invalid memory address or nil pointer dereference`
```

<details>

```py
import time
from hera.workflows import CronWorkflow, Container

# authenticate w Argo Server
global_config = authenticate()

with CronWorkflow(
    name="my-cw",
    namespace=global_config.namespace,
    schedule="*/1 * * * *",
    entrypoint="main",
) as cw:

    cmd_args = ["-c", "echo 'hello world'"]

    main = Container(
        name="main",
        command=["/bin/sh"],
        args=cmd_args,
    )

    pass

cw.create()

time.sleep(10)

with CronWorkflow(
    name="my-cw",
    namespace=global_config.namespace,
    schedule="2 * * * *", # new schedule
    entrypoint="main",
) as ncw:

    cmd_args = ["-c", "echo 'hello world'"]

    main = Container(
        name="main",
        command=["/bin/sh"],
        args=cmd_args,
    )

ncw.update()

```
</details>

Apologies @elliotgunton for not catching this sooner.
