### PR TITLE
Add testable support for configmaps

### DIFF
--- a/docs/examples/workflows-examples.md
+++ b/docs/examples/workflows-examples.md
@@ -62,6 +62,7 @@ The "Hera" collection shows off features and idiomatic usage of Hera such as the
 | [http-hello-world](https://github.com/argoproj/argo-workflows/blob/master/examples/http-hello-world.yaml) |
 | [http-success-condition](https://github.com/argoproj/argo-workflows/blob/master/examples/http-success-condition.yaml) |
 | [influxdb-ci](https://github.com/argoproj/argo-workflows/blob/master/examples/influxdb-ci.yaml) |
+| [intermediate-parameters](https://github.com/argoproj/argo-workflows/blob/master/examples/intermediate-parameters.yaml) |
 | [k8s-jobs](https://github.com/argoproj/argo-workflows/blob/master/examples/k8s-jobs.yaml) |
 | [k8s-orchestration](https://github.com/argoproj/argo-workflows/blob/master/examples/k8s-orchestration.yaml) |
 | [k8s-owner-reference](https://github.com/argoproj/argo-workflows/blob/master/examples/k8s-owner-reference.yaml) |

--- a/docs/examples/workflows/script_auto_infer.md
+++ b/docs/examples/workflows/script_auto_infer.md
@@ -79,7 +79,7 @@
           command:
           - python
           image: python:3.8
-          source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport json\n\n\
-            import pickle\nwith open('/tmp/i', 'rb') as f:\n    i = pickle.load(f)\nprint(i)"
+          source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport pickle\n\
+            with open('/tmp/i', 'rb') as f:\n    i = pickle.load(f)\nprint(i)"
     ```
 

--- a/examples/workflows/script-auto-infer.yaml
+++ b/examples/workflows/script-auto-infer.yaml
@@ -38,5 +38,5 @@ spec:
       command:
       - python
       image: python:3.8
-      source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport json\n\n\
-        import pickle\nwith open('/tmp/i', 'rb') as f:\n    i = pickle.load(f)\nprint(i)"
+      source: "import os\nimport sys\nsys.path.append(os.getcwd())\nimport pickle\n\
+        with open('/tmp/i', 'rb') as f:\n    i = pickle.load(f)\nprint(i)"

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -457,9 +457,10 @@ class InlineScriptConstructor(ScriptConstructor):
             # non-JSON encoded strings are returned, which fail the loads, but they can be used as plain strings
             # which is why this captures that in an except. This is only used for `InputFrom` cases as the extra
             # payload of the script is not necessary when regular input is set on the task via `func_params`
-            extract += f"""try: {param.name} = json.loads(r'''{{{{inputs.parameters.{param.name}}}}}''')\n"""
-            extract += f"""except: {param.name} = r'''{{{{inputs.parameters.{param.name}}}}}'''\n"""
-        return textwrap.dedent(extract)
+            if param.value_from is None:
+                extract += f"""try: {param.name} = json.loads(r'''{{{{inputs.parameters.{param.name}}}}}''')\n"""
+                extract += f"""except: {param.name} = r'''{{{{inputs.parameters.{param.name}}}}}'''\n"""
+        return textwrap.dedent(extract) if extract != "import json\n" else ""
 
     def generate_source(self, instance: Script) -> str:
         """Assembles and returns a script representation of the given function.

--- a/tests/configmap_tests/configmap_new.py
+++ b/tests/configmap_tests/configmap_new.py
@@ -1,0 +1,44 @@
+from hera.workflows import (
+    Parameter,
+    Workflow,
+    models as m,
+    script,
+)
+
+try:
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
+
+
+@script()
+def echo(
+    message: Annotated[
+        str,
+        Parameter(
+            name="message",
+            value_from=m.ValueFrom(
+                config_map_key_ref=m.ConfigMapKeySelector(
+                    name="simple-parameters",
+                    key="msg",
+                ),
+                default="configmap-default",
+                event="configmap-event",
+                expression="configmap-expression",
+                jq_filter="configmap-jq_filter",
+                json_path="configmap-json_path",
+                parameter="configmap-parameter",
+                path="configmap-path",
+                supplied={"name": "configmap-supplied"},
+            ),
+        ),
+    ]
+):
+    print(message)
+
+
+with Workflow(
+    generate_name="callable-steps-",
+    entrypoint="calling-steps",
+) as w:
+    echo()

--- a/tests/configmap_tests/configmap_old.py
+++ b/tests/configmap_tests/configmap_old.py
@@ -1,0 +1,38 @@
+from hera.workflows import (
+    Parameter,
+    Workflow,
+    models as m,
+    script,
+)
+
+
+@script(
+    inputs=[
+        Parameter(
+            name="message",
+            value_from=m.ValueFrom(
+                config_map_key_ref=m.ConfigMapKeySelector(
+                    name="simple-parameters",
+                    key="msg",
+                ),
+                default="configmap-default",
+                event="configmap-event",
+                expression="configmap-expression",
+                jq_filter="configmap-jq_filter",
+                json_path="configmap-json_path",
+                parameter="configmap-parameter",
+                path="configmap-path",
+                supplied={"name": "configmap-supplied"},
+            ),
+        ),
+    ]
+)
+def echo():
+    print(message)
+
+
+with Workflow(
+    generate_name="callable-steps-",
+    entrypoint="calling-steps",
+) as w:
+    echo()

--- a/tests/test_script_annotations_configmap.py
+++ b/tests/test_script_annotations_configmap.py
@@ -1,0 +1,22 @@
+import importlib
+import pytest
+
+from hera.workflows import (
+    Workflow,
+)
+
+from test_examples import _compare_workflows
+
+
+def test_configmap(global_config_fixture):
+    # GIVEN
+    global_config_fixture.experimental_features["script_annotations"] = True
+    workflow_old = importlib.import_module(f"tests.configmap_tests.configmap_old").w
+    workflow_new = importlib.import_module(f"tests.configmap_tests.configmap_new").w
+
+    # WHEN
+    output_old = workflow_old.to_dict()
+    output_new = workflow_new.to_dict()
+
+    # THEN
+    _compare_workflows(workflow_old, output_old, output_new)


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #704 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

Using annotations allows us to support configmaps for parameters in inputs of scripts. This can be done by:

```python
@script()
def echo(
    message: Annotated[
        str,
        Parameter(
            name="message",
            value_from=m.ValueFrom(
                config_map_key_ref=m.ConfigMapKeySelector(
                    name="simple-parameters",
                    key="msg",
                )
            ),
        ),
    ]
):
    print(message)
```

This also adds `value_from` for input parameters which is something we should support.