### PR TITLE
Add global_config_fixture, fix broken tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from hera.shared import global_config
+
+import pytest
+
+
+@pytest.fixture
+def global_config_fixture():
+    global_config.reset()
+    yield global_config
+    global_config.reset()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,7 +11,6 @@ import pytest
 import requests
 import yaml
 
-from hera.shared import global_config
 from hera.workflows import (
     CronWorkflow as HeraCronWorkflow,
     Workflow as HeraWorkflow,
@@ -93,10 +92,9 @@ def _compare_workflows(hera_workflow, w1: Dict, w2: Dict):
 @pytest.mark.parametrize(
     "module_name", [name for _, name, _ in pkgutil.iter_modules(hera_examples.__path__) if name != "upstream"]
 )
-def test_hera_output(module_name):
+def test_hera_output(module_name, global_config_fixture):
     # GIVEN
-    global_config.reset()
-    global_config.host = "http://hera.testing"
+    global_config_fixture.host = "http://hera.testing"
     workflow = importlib.import_module(f"examples.workflows.{module_name}").w
     generated_yaml_path = Path(hera_examples.__file__).parent / f"{module_name.replace('_', '-')}.yaml"
 
@@ -123,10 +121,9 @@ def test_hera_output(module_name):
 
 
 @pytest.mark.parametrize("module_name", [name for _, name, _ in pkgutil.iter_modules(hera_upstream_examples.__path__)])
-def test_hera_output_upstream(module_name):
+def test_hera_output_upstream(module_name, global_config_fixture):
     # GIVEN
-    global_config.reset()
-    global_config.host = "http://hera.testing"
+    global_config_fixture.host = "http://hera.testing"
     workflow = importlib.import_module(f"examples.workflows.upstream.{module_name}").w
     generated_yaml_path = Path(hera_upstream_examples.__file__).parent / f"{module_name.replace('_', '-')}.yaml"
     upstream_yaml_path = (

--- a/tests/test_unit/test_hooks.py
+++ b/tests/test_unit/test_hooks.py
@@ -1,12 +1,11 @@
-from hera.shared import global_config, register_pre_build_hook
 from hera.workflows.cluster_workflow_template import ClusterWorkflowTemplate
 from hera.workflows.container import Container
 from hera.workflows.workflow import Workflow
 from hera.workflows.workflow_template import WorkflowTemplate
 
 
-def test_container_pre_build_hooks():
-    @register_pre_build_hook
+def test_container_pre_build_hooks(global_config_fixture):
+    @global_config_fixture.register_pre_build_hook
     def set_container_default_image(container: Container) -> Container:
         container.image = "test_image"
         return container
@@ -17,14 +16,14 @@ def test_container_pre_build_hooks():
     assert c.image == "python:3.8"
     w.build()
     assert c.image == "test_image"
-    global_config.reset()
+    global_config_fixture.reset()
 
-    @register_pre_build_hook
+    @global_config_fixture.register_pre_build_hook
     def set_container_label(container: Container) -> Container:
         container.labels = {"test": "test"}
         return container
 
-    register_pre_build_hook(set_container_default_image)
+    global_config_fixture.register_pre_build_hook(set_container_default_image)
 
     with Workflow(name="t") as w:
         c = Container()
@@ -34,11 +33,10 @@ def test_container_pre_build_hooks():
     w.build()
     assert c.image == "test_image"
     assert c.labels["test"] == "test"
-    global_config.reset()
 
 
-def test_workflow_pre_build_hooks():
-    @register_pre_build_hook
+def test_workflow_pre_build_hooks(global_config_fixture):
+    @global_config_fixture.register_pre_build_hook
     def set_workflow_default_node_selector(workflow: Workflow) -> Workflow:
         workflow.node_selector = {
             "domain": "test",
@@ -53,11 +51,11 @@ def test_workflow_pre_build_hooks():
     w.build()
     assert w.node_selector["domain"] == "test"
     assert w.node_selector["team"] == "ABC"
-    global_config.reset()
+    global_config_fixture.reset()
 
-    register_pre_build_hook(set_workflow_default_node_selector)
+    global_config_fixture.register_pre_build_hook(set_workflow_default_node_selector)
 
-    @register_pre_build_hook
+    @global_config_fixture.register_pre_build_hook
     def set_workflow_default_labels(workflow: Workflow) -> Workflow:
         workflow.labels = {
             "label": "test",
@@ -73,20 +71,17 @@ def test_workflow_pre_build_hooks():
     assert w.node_selector["domain"] == "test"
     assert w.node_selector["team"] == "ABC"
     assert w.labels["label"] == "test"
-    global_config.reset()
 
 
-def test_workflow_template_pre_build_hooks():
-    global_config.reset()
-
-    @register_pre_build_hook
+def test_workflow_template_pre_build_hooks(global_config_fixture):
+    @global_config_fixture.register_pre_build_hook
     def set_workflow_template_default_labels(workflow_template: WorkflowTemplate) -> WorkflowTemplate:
         workflow_template.labels = {
             "wt_label": "test",
         }
         return workflow_template
 
-    @register_pre_build_hook
+    @global_config_fixture.register_pre_build_hook
     def set_cwt_default_labels(cluster_workflow_template: ClusterWorkflowTemplate) -> ClusterWorkflowTemplate:
         cluster_workflow_template.labels = {
             "cwt_label": "test",
@@ -101,17 +96,15 @@ def test_workflow_template_pre_build_hooks():
     assert wt.labels == {"wt_label": "test"}
 
 
-def test_cluster_workflow_template_pre_build_hooks():
-    global_config.reset()
-
-    @register_pre_build_hook
+def test_cluster_workflow_template_pre_build_hooks(global_config_fixture):
+    @global_config_fixture.register_pre_build_hook
     def set_workflow_template_default_labels(workflow_template: WorkflowTemplate) -> WorkflowTemplate:
         workflow_template.labels = {
             "wt_label": "test",
         }
         return workflow_template
 
-    @register_pre_build_hook
+    @global_config_fixture.register_pre_build_hook
     def set_cwt_default_labels(cluster_workflow_template: ClusterWorkflowTemplate) -> ClusterWorkflowTemplate:
         cluster_workflow_template.labels = {
             "cwt_label": "test",

--- a/tests/test_unit/test_workflow_template.py
+++ b/tests/test_unit/test_workflow_template.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hera.exceptions import NotFound
-from hera.shared import global_config
 from hera.workflows import Container, Steps
 from hera.workflows.models import (
     WorkflowCreateRequest,
@@ -25,8 +24,8 @@ def test_workflow_template_setting_status_errors():
     assert "status is not a valid field on a WorkflowTemplate" in str(e.value)
 
 
-def test_workflow_template_create():
-    global_config.host = "http://hera.testing"
+def test_workflow_template_create(global_config_fixture):
+    global_config_fixture.host = "http://hera.testing"
     ws = WorkflowsService()
     ws.create_workflow_template = MagicMock()
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, global_config leaks across all tests. Running them in random order gets indeterminate results. This makes a start to isolate the global config per test with a pytest fixture to reset it before and after use in the test.
