### PR TITLE
Fix create_as_workflow and improve test

### DIFF
--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -4,7 +4,7 @@ See https://argoproj.github.io/argo-workflows/workflow-templates/
 for more on WorkflowTemplates.
 """
 from pathlib import Path
-from typing import Dict, Optional, Type, Union
+from typing import Dict, Optional, Type, Union, cast
 
 try:
     from typing import Annotated  # type: ignore
@@ -140,7 +140,7 @@ class WorkflowTemplate(Workflow):
         return cls._from_file(yaml_file, _ModelWorkflowTemplate)
 
     def _get_as_workflow(self, generate_name: Optional[str]) -> Workflow:
-        workflow = Workflow.from_dict(self.to_dict())
+        workflow = cast(Workflow, Workflow.from_dict(self.to_dict()))
         workflow.kind = "Workflow"
 
         if generate_name is not None:

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -140,7 +140,7 @@ class WorkflowTemplate(Workflow):
         return cls._from_file(yaml_file, _ModelWorkflowTemplate)
 
     def _get_as_workflow(self, generate_name: Optional[str]) -> Workflow:
-        workflow = Workflow(**self.dict())
+        workflow = Workflow.from_dict(self.to_dict())
         workflow.kind = "Workflow"
 
         if generate_name is not None:

--- a/tests/test_unit/test_workflow_template.py
+++ b/tests/test_unit/test_workflow_template.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hera.exceptions import NotFound
+from hera.shared import global_config
 from hera.workflows import Container, Steps
 from hera.workflows.models import (
     WorkflowCreateRequest,
@@ -14,7 +15,7 @@ from hera.workflows.models import (
 from hera.workflows.service import WorkflowsService
 from hera.workflows.workflow import NAME_LIMIT, Workflow
 from hera.workflows.workflow_template import _TRUNCATE_LENGTH, WorkflowTemplate
-from hera.shared import global_config
+
 
 def test_workflow_template_setting_status_errors():
     with pytest.raises(ValueError) as e:
@@ -78,7 +79,7 @@ def test_workflow_template_create_as_workflow():
         wt.workflows_service.create_workflow.assert_called_once_with(
             WorkflowCreateRequest(workflow=expected_workflow.build()),
             namespace="my-namespace",
-    )
+        )
 
 
 def test_workflow_template_get_as_workflow():

--- a/tests/test_unit/test_workflow_template.py
+++ b/tests/test_unit/test_workflow_template.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hera.exceptions import NotFound
+from hera.workflows import Container, Steps
 from hera.workflows.models import (
     WorkflowCreateRequest,
     WorkflowStatus,
@@ -13,7 +14,7 @@ from hera.workflows.models import (
 from hera.workflows.service import WorkflowsService
 from hera.workflows.workflow import NAME_LIMIT, Workflow
 from hera.workflows.workflow_template import _TRUNCATE_LENGTH, WorkflowTemplate
-
+from hera.shared import global_config
 
 def test_workflow_template_setting_status_errors():
     with pytest.raises(ValueError) as e:
@@ -24,6 +25,7 @@ def test_workflow_template_setting_status_errors():
 
 
 def test_workflow_template_create():
+    global_config.host = "http://hera.testing"
     ws = WorkflowsService()
     ws.create_workflow_template = MagicMock()
 
@@ -46,27 +48,36 @@ def test_workflow_template_create():
 
 
 def test_workflow_template_create_as_workflow():
-    ws = WorkflowsService(namespace="my-namespace")
-    ws.create_workflow = MagicMock()
+    with patch.object(WorkflowsService, "create_workflow", return_value=MagicMock()) as create_workflow:
+        # We have to patch the function at the class level because create_as_workflow copies the workflows service
+        # from the WorkflowTemplate to the *separate* Workflow object.
 
-    # Note we set the name to None here, otherwise the workflow will take the name from the returned object
-    ws.create_workflow.return_value.metadata.name = None
+        ws = WorkflowsService(namespace="my-namespace")
+        # Note we set the name to None here, otherwise the workflow will take the name from the returned object
+        create_workflow.return_value.metadata.name = None
 
-    # GIVEN
-    with WorkflowTemplate(
-        name="my-wt",
-        namespace="my-namespace",
-        workflows_service=ws,
-    ) as wt:
-        pass
+        # GIVEN
+        with WorkflowTemplate(
+            name="my-wt",
+            namespace="my-namespace",
+            workflows_service=ws,
+        ) as wt:
+            cowsay = Container(name="cowsay", image="docker/whalesay", command=["cowsay", "foo"])
+            with Steps(name="steps"):
+                cowsay()
 
-    # WHEN
-    wt.create_as_workflow()
+        expected_workflow = Workflow.from_dict(wt.to_dict())
+        expected_workflow.kind = "Workflow"
+        expected_workflow.generate_name = expected_workflow.name
+        expected_workflow.name = None
 
-    # THEN
-    wt.workflows_service.create_workflow.assert_called_once_with(
-        WorkflowCreateRequest(workflow=wt._get_as_workflow(None).build()),
-        namespace="my-namespace",
+        # WHEN
+        wt.create_as_workflow()
+
+        # THEN
+        wt.workflows_service.create_workflow.assert_called_once_with(
+            WorkflowCreateRequest(workflow=expected_workflow.build()),
+            namespace="my-namespace",
     )
 
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #692
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, using `**self.dict()` doesn't do a deep copy of `self`, so for example, `tasks` under a dag template in `self.templates` are not copied. This PR now uses `Workflow.from_dict(self.to_dict())` to correctly perform a deep copy.
