### PR TITLE
Add Content-Type header to PUT and POST requests

### DIFF
--- a/scripts/service.py
+++ b/scripts/service.py
@@ -147,7 +147,11 @@ class ServiceEndpoint:
             params = "None"
 
         # headers
-        headers = "{'Authorization': f'Bearer {self.token}'}"
+        headers = "{'Authorization': f'Bearer {self.token}'"
+        if self.method == "post" or self.method == "put":
+            headers += f", 'Content-Type': '{self.consumes}'"
+
+        headers += "}"
 
         # body/data
         body_params = [p for p in self.params if p.in_ == "body"]

--- a/src/hera/events/service.py
+++ b/src/hera/events/service.py
@@ -96,7 +96,7 @@ class EventsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -134,7 +134,7 @@ class EventsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -187,7 +187,7 @@ class EventsService:
                 discriminator=discriminator, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -260,7 +260,7 @@ class EventsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -296,7 +296,7 @@ class EventsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),

--- a/src/hera/workflows/service.py
+++ b/src/hera/workflows/service.py
@@ -196,7 +196,7 @@ class WorkflowsService:
         resp = requests.put(
             url=urljoin(self.host, "api/v1/archived-workflows/{uid}/resubmit").format(uid=uid),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -213,7 +213,7 @@ class WorkflowsService:
         resp = requests.put(
             url=urljoin(self.host, "api/v1/archived-workflows/{uid}/retry").format(uid=uid),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -266,7 +266,7 @@ class WorkflowsService:
         resp = requests.post(
             url=urljoin(self.host, "api/v1/cluster-workflow-templates"),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -283,7 +283,7 @@ class WorkflowsService:
         resp = requests.post(
             url=urljoin(self.host, "api/v1/cluster-workflow-templates/lint"),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -319,7 +319,7 @@ class WorkflowsService:
         resp = requests.put(
             url=urljoin(self.host, "api/v1/cluster-workflow-templates/{name}").format(name=name),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -419,7 +419,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -449,7 +449,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -511,7 +511,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -577,7 +577,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -609,7 +609,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -725,7 +725,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -746,7 +746,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -786,7 +786,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -880,7 +880,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -899,7 +899,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -918,7 +918,7 @@ class WorkflowsService:
                 namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1044,7 +1044,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1063,7 +1063,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1082,7 +1082,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1101,7 +1101,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1120,7 +1120,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1139,7 +1139,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),
@@ -1160,7 +1160,7 @@ class WorkflowsService:
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
             params=None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
             data=req.json(
                 exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
             ),


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, outgoing PUT and POST requests don't have a "Content-Type" header ("application/json" in all cases here).
Argo doesn't seem to mind that, but when interfacing with other HTTP servers (or proxies) this may be a requirement for a JSON payload.

This PR adds "Content-Type" header to all PUT and POST requests.
