### PR TITLE
Use the runner constructor in Parameter/Artifact annotation examples

### DIFF
--- a/docs/examples/workflows/script_annotations.md
+++ b/docs/examples/workflows/script_annotations.md
@@ -20,7 +20,7 @@
     global_config.experimental_features["script_runner"] = True
 
 
-    @script()
+    @script(constructor="runner")
     def echo_all(
         an_int: Annotated[int, Parameter(description="an_int parameter", default=1)],
         a_bool: Annotated[bool, Parameter(description="a_bool parameter", default=True)],
@@ -87,36 +87,17 @@
             name: a_string
         name: echo-all
         script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.script_annotations:echo_all
           command:
           - python
+          env:
+          - name: hera__script_annotations
+            value: ''
           image: python:3.8
-          source: 'import os
-
-            import sys
-
-            sys.path.append(os.getcwd())
-
-            import json
-
-            try: a_bool = json.loads(r''''''{{inputs.parameters.a_bool}}'''''')
-
-            except: a_bool = r''''''{{inputs.parameters.a_bool}}''''''
-
-            try: a_string = json.loads(r''''''{{inputs.parameters.a_string}}'''''')
-
-            except: a_string = r''''''{{inputs.parameters.a_string}}''''''
-
-            try: an_int = json.loads(r''''''{{inputs.parameters.an_int}}'''''')
-
-            except: an_int = r''''''{{inputs.parameters.an_int}}''''''
-
-
-            print(an_int)
-
-            print(a_bool)
-
-            print(a_string)
-
-            print(an_artifact)'
+          source: '{{inputs.parameters}}'
     ```
 

--- a/examples/workflows/script-annotations.yaml
+++ b/examples/workflows/script-annotations.yaml
@@ -36,34 +36,15 @@ spec:
         name: a_string
     name: echo-all
     script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.script_annotations:echo_all
       command:
       - python
+      env:
+      - name: hera__script_annotations
+        value: ''
       image: python:3.8
-      source: 'import os
-
-        import sys
-
-        sys.path.append(os.getcwd())
-
-        import json
-
-        try: a_bool = json.loads(r''''''{{inputs.parameters.a_bool}}'''''')
-
-        except: a_bool = r''''''{{inputs.parameters.a_bool}}''''''
-
-        try: a_string = json.loads(r''''''{{inputs.parameters.a_string}}'''''')
-
-        except: a_string = r''''''{{inputs.parameters.a_string}}''''''
-
-        try: an_int = json.loads(r''''''{{inputs.parameters.an_int}}'''''')
-
-        except: an_int = r''''''{{inputs.parameters.an_int}}''''''
-
-
-        print(an_int)
-
-        print(a_bool)
-
-        print(a_string)
-
-        print(an_artifact)'
+      source: '{{inputs.parameters}}'

--- a/examples/workflows/script_annotations.py
+++ b/examples/workflows/script_annotations.py
@@ -10,7 +10,7 @@ global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_runner"] = True
 
 
-@script()
+@script(constructor="runner")
 def echo_all(
     an_int: Annotated[int, Parameter(description="an_int parameter", default=1)],
     a_bool: Annotated[bool, Parameter(description="a_bool parameter", default=True)],

--- a/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, ArtifactoryArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, ArtifactoryArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_artifactory_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, ArtifactoryArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_azure_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_azure_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, AzureArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_azure_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_azure_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, AzureArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_azure_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_azure_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, AzureArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_gcs_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_gcs_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, GCSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_gcs_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_gcs_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, GCSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_gcs_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_gcs_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, GCSArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_git_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_git_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, GitArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_git_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_git_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, GitArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_git_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_git_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, GitArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, HDFSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, HDFSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_hdfs_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, HDFSArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_http_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_http_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, HTTPArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_http_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_http_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, HTTPArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_http_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_http_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, HTTPArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", mode=123)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", mode=123)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", mode=123, recurseMode=True)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_mode_recurse_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", mode=123, recurseMode=True)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_optional_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_optional_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_optional_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_optional_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", optional=True)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_optional_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_optional_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", optional=True)])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_oss_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_oss_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, OSSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_oss_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_oss_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, OSSArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_oss_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_oss_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, OSSArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_raw_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_raw_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, RawArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_raw_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_raw_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, RawArtifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_raw_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_raw_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, RawArtifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_s3_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_s3_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact, S3Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_s3_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_s3_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact, S3Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_s3_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_s3_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact, S3Artifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/tests/annotation_regression_examples/script_annotations_artifacts_subpath_new.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_subpath_new.py
@@ -9,7 +9,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script()

--- a/tests/annotation_regression_examples/script_annotations_artifacts_subpath_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_subpath_old.py
@@ -1,9 +1,6 @@
-from hera.shared import global_config
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", subpath="tmp")])

--- a/tests/annotation_regression_examples/script_annotations_artifacts_subpath_old.py
+++ b/tests/annotation_regression_examples/script_annotations_artifacts_subpath_old.py
@@ -4,7 +4,6 @@ from hera.workflows.artifact import Artifact
 from hera.workflows.steps import Steps
 
 global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_runner"] = True
 
 
 @script(inputs=[Artifact(name="my_artifact", path="tmp/file", subpath="tmp")])

--- a/tests/artifact_annotations/script_annotations_artifact_file.py
+++ b/tests/artifact_annotations/script_annotations_artifact_file.py
@@ -15,7 +15,7 @@ global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_runner"] = True
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(
     an_artifact: Annotated[str, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=ArtifactLoader.file)]
 ) -> str:

--- a/tests/artifact_annotations/script_annotations_artifact_file_with_path.py
+++ b/tests/artifact_annotations/script_annotations_artifact_file_with_path.py
@@ -15,7 +15,7 @@ global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_runner"] = True
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(
     an_artifact: Annotated[str, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=ArtifactLoader.file)]
 ) -> str:

--- a/tests/artifact_annotations/script_annotations_artifact_object.py
+++ b/tests/artifact_annotations/script_annotations_artifact_object.py
@@ -20,7 +20,7 @@ class MyArtifact(BaseModel):
     b = "b"
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(
     an_artifact: Annotated[MyArtifact, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=ArtifactLoader.json)]
 ) -> str:

--- a/tests/artifact_annotations/script_annotations_artifact_path.py
+++ b/tests/artifact_annotations/script_annotations_artifact_path.py
@@ -16,7 +16,7 @@ global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_runner"] = True
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(an_artifact: Annotated[Path, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=None)]) -> str:
     return an_artifact.read_text()
 

--- a/tests/artifact_annotations/script_annotations_artifact_wrong_loader.py
+++ b/tests/artifact_annotations/script_annotations_artifact_wrong_loader.py
@@ -15,7 +15,7 @@ global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_runner"] = True
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(
     an_artifact: Annotated[str, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader="a different loader")]
 ) -> str:


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes new annotation examples
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

This PR fixes the runner constructor usage for artifact annotations where in some tests incorrect yaml would be generated.
