### PR TITLE
Fix output Artifact/Parameter annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to Hera
+# Contributing to Hera
 
 **Thank you for considering a contribution to Hera! Your time is the ultimate currency, and the community highly
 appreciates your willingness to dedicate some time to Hera for the benefit of everyone!**
@@ -16,11 +16,11 @@ Please keep in mind the following guidelines and practices when contributing to 
 1. Add unit tests for any new code you write.
 1. Add an example, or extend an existing example, with any new features you may add. Use `make examples` to ensure that the documentation and examples are in sync.
 
-### Adding new Workflow tests
+## Adding new Workflow tests
 
 Hera has an automated-test harness that is coupled with our documentation. In order to add new tests, please follow these steps - 
 
-#### Local Hera examples
+### Local Hera examples
 
 Tests that do not correspond to any upstream Argo Workflow examples should live in `examples/workflows/*.py`
 
@@ -31,7 +31,7 @@ In order to add a new workflow test to test Hera functionality, do the following
 - If you would like to update the golden copy of the test files, you can run `make regenerate-test-data`
 - The golden copies must be checked in to ensure that regressions may be caught in the future
 
-#### Upstream Hera examples
+### Upstream Hera examples
 
 Tests that correspond to any [upstream Argo Workflow examples](https://github.com/argoproj/argo-workflows/tree/master/examples) should live in `examples/workflows/upstream/*.py`. These tests exist to ensure that Hera has complete parity with Argo Workflows and also to catch any regressions that might happen.
 
@@ -42,7 +42,24 @@ In order to add a new workflow test to test Hera functionality, do the following
 - If you would like to update the golden copy of the test files, you can run `make regenerate-test-data`
 - The golden copies must be checked in to ensure that regressions may be caught in the future
 
-### Code of Conduct
+## Working in VSCode
+
+If your preferred IDE is VSCode, you may have an issue using the integrated Testing extension where breakpoints are not
+respected. To solve this, add the following as a config in your `.vscode/launch.json` file:
+
+```json
+{
+   "name": "Debug Tests",
+   "type": "python",
+   "request": "launch",
+   "purpose": ["debug-test"],
+   "console": "integratedTerminal",
+   "justMyCode": false,
+   "env": {"PYTEST_ADDOPTS": "--no-cov"}
+}
+```
+
+## Code of Conduct
 
 Please be mindful of and adhere to the CNCF's
 [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) when contributing to hera.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and its crew were specially protected by the goddess Hera.
 Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make the Argo
 ecosystem accessible by simplifying workflow construction and submission.
 
-# Table of content
+# Table of contents
 
 - [Hera](#hera)
 - [Table of content](#table-of-content)

--- a/docs/examples/workflows/script_annotations_outputs.md
+++ b/docs/examples/workflows/script_annotations_outputs.md
@@ -34,8 +34,8 @@
         successor: Annotated[Path, Parameter(name="successor", output=True)],
         successor2: Annotated[Path, Artifact(name="successor2", output=True)],
     ) -> Tuple[Annotated[int, Parameter(name="successor3")], Annotated[int, Artifact(name="successor4")]]:
-        successor.write_text(a_number + 1)
-        successor2.write_text(a_number + 2)
+        successor.write_text(str(a_number + 1))
+        successor2.write_text(str(a_number + 2))
         return a_number + 3, a_number + 4
 
 
@@ -69,10 +69,16 @@
         outputs:
           artifacts:
           - name: successor2
+            path: user/chosen/outputs/artifacts/successor2
           - name: successor4
+            path: user/chosen/outputs/artifacts/successor4
           parameters:
           - name: successor
+            valueFrom:
+              path: user/chosen/outputs/parameters/successor
           - name: successor3
+            valueFrom:
+              path: user/chosen/outputs/parameters/successor3
         script:
           args:
           - -m

--- a/docs/getting-started/walk-through/advanced-hera-features.md
+++ b/docs/getting-started/walk-through/advanced-hera-features.md
@@ -177,7 +177,7 @@ def read_artifact():
         print(a_file.read())
 ```
 
-By using annotations we can avoid repeating the `path` of the file, and your function can use the variable directly as a
+By using annotations we can avoid repeating the `path` of the file, and the function can use the variable directly as a
 `Path` object, with its value already set to the given path:
 
 ```python
@@ -302,7 +302,7 @@ def func(...) -> Annotated[arbitrary_pydantic_type, Artifact(name="my-output")]:
 ```
 
 For multiple outputs, the return type should be a `Tuple` of arbitrary Pydantic types with individual
-`Parameter`/`Artifact` annotations, and you should return a tuple from the function matching these types:
+`Parameter`/`Artifact` annotations, and the function must return a tuple from the function matching these types:
 ```python
 @script()
 def func(...) -> Tuple[
@@ -314,7 +314,7 @@ def func(...) -> Tuple[
 ```
 
 Hera also allows output `Parameter`/`Artifact`s as part of the function signature when specified as a `Path` type,
-allowing users to write to the output path, without needing an explicit return. They require an additional field
+allowing users to write to the path as an output, without needing an explicit return. They require an additional field
 `output=True` to distinguish them from the input parameters and must have an underlying `Path` type (or another type
 that will write to disk). For `Parameters`, they will have the path of `/hera/outputs/parameters/<name>`, which can be
 changed by setting the parameter's `value_from` argument. For `Artifacts`, they will have a path of

--- a/docs/getting-started/walk-through/advanced-hera-features.md
+++ b/docs/getting-started/walk-through/advanced-hera-features.md
@@ -98,9 +98,9 @@ dictionary before using the feature:
 global_config.experimental_features["NAME_OF_FEATURE"] = True
 ```
 
-### Currently supported experimental features:
+## Currently supported experimental features:
 
-#### `RunnerScriptConstructor`
+### `RunnerScriptConstructor`
 The `RunnerScriptConstructor` found in `hera.workflows.script` and seen in the
 [callable script example](../../examples/workflows/callable_script.md) is a robust way to run Python functions on Argo.
 The image used by the script should be built from the source code package itself and its dependencies, so that the
@@ -113,22 +113,23 @@ global_config.experimental_features["script_runner"] = True
 ```
 
 
-#### Script Annotations
-Annotations are supported for input `Parameter`s and `Artifact`s. They can be added using `typing.Annotated` in the function parameters. 
+### Script Annotations
 
-```python
-@script()
-def func(a_param: Annotated[str, Parameter(name="a-param", default="param")]):
-    ...
+Annotation syntax using `typing.Annotated` is supported for `Parameter`s and `Artifact`s as inputs and outputs for
+functions decorated as `scripts`. They use `Annotated` as the type in the function parameters and allow us to simplify
+writing scripts with parameters and artifacts that require additional fields such as a `description` or alternative
+`name`.
+
+
+This feature can be enabled by setting the `experimental_feature` flag `script_annotations`
+
+```py
+global_config.experimental_features["script_annotations"] = True
 ```
 
-This allows us to simplify writing scripts with parameters and artifacts that require additional fields. 
+#### Parameters
 
-An example can be seen [here](../../examples/workflows/script_annoations_inputs.md)
-
-##### Parameters
-
-In Hera, we can specify inputs inside the `@script` decorator as follows:
+In Hera, we can currently specify inputs inside the `@script` decorator as follows:
 
 ```python
 @script(
@@ -144,7 +145,8 @@ def echo_all(an_int=1, a_bool=True, a_string="a"):
     print(a_string)
 ```
 
-Notice how `Parameter` `name`s and `default` values are duplicated. Using annotations, we can do:
+Notice how the `name` and `default` values are duplicated for each `Parameter`. Using annotations, we can rewrite this
+as:
 
 ```python
 @script()
@@ -160,51 +162,71 @@ def echo_all(
 
 The fields allowed in the `Parameter` annotations are: `name`, `default`, `enum`, and `description`.
 
-##### Artifacts
+#### Artifacts
 
-The improvement is even more noticeable for `Artifact`s. In Hera we are able to specify `Artifact`s in `inputs`:
+> Note: Artifact annotations are only supported when used with the `RunnerScriptConstructor`.
+
+
+The feature is even more powerful for `Artifact`s. In Hera we are currently able to specify `Artifact`s in `inputs`, but
+have no way to programmatically link the given path to the code within the function:
 
 ```python
 @script(inputs=Artifact(name="my-artifact", path="/tmp/file"))
 def read_artifact():
-    with open("/tmp/file") as a_file:
+    with open("/tmp/file") as a_file:  # Repeating "/tmp/file" is prone to human error!
         print(a_file.read())
 ```
 
-But by using annotations we can avoid repeating the `path` of the file, and access the artifact as if it's a regular Python argument of the given type:
+By using annotations we can avoid repeating the `path` of the file, and your function can use the variable directly as a
+`Path` object, with its value already set to the given path:
 
 ```python
-@script()
+@script(constructor="runner")
 def read_artifact(an_artifact: Annotated[Path, Artifact(name="my-artifact", path="/tmp/file")]):
     print(an_artifact.read_text())
 ```
 
-The path duplication is no longer necessary since `an_artifact` is a `Path` object.
-
 The fields allowed in the `Artifact` annotations are: `name`, `path`, and `loader`.
 
-For `Artifact`s, we allow three types of loaders. Using `ArtifactLoader`, we have `file`, `json`, 
-and `None`.
+#### Artifact Loaders
 
-With no loader, the `path` attribute of `Artifact` is extracted and can be subsequently used in 
-the function body by referring to the function parameter. This can be seen above.
+In case you want to load an object directly from the Artifact path, we allow two types of loaders besides the default
+`Path` behaviour used when no loader is specified. The `ArtifactLoader` enum provides `file` and `json` loaders.
 
-When the loader is set to `file`, the function parameter will be the contents of the file 
-stored at `path`. 
+##### `None` loader
+With `None` set as the loader (which is by default) in the Artifact annotation, the `path` attribute of `Artifact` is
+extracted and used to provide a `pathlib.Path` object for the given argument, which can be used directly in the function
+body. The following example is the same as above except for explicitly setting the loader to `None`:
 
 ```python
-@script()
+@script(constructor="runner")
 def read_artifact(
-    an_artifact: Annotated[str, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=ArtifactLoader.file)]
+    an_artifact: Annotated[Path, Artifact(name="my-artifact", path="/tmp/file", loader=None)]
+):
+    print(an_artifact.read_text())
+```
+
+##### `file` loader
+
+When the loader is set to `file`, the function parameter type should be `str`, and will contain the contents string
+representation of the file stored at `path` (essentially performing `path.read_text()` automatically):
+
+```python
+@script(constructor="runner")
+def read_artifact(
+    an_artifact: Annotated[str, Artifact(name="my-artifact", path="/tmp/file", loader=ArtifactLoader.file)]
 ) -> str:
     return an_artifact
 ```
 
-This loads the contents of the file at `ARTIFACT_PATH` to the argument `an_artifact` and subsequently 
-can be used as a string inside the function.
+This loads the contents of the file at `"/tmp/file"` to the argument `an_artifact` and subsequently can be used as a
+string inside the function.
 
-When the loader is set to `json`, the contents of the file at `path` are 
-read and parsed to `json`.
+##### `json` loader
+
+When the loader is set to `json`, the contents of the file at `path` are read and parsed to a dictionary via `json.load`
+(essentially performing `json.load(path.open())` automatically). By specifying a Pydantic type, this dictionary can even
+be automatically parsed to that type:
 
 ```python
 class MyArtifact(BaseModel):
@@ -212,33 +234,32 @@ class MyArtifact(BaseModel):
     b = "b"
 
 
-@script()
+@script(constructor="runner")
 def read_artifact(
-    an_artifact: Annotated[MyArtifact, Artifact(name="my-artifact", path=ARTIFACT_PATH, loader=ArtifactLoader.json)]
+    an_artifact: Annotated[MyArtifact, Artifact(name="my-artifact", path="/tmp/file", loader=ArtifactLoader.json)]
 ) -> str:
     return an_artifact.a + an_artifact.b
 ```
 
-Here, we have a json representation of `MyArtifact` stored at `ARTIFACT_PATH`. We can load it with `ArtifactLoader.json`
-and then use `an_artifact` as an instance of `MyArtifact` inside the function.
+Here, we have a json representation of `MyArtifact` such as `{"a": "hello ", "b": "world"}` stored at `"/tmp/file"`. We
+can load it with `ArtifactLoader.json` and then use `an_artifact` as an instance of `MyArtifact` inside the function, so
+the function will return `"hello world"`.
+
+##### Function parameter name aliasing
 
 Script annotations can work on top of the `RunnerScriptConstructor` for name aliasing of function
 parameters, in particular to allow a public `kebab-case` parameter, while using a `snake_case`
 Python function parameter. When using a `RunnerScriptConstructor`, an environment variable
 `hera__script_annotations` will be added to the Script template (visible in the exported YAML file).
-Script annotations also work with the regular `InlineScriptConstructor` for
-generating valid template parameters in the yaml instead of adding them in the `@script` decorator.
 
-This feature can be enabled by setting the `experimental_feature` flag `script_annotations`
+#### Outputs
 
-```py
-global_config.experimental_features["script_annotations"] = True
-```
+> Note: Output annotations are only supported when used with the `RunnerScriptConstructor`.
 
-##### Outputs
-The annotations can also be used for outputs. An example can be seen [here](../../examples/workflows/script_annoations_outputs.md)
+Annotations can also be used for outputs. An example can be seen
+[here](../../examples/workflows/script_annotations_outputs).
 
-Hera offers this for a simple hello world example:
+For a simple hello world output artifact example we currently have:
 ```python
 @script(outputs=Artifact(name="hello-art", path="/tmp/hello_world.txt"))
 def whalesay():
@@ -254,32 +275,50 @@ def func() -> Annotated[str, Artifact(name="hello-art", path="/tmp/hello_world.t
 ```
 
 The idea is to save the returned value in a file according to this schema:
-`/hera/outputs/parameters/<name>`
-`/hera/outputs/artifacts/<name>`
-for easy access in subsequent `Steps`/`Tasks`. The output is also exposed in the `outputs` section of the resulting yaml. 
+* `/hera/outputs/parameters/<name>`
+* `/hera/outputs/artifacts/<name>`
 
-The item returned from the function can be of any serialisable Pydantic type. That arbitrary type needs to be 
-`Annotated` with an `Artifact` or `Parameter`. One of 
-these is needed because we have to know where to save it to file at the end. The `Parameter`/`Artifact`'s `name` will 
-be taken and used for creating the path for saving the item. If the annotation is `Artifact` and it contains a `path`, 
-we use that `path` to save the output.
+The output is also exposed in the `outputs` section of the resulting yaml. 
+
+The item returned from the function can be of any serialisable Pydantic type (or basic Python type) and needs to be
+`Annotated` with an `Artifact` or `Parameter`. The `Parameter`/`Artifact`'s `name` will be taken and used for creating
+the path for saving the item. If the annotation is `Artifact` and it contains a `path`, we use that `path` to save the
+output. See below for examples of an output `Parameter` or `Artifact`:
+
+Parameter output:
 
 ```python
 @script()
-def func(...) -> Annotated[arbitrary_pydantic_type, OutputItem]:
-    return output
+def func(...) -> Annotated[arbitrary_pydantic_type, Parameter(name="my-output")]:
+    return output  # will be saved to /hera/outputs/parameters/my-output
 ```
 
-We also allow the return type to be a `Tuple` of arbitrary Pydantic types with `Parameter`/`Artifact` annotations.
+Artifact output:
+
 ```python
 @script()
-def func(...) -> Tuple[Annotated[arbitrary_pydantic_type_a, Artifact/Parameter], Annotated[arbitrary_pydantic_type_b, Artifact/Parameter], ...]:
-    return output_a, output_b
+def func(...) -> Annotated[arbitrary_pydantic_type, Artifact(name="my-output")]:
+    return output  # will be saved to /hera/outputs/artifacts/my-output
 ```
 
-We also want to allow `Parameter`/`Artifact`s as part of the function signature, allowing users to access/write to the 
-output path as if it were a `Path` object. They will require an additional field `output=True` to distinguish 
-them from the input parameters but will otherwise behave in the same way.
+For multiple outputs, the return type should be a `Tuple` of arbitrary Pydantic types with individual
+`Parameter`/`Artifact` annotations, and you should return a tuple from the function matching these types:
+```python
+@script()
+def func(...) -> Tuple[
+    Annotated[arbitrary_pydantic_type_a, Artifact],
+    Annotated[arbitrary_pydantic_type_b, Parameter],
+    Annotated[arbitrary_pydantic_type_c, Parameter],
+    ...]:
+    return output_a, output_b, output_c
+```
+
+Hera also allows output `Parameter`/`Artifact`s as part of the function signature when specified as a `Path` type,
+allowing users to write to the output path, without needing an explicit return. They require an additional field
+`output=True` to distinguish them from the input parameters and must have an underlying `Path` type (or another type
+that will write to disk). For `Parameters`, they will have the path of `/hera/outputs/parameters/<name>`, which can be
+changed by setting the parameter's `value_from` argument. For `Artifacts`, they will have a path of
+`/hera/outputs/artifacts/<name>`, which can be changed by setting the `path` of the `Artifact`.
 
 ```python
 @script()
@@ -288,7 +327,7 @@ def func(..., output_param: Annotated[Path, Parameter(output=True, global_name="
     return output
 ```
 
-The parent outputs directory `/hera/outputs` can be overwritten by the user. This is done by adding 
+The outputs directory `/hera/outputs` can be set by the user. This is done by adding:
 ```python
 global_config.set_class_defaults(RunnerScriptConstructor, outputs_directory="user/chosen/outputs")
 ```

--- a/docs/getting-started/walk-through/advanced-hera-features.md
+++ b/docs/getting-started/walk-through/advanced-hera-features.md
@@ -168,12 +168,21 @@ The fields allowed in the `Parameter` annotations are: `name`, `default`, `enum`
 
 
 The feature is even more powerful for `Artifact`s. In Hera we are currently able to specify `Artifact`s in `inputs`, but
-have no way to programmatically link the given path to the code within the function:
+the given path is not programmatically linked to the code within the function unless defined outside the scope of the
+function:
 
 ```python
 @script(inputs=Artifact(name="my-artifact", path="/tmp/file"))
 def read_artifact():
     with open("/tmp/file") as a_file:  # Repeating "/tmp/file" is prone to human error!
+        print(a_file.read())
+
+# or
+
+MY_PATH = "/tmp/file"  # Now accessible outside of the function scope!
+@script(inputs=Artifact(name="my-artifact", path=MY_PATH))
+def read_artifact():
+    with open(MY_PATH) as a_file:
         print(a_file.read())
 ```
 

--- a/examples/workflows/script-annotations-outputs.yaml
+++ b/examples/workflows/script-annotations-outputs.yaml
@@ -20,10 +20,16 @@ spec:
     outputs:
       artifacts:
       - name: successor2
+        path: user/chosen/outputs/artifacts/successor2
       - name: successor4
+        path: user/chosen/outputs/artifacts/successor4
       parameters:
       - name: successor
+        valueFrom:
+          path: user/chosen/outputs/parameters/successor
       - name: successor3
+        valueFrom:
+          path: user/chosen/outputs/parameters/successor3
     script:
       args:
       - -m

--- a/examples/workflows/script_annotations_outputs.py
+++ b/examples/workflows/script_annotations_outputs.py
@@ -24,8 +24,8 @@ def script_param_artifact_in_function_signature_and_return_type(
     successor: Annotated[Path, Parameter(name="successor", output=True)],
     successor2: Annotated[Path, Artifact(name="successor2", output=True)],
 ) -> Tuple[Annotated[int, Parameter(name="successor3")], Annotated[int, Artifact(name="successor4")]]:
-    successor.write_text(a_number + 1)
-    successor2.write_text(a_number + 2)
+    successor.write_text(str(a_number + 1))
+    successor2.write_text(str(a_number + 2))
     return a_number + 3, a_number + 4
 
 

--- a/src/hera/workflows/parameter.py
+++ b/src/hera/workflows/parameter.py
@@ -107,7 +107,7 @@ class Parameter(_ModelParameter):
     @classmethod
     def _get_input_attributes(cls):
         """Return the attributes used for input parameter annotations."""
-        return ["enum", "description", "default", "name", "value_from"]
+        return ["enum", "description", "default", "name", "value", "value_from"]
 
 
 __all__ = ["Parameter"]

--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -108,8 +108,10 @@ def _map_keys(function: Callable, kwargs: dict) -> dict:
     mapped_kwargs = {}
     for param_name, param in inspect.signature(function).parameters.items():
         if get_origin(param.annotation) is Annotated and isinstance(get_args(param.annotation)[1], Parameter):
+            # TODO: What about parameters marked as output? Do we automatically add a value_from?
             mapped_kwargs[param_name] = kwargs[get_args(param.annotation)[1].name]
         elif get_origin(param.annotation) is Annotated and isinstance(get_args(param.annotation)[1], Artifact):
+            # TODO: What about artifacts marked as output? Do we automatically add a path?
             if get_args(param.annotation)[1].loader == ArtifactLoader.json.value:
                 path = Path(get_args(param.annotation)[1].path)
                 mapped_kwargs[param_name] = json.load(path.open())

--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, List, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Tuple, Union, cast
 
 from pydantic import validate_arguments
 from typing_extensions import get_args, get_origin
@@ -14,7 +14,7 @@ from typing_extensions import get_args, get_origin
 from hera.shared.serialization import serialize
 from hera.workflows import Artifact, Parameter
 from hera.workflows.artifact import ArtifactLoader
-from hera.workflows.script import _extract_output_annotations
+from hera.workflows.script import _extract_return_annotation_output
 
 try:
     from typing import Annotated  # type: ignore
@@ -65,7 +65,7 @@ def _parse(value, key, f):
         The parsed value.
 
     """
-    if _is_str_kwarg_of(key, f) or _is_artifact_loaded(key, f):
+    if _is_str_kwarg_of(key, f) or _is_artifact_loaded(key, f) or _is_output_kwarg(key, f):
         return value
     try:
         return json.loads(value)
@@ -81,8 +81,8 @@ def _is_str_kwarg_of(key: str, f: Callable):
     try:
         return issubclass(type_, str)
     except TypeError:
-        # If this happens then it means that the annotation is complex type annotation
-        # and may
+        # If this happens then it means that the annotation is a more complex type annotation
+        # and may be interpretable by the Hera runner
         return False
 
 
@@ -96,6 +96,16 @@ def _is_artifact_loaded(key, f):
     )
 
 
+def _is_output_kwarg(key, f):
+    """Check if param `key` of function `f` is an output Artifact/Parameter."""
+    param = inspect.signature(f).parameters[key]
+    return (
+        get_origin(param.annotation) is Annotated
+        and isinstance(get_args(param.annotation)[1], (Artifact, Parameter))
+        and get_args(param.annotation)[1].output
+    )
+
+
 def _map_keys(function: Callable, kwargs: dict) -> dict:
     """Change the kwargs's keys to use the Python name instead of the parameter name which could be kebab case.
 
@@ -105,28 +115,47 @@ def _map_keys(function: Callable, kwargs: dict) -> dict:
     if os.environ.get("hera__script_annotations", None) is None:
         return {key.replace("-", "_"): value for key, value in kwargs.items()}
 
-    mapped_kwargs = {}
-    for param_name, param in inspect.signature(function).parameters.items():
-        if get_origin(param.annotation) is Annotated and isinstance(get_args(param.annotation)[1], Parameter):
-            # TODO: What about parameters marked as output? Do we automatically add a value_from?
-            mapped_kwargs[param_name] = kwargs[get_args(param.annotation)[1].name]
-        elif get_origin(param.annotation) is Annotated and isinstance(get_args(param.annotation)[1], Artifact):
-            # TODO: What about artifacts marked as output? Do we automatically add a path?
-            if get_args(param.annotation)[1].loader == ArtifactLoader.json.value:
-                path = Path(get_args(param.annotation)[1].path)
-                mapped_kwargs[param_name] = json.load(path.open())
-            elif get_args(param.annotation)[1].loader == ArtifactLoader.file.value:
-                path = Path(get_args(param.annotation)[1].path)
-                mapped_kwargs[param_name] = path.read_text()
-            elif get_args(param.annotation)[1].loader is None:
-                mapped_kwargs[param_name] = get_args(param.annotation)[1].path
+    mapped_kwargs: Dict[str, Any] = {}
+    for param_name, func_param in inspect.signature(function).parameters.items():
+        if get_origin(func_param.annotation) is Annotated:
+            annotated_type = get_args(func_param.annotation)[1]
+
+            if isinstance(annotated_type, Parameter):
+                if annotated_type.output:
+                    if annotated_type.value_from and annotated_type.value_from.path:
+                        mapped_kwargs[param_name] = Path(annotated_type.value_from.path)
+                    else:
+                        mapped_kwargs[param_name] = _get_outputs_path(annotated_type)
+                    # Automatically create the parent directory (if required)
+                    mapped_kwargs[param_name].parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    mapped_kwargs[param_name] = kwargs[annotated_type.name]
+            elif isinstance(annotated_type, Artifact):
+                if annotated_type.output:
+                    if annotated_type.path:
+                        mapped_kwargs[param_name] = Path(annotated_type.path)
+                    else:
+                        mapped_kwargs[param_name] = _get_outputs_path(annotated_type)
+                    # Automatically create the parent directory (if required)
+                    mapped_kwargs[param_name].parent.mkdir(parents=True, exist_ok=True)
+                elif annotated_type.path:
+                    if annotated_type.loader == ArtifactLoader.json.value:
+                        path = Path(annotated_type.path)
+                        mapped_kwargs[param_name] = json.load(path.open())
+                    elif annotated_type.loader == ArtifactLoader.file.value:
+                        path = Path(annotated_type.path)
+                        mapped_kwargs[param_name] = path.read_text()
+                    elif annotated_type.loader is None:
+                        mapped_kwargs[param_name] = annotated_type.path
         else:
             mapped_kwargs[param_name] = kwargs[param_name]
+
     return mapped_kwargs
 
 
-def _save_outputs(
-    function_results: Union[Tuple[Any], Any], output_destinations: List[Tuple[type, Union[Parameter, Artifact]]]
+def _save_annotated_return_outputs(
+    function_results: Union[Tuple[Any], Any],
+    output_destinations: List[Tuple[type, Union[Parameter, Artifact]]],
 ) -> None:
     """Save the results of the function to the specified output destinations.
 
@@ -208,10 +237,12 @@ def _runner(entrypoint: str, kwargs_list: Any) -> Any:
     function = _ignore_unmatched_kwargs(function)
 
     if os.environ.get("hera__script_annotations", None) is not None:
-        output_annotations = _extract_output_annotations(function)
+        output_annotations = _extract_return_annotation_output(function)
 
         if output_annotations:
-            _save_outputs(function(**kwargs), output_annotations)
+            # This will save outputs returned from the function only. Any function parameters/artifacts marked as
+            # outputs should be written to within the function itself.
+            _save_annotated_return_outputs(function(**kwargs), output_annotations)
             return None
 
     return function(**kwargs)

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -12,7 +12,6 @@ from functools import wraps
 from typing import (
     Any,
     Callable,
-    Dict,
     List,
     Optional,
     Tuple,
@@ -50,9 +49,9 @@ from hera.workflows.models import (
     ScriptTemplate as _ModelScriptTemplate,
     SecurityContext,
     Template as _ModelTemplate,
+    ValueFrom,
 )
 from hera.workflows.parameter import MISSING, Parameter
-from hera.workflows.protocol import Inputable
 from hera.workflows.steps import Step
 from hera.workflows.task import Task
 from hera.workflows.volume import EmptyDirVolume
@@ -237,7 +236,7 @@ class Script(
         func_artifacts: List[Artifact] = []
         if callable(self.source):
             if global_config.experimental_features["script_annotations"]:
-                func_parameters, func_artifacts = _get_parameters_and_artifacts_from_callable(self.source)
+                func_parameters, func_artifacts = _get_inputs_from_callable(self.source)
             else:
                 func_parameters = _get_parameters_from_callable(self.source)
 
@@ -252,8 +251,12 @@ class Script(
         if not global_config.experimental_features["script_annotations"]:
             return outputs
 
-        out_parameters, out_artifacts = _get_outputs_from_callable(self.source)
-        func_parameters, func_artifacts = _get_outputs_from_callable_signature(self.source)
+        outputs_directory = None
+        if isinstance(self.constructor, RunnerScriptConstructor):
+            outputs_directory = self.constructor.outputs_directory or self.constructor.DEFAULT_HERA_OUTPUTS_DIRECTORY
+
+        out_parameters, out_artifacts = _get_outputs_from_return_annotation(self.source, outputs_directory)
+        func_parameters, func_artifacts = _get_outputs_from_parameter_annotations(self.source, outputs_directory)
         func_parameters.extend(out_parameters)
         func_artifacts.extend(out_artifacts)
 
@@ -273,15 +276,15 @@ class Script(
             return current_io
         if current_io is None:
             if output:
-                current_io = ModelOutputs(
+                return ModelOutputs(
                     parameters=[p.as_output() for p in func_parameters] or None,
                     artifacts=[a._build_artifact() for a in func_artifacts] or None,
                 )
-            else:
-                current_io = ModelInputs(
-                    parameters=[p.as_input() for p in func_parameters] or None,
-                    artifacts=[a._build_artifact() for a in func_artifacts] or None,
-                )
+
+            return ModelInputs(
+                parameters=[p.as_input() for p in func_parameters] or None,
+                artifacts=[a._build_artifact() for a in func_artifacts] or None,
+            )
 
         seen_params = {p.name for p in current_io.parameters or []}
         seen_artifacts = {a.name for a in current_io.artifacts or []}
@@ -334,32 +337,37 @@ def _get_parameters_from_callable(source: Callable) -> List[Parameter]:
     return parameters
 
 
-def _get_outputs_from_callable(
+def _get_outputs_from_return_annotation(
     source: Callable,
+    outputs_directory: Optional[str],
 ) -> Tuple[List[Parameter], List[Artifact]]:
-    """Look through the function signature return and find all the output Parameters and Artifacts defined there."""
+    """Returns a tuple of output Parameters and Artifacts defined in the function signature's return annotation."""
     parameters = []
     artifacts = []
 
-    if get_origin(inspect.signature(source).return_annotation) is Annotated:
-        annotation = get_args(inspect.signature(source).return_annotation)[1]
+    def append_annotation(annotation: Union[Artifact, Parameter]):
         if isinstance(annotation, Artifact):
+            if annotation.path is None and outputs_directory is not None:
+                annotation.path = outputs_directory + f"/artifacts/{annotation.name}"
             artifacts.append(annotation)
         elif isinstance(annotation, Parameter):
+            if annotation.value_from is None and outputs_directory is not None:
+                annotation.value_from = ValueFrom(path=outputs_directory + f"/parameters/{annotation.name}")
             parameters.append(annotation)
-    elif get_origin(inspect.signature(source).return_annotation) is tuple:
-        for a in get_args(inspect.signature(source).return_annotation):
-            annotation = get_args(a)[1]
-            if isinstance(annotation, Artifact):
-                artifacts.append(annotation)
-            elif isinstance(annotation, Parameter):
-                parameters.append(annotation)
 
+    if get_origin(inspect.signature(source).return_annotation) is Annotated:
+        append_annotation(get_args(inspect.signature(source).return_annotation)[1])
+    elif get_origin(inspect.signature(source).return_annotation) is tuple:
+        for annotation in get_args(inspect.signature(source).return_annotation):
+            append_annotation(get_args(annotation)[1])
     return parameters, artifacts
 
 
-def _get_outputs_from_callable_signature(source: Callable) -> Tuple[List[Parameter], List[Artifact]]:
-    """Look through the function signature parameters and find all Parameters and Artifacts annotated as output."""
+def _get_outputs_from_parameter_annotations(
+    source: Callable,
+    outputs_directory: Optional[str],
+) -> Tuple[List[Parameter], List[Artifact]]:
+    """Returns a tuple of output Parameters and Artifacts defined in the function signature parameters."""
     parameters: List[Parameter] = []
     artifacts: List[Artifact] = []
 
@@ -367,93 +375,124 @@ def _get_outputs_from_callable_signature(source: Callable) -> Tuple[List[Paramet
         if get_origin(p.annotation) is not Annotated:
             continue
         annotation = get_args(p.annotation)[1]
-        if not hasattr(annotation, "output") or not annotation.output:
+
+        if not isinstance(annotation, (Artifact, Parameter)):
+            raise ValueError(f"The output {type(annotation)} cannot be used as an annotation.")
+
+        if not annotation.output:
             continue
 
-        output_type = type(annotation)
-        assert output_type is Artifact or output_type is Parameter
-
-        kwargs: Dict[str, Any] = {}
-        if isinstance(output_type, Inputable):
-            for attr in output_type._get_input_attributes():
-                if hasattr(annotation, attr) and getattr(annotation, attr) is not None:
-                    kwargs[attr] = getattr(annotation, attr)
-        else:
-            raise ValueError(f"The output {output_type} cannot be an input annotation.")
+        new_object = annotation.copy()
 
         # use the function parameter name when not provided by user
-        if "name" not in kwargs:
-            kwargs["name"] = name
+        if not new_object.name:
+            new_object.name = name
 
-        new_object = output_type(**kwargs)
+        if isinstance(new_object, Parameter) and new_object.value_from is None and outputs_directory is not None:
+            new_object.value_from = ValueFrom(path=outputs_directory + f"/parameters/{new_object.name}")
+        elif isinstance(new_object, Artifact) and new_object.path is None and outputs_directory is not None:
+            new_object.path = outputs_directory + f"/artifacts/{new_object.name}"
 
-        if isinstance(get_args(p.annotation)[1], Artifact):
+        if isinstance(new_object, Artifact):
             artifacts.append(new_object)
-        elif isinstance(get_args(p.annotation)[1], Parameter):
+        elif isinstance(new_object, Parameter):
             parameters.append(new_object)
 
     return parameters, artifacts
 
 
-def _get_parameters_and_artifacts_from_callable(source: Callable) -> Tuple[List[Parameter], List[Artifact]]:
-    """Look through the function signature and find all Parameters and Artifacts *not* annotated as output."""
+def _get_inputs_from_callable(source: Callable) -> Tuple[List[Parameter], List[Artifact]]:
+    """Return all inputs from the function.
+
+    This includes all basic Python function parameters, and all parameters with a Parameter or Artifact annotation.
+    """
     parameters = []
     artifacts = []
 
-    for p in inspect.signature(source).parameters.values():
-        if get_origin(p.annotation) is Annotated and isinstance(get_args(p.annotation)[1], Artifact):
-            annotation = get_args(p.annotation)[1]
-            if hasattr(annotation, "output") and annotation.output:
-                continue
-            mytype = type(annotation)
-            kwargs = {}
-            for attr in mytype._get_input_attributes():
-                if hasattr(annotation, attr) and getattr(annotation, attr) is not None:
-                    kwargs[attr] = getattr(annotation, attr)
-
-            artifact = mytype(**kwargs)
-            artifacts.append(artifact)
-        else:
-            if p.default != inspect.Parameter.empty and p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
-                default = p.default
+    for func_param in inspect.signature(source).parameters.values():
+        if get_origin(func_param.annotation) is not Annotated:
+            if (
+                func_param.default != inspect.Parameter.empty
+                and func_param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            ):
+                default = func_param.default
             else:
                 default = MISSING
 
-            param = Parameter(name=p.name, default=default)
-            parameters.append(param)
+            parameters.append(Parameter(name=func_param.name, default=default))
+        else:
+            annotation = get_args(func_param.annotation)[1]
 
-            if get_origin(p.annotation) is not Annotated:
+            if not isinstance(annotation, (Artifact, Parameter)):
+                raise ValueError(f"The output {type(annotation)} cannot be used as an annotation.")
+
+            if annotation.output:
                 continue
 
-            annotation = get_args(p.annotation)[1]
+            # Create a new object so we don't modify the Workflow itself
+            new_object = annotation.copy()
+            if not new_object.name:
+                new_object.name = func_param.name
 
-            if hasattr(annotation, "output") and annotation.output:
-                parameters.pop()
-                continue
-
-            if not isinstance(annotation, Parameter):
-                continue
-
-            for attr in Parameter._get_input_attributes():
-                if not hasattr(annotation, attr) or getattr(annotation, attr) is None:
-                    continue
-
-                if attr == "default" and param.default is not None:
-                    raise ValueError(
-                        "The default cannot be set via both the function parameter default and the annotation's default"
-                    )
-                setattr(param, attr, getattr(annotation, attr))
+            if isinstance(new_object, Artifact):
+                artifacts.append(new_object)
+            elif isinstance(new_object, Parameter):
+                if func_param.default != inspect.Parameter.empty:
+                    if new_object.default is not None:
+                        raise ValueError(
+                            "default cannot be set via both the function parameter default and the Parameter's default"
+                        )
+                    new_object.default = str(func_param.default)
+                parameters.append(new_object)
 
     return parameters, artifacts
 
 
+def _extract_return_annotation_output(source: Callable) -> List:
+    """Extract the output annotations from the return annotation of the function signature."""
+    output = []
+
+    origin_type = get_origin(inspect.signature(source).return_annotation)
+    annotation_args = get_args(inspect.signature(source).return_annotation)
+    if origin_type is Annotated:
+        output.append(annotation_args)
+    elif origin_type is tuple:
+        for annotated_type in annotation_args:
+            output.append(get_args(annotated_type))
+
+    return output
+
+
+def _extract_all_output_annotations(source: Callable) -> List:
+    """Extract the output annotations out of the function signature.
+
+    This includes parameters marked as outputs and the return annotation of `source`.
+    """
+    output = []
+
+    for _, func_param in inspect.signature(source).parameters.items():
+        if get_origin(func_param.annotation) is Annotated:
+            annotation_args = get_args(func_param.annotation)
+            annotated_type = annotation_args[1]
+            if isinstance(annotated_type, (Artifact, Parameter)) and annotated_type.output:
+                output.append(annotation_args)
+
+    output.extend(_extract_return_annotation_output(source))
+
+    return output
+
+
 def _output_annotations_used(source: Callable) -> bool:
-    """Check if output annotations are used."""
+    """Check if any output annotations are used.
+
+    This includes parameters marked as outputs and the return annotation of `source`.
+    """
     if not global_config.experimental_features["script_annotations"]:
         return False
     if not callable(source):
         return False
-    return _extract_output_annotations(cast(Callable, source)) is not None
+
+    return bool(_extract_all_output_annotations(source))
 
 
 FuncIns = ParamSpec("FuncIns")  # For input types of given func to script decorator
@@ -549,20 +588,6 @@ def script(**script_kwargs):
         return task_wrapper
 
     return script_wrapper
-
-
-def _extract_output_annotations(function: Callable) -> Optional[List]:
-    """Extract the output annotations out of the function signature."""
-    output = []
-    origin_type = get_origin(inspect.signature(function).return_annotation)
-    annotation_args = get_args(inspect.signature(function).return_annotation)
-    if origin_type is Annotated:
-        output.append(annotation_args)
-    elif origin_type is tuple:
-        for annotation in annotation_args:
-            output.append(get_args(annotation))
-
-    return output or None
 
 
 class InlineScriptConstructor(ScriptConstructor):

--- a/tests/script_annotations_outputs/script_annotations_output.py
+++ b/tests/script_annotations_outputs/script_annotations_output.py
@@ -72,11 +72,13 @@ def script_param_no_name(a_number) -> Annotated[int, Parameter()]:
 
 
 @script(constructor="runner")
-def script_param_in_function_signature(
+def script_outputs_in_function_signature(
     a_number: Annotated[int, Parameter(name="a_number")],
     successor: Annotated[Path, Parameter(name="successor", output=True)],
+    successor2: Annotated[Path, Artifact(name="successor2", output=True)],
 ):
-    successor.write_text(a_number + 1)
+    successor.write_text(str(a_number + 1))
+    successor2.write_text(str(a_number + 2))
 
 
 with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:

--- a/tests/script_annotations_outputs/script_annotations_output_custom_output_directory.py
+++ b/tests/script_annotations_outputs/script_annotations_output_custom_output_directory.py
@@ -1,0 +1,29 @@
+"""Test the correctness of the Output annotations. The test inspects the inputs and outputs of the workflow."""
+
+try:
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
+
+from pathlib import Path
+
+from hera.shared import global_config
+from hera.workflows import Parameter, RunnerScriptConstructor, Workflow, script
+from hera.workflows.steps import Steps
+
+global_config.experimental_features["script_runner"] = True
+global_config.experimental_features["script_annotations"] = True
+global_config.set_class_defaults(RunnerScriptConstructor, outputs_directory="/user/chosen/outputs")
+
+
+@script(constructor="runner")
+def script_param_in_fun_sig(
+    a_number: Annotated[int, Parameter(name="a_number")],
+    successor: Annotated[Path, Parameter(name="successor", output=True)],
+):
+    successor.write_text(str(a_number + 1))
+
+
+with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
+    with Steps(name="my_steps") as s:
+        script_param_in_fun_sig(arguments={"a_number": 3})

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -1,16 +1,16 @@
 import importlib
 
-from hera.workflows.script import _get_parameters_and_artifacts_from_callable
+from hera.workflows.script import _get_inputs_from_callable
 
 
-def test_get_parameters_and_artifacts_from_callable_simple_params():
+def test_get_inputs_from_callable_simple_params():
     # GIVEN
     entrypoint = "tests.helper:my_function"
     module, function_name = entrypoint.split(":")
     function = getattr(importlib.import_module(module), function_name)
 
     # WHEN
-    params, artifacts = _get_parameters_and_artifacts_from_callable(function)
+    params, artifacts = _get_inputs_from_callable(function)
 
     # THEN
     assert params is not None
@@ -25,21 +25,21 @@ def test_get_parameters_and_artifacts_from_callable_simple_params():
     assert b.name == "b"
 
 
-def test_get_parameters_and_artifacts_from_callable_no_params():
+def test_get_inputs_from_callable_no_params():
     # GIVEN
     entrypoint = "tests.helper:no_param_function"
     module, function_name = entrypoint.split(":")
     function = getattr(importlib.import_module(module), function_name)
 
     # WHEN
-    params, artifacts = _get_parameters_and_artifacts_from_callable(function)
+    params, artifacts = _get_inputs_from_callable(function)
 
     # THEN
     assert params == []
     assert artifacts == []
 
 
-def test_get_parameters_and_artifacts_from_callable_simple_artifact(tmp_path, monkeypatch):
+def test_get_inputs_from_callable_simple_artifact(tmp_path, monkeypatch):
     # GIVEN
     if not tmp_path.is_file():
         tmp_path = tmp_path / "my_file.txt"
@@ -57,7 +57,7 @@ def test_get_parameters_and_artifacts_from_callable_simple_artifact(tmp_path, mo
     function = getattr(md, function_name)
 
     # WHEN
-    params, artifacts = _get_parameters_and_artifacts_from_callable(function)
+    params, artifacts = _get_inputs_from_callable(function)
 
     # THEN
     assert params == []


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes bugs in #741
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, output Artifacts/Parameters contained in function return annotations or function parameter annotations where marked as output don't output their paths in the yaml. The runner also does not pre-load function input parameters marked as outputs as Path objects for the given kwarg.

This PR fixes output annotations for these use cases and makes the tests more robust. The "advanced-hera-features" doc was also edited.

I also fixed the codebase for use with VSCode's pytest debugger.
