### PR TITLE
Fix missing examples test, add markdown table output

### DIFF
--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -28,5 +28,8 @@ def test_for_missing_examples():
     }
 
     if len(missing) > 0:
-        print(json.dumps(missing_examples, indent=2))
+        print("| Name | Link |")
+        print("|------|------|")
+        for name, link in missing_examples.items():
+            print(f"| {name} | {link} |")
         assert False, f"Missing {len(missing)} examples"

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -15,7 +15,7 @@ def test_for_missing_examples():
         file["path"] for file in repo_json["tree"] if "examples/" in file["path"] and ".yaml" in file["path"]
     ]
 
-    argo_examples = map(lambda file: file[len("examples/") :][: len(".yaml")], argo_examples)
+    argo_examples = map(lambda file: file[len("examples/") :][: -len(".yaml")], argo_examples)
 
     hera_examples = [name for _, name, _ in pkgutil.iter_modules(hera_upstream_examples.__path__)]
     hera_examples = list(map(lambda file: file.replace("__", "/").replace("_", "-"), hera_examples))
@@ -27,4 +27,6 @@ def test_for_missing_examples():
         for example in missing
     }
 
-    assert len(missing) == 0, f"Missing {len(missing)} examples: {json.dumps(missing_examples, indent=2)}"
+    if len(missing) > 0:
+        print(json.dumps(missing_examples, indent=2))
+        assert False, f"Missing {len(missing)} examples"


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Tracking #567 
- [ ] ~Tests added~ Fixed missing examples test
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
There was a missing minus when creating the list of `argo_examples`, so the list of missing examples had broken links. This PR fixes the links and dumps it to stdout as a markdown table to copy out (see https://github.com/argoproj-labs/hera/issues/567#issuecomment-1639763692)
