### PR TITLE
Fix: script function called under workflow no longer returns a Step

### DIFF
--- a/docs/examples/workflows/hello_world.md
+++ b/docs/examples/workflows/hello_world.md
@@ -16,8 +16,12 @@
         print("Hello, {s}!".format(s=s))
 
 
-    with Workflow(generate_name="task-exit-handler-", entrypoint="s") as w:
-        hello(s="hello")
+    with Workflow(
+        generate_name="hello-world-",
+        entrypoint="hello",
+        arguments={"s": "world"},
+    ) as w:
+        hello()
     ```
 
 === "YAML"
@@ -26,9 +30,13 @@
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow
     metadata:
-      generateName: task-exit-handler-
+      generateName: hello-world-
     spec:
-      entrypoint: s
+      arguments:
+        parameters:
+        - name: s
+          value: world
+      entrypoint: hello
       templates:
       - inputs:
           parameters:

--- a/examples/workflows/hello-world.yaml
+++ b/examples/workflows/hello-world.yaml
@@ -1,9 +1,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: task-exit-handler-
+  generateName: hello-world-
 spec:
-  entrypoint: s
+  arguments:
+    parameters:
+    - name: s
+      value: world
+  entrypoint: hello
   templates:
   - inputs:
       parameters:

--- a/examples/workflows/hello_world.py
+++ b/examples/workflows/hello_world.py
@@ -6,5 +6,9 @@ def hello(s: str):
     print("Hello, {s}!".format(s=s))
 
 
-with Workflow(generate_name="task-exit-handler-", entrypoint="s") as w:
-    hello(s="hello")
+with Workflow(
+    generate_name="hello-world-",
+    entrypoint="hello",
+    arguments={"s": "world"},
+) as w:
+    hello()

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -26,7 +26,7 @@ from hera.workflows._context import SubNodeMixin, _context
 from hera.workflows.artifact import Artifact
 from hera.workflows.env import Env, _BaseEnv
 from hera.workflows.env_from import _BaseEnvFrom
-from hera.workflows.exceptions import InvalidTemplateCall, InvalidType
+from hera.workflows.exceptions import InvalidTemplateCall
 from hera.workflows.metrics import Metrics, _BaseMetric
 from hera.workflows.models import (
     HTTP,
@@ -600,16 +600,17 @@ class CallableTemplateMixin(ArgumentsMixin):
     """`CallableTemplateMixin` provides the ability to 'call' the template like a regular Python function.
 
     The callable template implements the `__call__` method for the inheritor. The `__call__` method supports invoking
-    the template as a regular Python function. The call must be executed within an active context, such as a `DAG` or
-    `Steps` since the call returns either a `Step` or a `Task` depending on the active context (`Step` for `Steps` and
-    `Task` for `DAG`, respectively). Note that `Steps` also supports calling templates in a parallel steps context
-    via using `Steps(...).parallel()`. When the call is executed and the template does not exist on the active
-    context, i.e. the workflow, it is automatically added for the user. Note that invoking the same template multiple
-    times does *not* result in the creation/addition of the same template to the active context/workflow. Rather, a
-    union is performed, so space is saved for users on the templates field and templates are not duplicated.
+    the template as a regular Python function. The call must be executed within an active context, which is a
+    `Workflow`, `DAG` or `Steps` context since the call optionally returns a `Step` or a `Task` depending on the active
+    context (`None` for `Workflow`, `Step` for `Steps` and `Task` for `DAG`). Note that `Steps` also supports calling
+    templates in a parallel steps context via using `Steps(...).parallel()`. When the call is executed and the template
+    does not exist on the active context, i.e. the workflow, it is automatically added for the user. Note that invoking
+    the same template multiple times does *not* result in the creation/addition of the same template to the active
+    context/workflow. Rather, a union is performed, so space is saved for users on the templates field and templates are
+    not duplicated.
     """
 
-    def __call__(self, *args, **kwargs) -> Union[Step, Task]:
+    def __call__(self, *args, **kwargs) -> Union[None, Step, Task]:
         if "name" not in kwargs:
             kwargs["name"] = self.name  # type: ignore
 
@@ -632,21 +633,34 @@ class CallableTemplateMixin(ArgumentsMixin):
         # the step/task will miss adding them when building the final arguments
         kwargs["arguments"] = arguments
 
-        try:
-            from hera.workflows.steps import Step
+        from hera.workflows.dag import DAG
+        from hera.workflows.script import Script
+        from hera.workflows.steps import Parallel, Step, Steps
+        from hera.workflows.task import Task
+        from hera.workflows.workflow import Workflow
 
+        if isinstance(_context.pieces[-1], Workflow):
+            # Notes on callable templates under a Workflow:
+            # * If the user calls a script directly under a Workflow (outside of a Steps/DAG) then we add the script
+            #   template to the workflow and return None.
+            # * Containers are already added when initialized under the Workflow context so a called Container doesn't
+            #   make sense in that context, so we will raise the InvalidTemplateCall exception later.
+            # * We do not currently validate the added templates to stop a user adding the same template multiple times,
+            #   which can happen if "calling" the same script multiple times to add it to the workflow, or initializing
+            #   a second `Container` exactly like the first.
+            if isinstance(self, Script):
+                _context.add_sub_node(self)
+                return None
+
+        if isinstance(_context.pieces[-1], (Steps, Parallel)):
             return Step(*args, template=self, **kwargs)
-        except InvalidType:
-            pass
 
-        try:
-            from hera.workflows.task import Task
-
+        if isinstance(_context.pieces[-1], DAG):
             return Task(*args, template=self, **kwargs)
-        except InvalidType:
-            pass
 
-        raise InvalidTemplateCall("Container is not under a Steps, Parallel, or DAG context")
+        raise InvalidTemplateCall(
+            f"Callable Template '{self.name}' is not under a Workflow, Steps, Parallel, or DAG context"
+        )
 
     def _get_arguments(self, **kwargs) -> List:
         """Returns a list of arguments from the kwargs given to the template call."""

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -639,27 +639,28 @@ class CallableTemplateMixin(ArgumentsMixin):
         from hera.workflows.task import Task
         from hera.workflows.workflow import Workflow
 
-        if isinstance(_context.pieces[-1], Workflow):
-            # Notes on callable templates under a Workflow:
-            # * If the user calls a script directly under a Workflow (outside of a Steps/DAG) then we add the script
-            #   template to the workflow and return None.
-            # * Containers are already added when initialized under the Workflow context so a called Container doesn't
-            #   make sense in that context, so we will raise the InvalidTemplateCall exception later.
-            # * We do not currently validate the added templates to stop a user adding the same template multiple times,
-            #   which can happen if "calling" the same script multiple times to add it to the workflow, or initializing
-            #   a second `Container` exactly like the first.
-            if isinstance(self, Script):
-                _context.add_sub_node(self)
-                return None
+        if _context.pieces:
+            if isinstance(_context.pieces[-1], Workflow):
+                # Notes on callable templates under a Workflow:
+                # * If the user calls a script directly under a Workflow (outside of a Steps/DAG) then we add the script
+                #   template to the workflow and return None.
+                # * Containers are already added when initialized under the Workflow context so a called Container doesn't
+                #   make sense in that context, so we will raise the InvalidTemplateCall exception later.
+                # * We do not currently validate the added templates to stop a user adding the same template multiple times,
+                #   which can happen if "calling" the same script multiple times to add it to the workflow, or initializing
+                #   a second `Container` exactly like the first.
+                if isinstance(self, Script):
+                    _context.add_sub_node(self)
+                    return None
 
-        if isinstance(_context.pieces[-1], (Steps, Parallel)):
-            return Step(*args, template=self, **kwargs)
+            if isinstance(_context.pieces[-1], (Steps, Parallel)):
+                return Step(*args, template=self, **kwargs)
 
-        if isinstance(_context.pieces[-1], DAG):
-            return Task(*args, template=self, **kwargs)
+            if isinstance(_context.pieces[-1], DAG):
+                return Task(*args, template=self, **kwargs)
 
         raise InvalidTemplateCall(
-            f"Callable Template '{self.name}' is not under a Workflow, Steps, Parallel, or DAG context"
+            f"Callable Template '{self.name}' is not under a Workflow, Steps, Parallel, or DAG context"  # type: ignore
         )
 
     def _get_arguments(self, **kwargs) -> List:

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -644,8 +644,9 @@ class CallableTemplateMixin(ArgumentsMixin):
                 # Notes on callable templates under a Workflow:
                 # * If the user calls a script directly under a Workflow (outside of a Steps/DAG) then we add the script
                 #   template to the workflow and return None.
-                # * Containers are already added when initialized under the Workflow context so a called Container doesn't
-                #   make sense in that context, so we will raise the InvalidTemplateCall exception later.
+                # * Containers, ContainerSets and Data objects (i.e. subclasses of CallableTemplateMixin) are already
+                #   added when initialized under the Workflow context so a callable doesn't make sense in that context,
+                #   so we raise an InvalidTemplateCall exception.
                 # * We do not currently validate the added templates to stop a user adding the same template multiple times,
                 #   which can happen if "calling" the same script multiple times to add it to the workflow, or initializing
                 #   a second `Container` exactly like the first.
@@ -653,6 +654,9 @@ class CallableTemplateMixin(ArgumentsMixin):
                     _context.add_sub_node(self)
                     return None
 
+                raise InvalidTemplateCall(
+                    f"Callable Template '{self.name}' is not callable under a Workflow"  # type: ignore
+                )
             if isinstance(_context.pieces[-1], (Steps, Parallel)):
                 return Step(*args, template=self, **kwargs)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -37,8 +37,7 @@ async def abuild_workflow_set(event):
 
 
 def test_async_context():
-    """
-    In this test, we create 2 workflows using async functions and make sure the context isn't leaking.
+    """In this test, we create 2 workflows using async functions and make sure the context isn't leaking.
 
     In the middle of the first one, we pause by waiting thus never calling the context exit() function;
     meanwhile the 2nd function will create another workflow, then unblock the first one which will resume.
@@ -66,9 +65,7 @@ def test_async_context():
 
 
 def test_sync_context():
-    """
-    Context is not leaking between 2 successive sync workflow creations
-    """
+    """Context is not leaking between 2 successive sync workflow creations."""
     with Workflow(
         generate_name="w0-",
         entrypoint="steps",

--- a/tests/test_unit/test_container_set.py
+++ b/tests/test_unit/test_container_set.py
@@ -1,0 +1,26 @@
+import pytest
+
+from hera.workflows.container import Container
+from hera.workflows.container_set import ContainerSet
+from hera.workflows.exceptions import InvalidTemplateCall
+from hera.workflows.parameter import Parameter
+from hera.workflows.workflow import Workflow
+
+
+def test_container_set_callable_container_raises_error():
+    with pytest.raises(InvalidTemplateCall) as e:
+        # GIVEN
+        with Workflow(name="w"):
+            whalesay = Container(
+                name="whalesay",
+                inputs=[Parameter(name="message")],
+                image="docker/whalesay",
+                command=["cowsay"],
+                args=["{{inputs.parameters.message}}"],
+            )
+            with ContainerSet(name="cs"):
+                # WHEN
+                whalesay()
+
+    # THEN InvalidTemplateCall raised
+    assert "Callable Template 'whalesay' is not under a Workflow, Steps, Parallel, or DAG context" in str(e.value)

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from hera.workflows.exceptions import InvalidTemplateCall
 
+from hera.workflows.container import Container
+from hera.workflows.exceptions import InvalidTemplateCall
 from hera.workflows.models import WorkflowCreateRequest
+from hera.workflows.parameter import Parameter
+from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService
 from hera.workflows.workflow import NAME_LIMIT, Workflow
-from hera.workflows.script import script
-from hera.workflows.container import Container
-from hera.workflows.parameter import Parameter
 
 
 def test_workflow_name_validators():
@@ -101,4 +101,4 @@ def test_workflow_callable_container_raises_error():
             whalesay()
 
     # THEN InvalidTemplateCall raised
-    assert "Callable Template 'whalesay' is not under a Workflow, Steps, Parallel, or DAG context" in str(e.value)
+    assert "Callable Template 'whalesay' is not callable under a Workflow" in str(e.value)


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #709 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
* Fix hello_world example
* Keep the behaviour that the script template itself is added to the
list of templates in the Workflow
* Remove the behaviour that a `Step` object is returned from the call
of the script
* Change to look-before-you-leap for returned object from the
CallableTemplateMixin's `__call__` to make it clearer what's happening