### PR TITLE
Fix indentation error for staticmethods decorated as scripts

### DIFF
--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -566,21 +566,21 @@ def script(**script_kwargs):
             Another callable that represents the `Script` object `__call__` method when in a Steps or DAG context,
             otherwise return the callable function unchanged.
         """
+        # instance methods are wrapped in `staticmethod`. Hera can capture that type and extract the underlying
+        # function for remote submission since it does not depend on any class or instance attributes, so it is
+        # submittable
+        if isinstance(func, staticmethod):
+            source: Callable = func.__func__
+        else:
+            source = func
+
         if "name" in script_kwargs:
             # take the client-provided `name` if it is submitted, pop the name for otherwise there will be two
             # kwargs called `name`
             name = script_kwargs.pop("name")
         else:
             # otherwise populate the `name` from the function name
-            name = func.__name__.replace("_", "-")
-
-        # instance methods are wrapped in `staticmethod`. Hera can capture that type and extract the underlying
-        # function for remote submission since it does not depend on any class or instance attributes, so it is
-        # submittable
-        if isinstance(func, staticmethod):
-            source = func.__func__
-        else:
-            source = func
+            name = source.__name__.replace("_", "-")
 
         s = Script(name=name, source=source, **script_kwargs)
 

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -85,3 +85,27 @@ def test_script_name_kwarg_in_decorator():
 
     # THEN
     assert w.templates[0].name == "my-alt-name"
+
+
+def test_script_parses_static_method():
+    class Test:
+        @script()
+        @staticmethod
+        def my_func():
+            print(42)
+
+        @script(name="test")
+        @staticmethod
+        def my_func2():
+            print(42)
+
+    # GIVEN my_func above
+    # WHEN
+    with Workflow(name="test-script") as w:
+        Test.my_func()
+        Test.my_func2()
+
+    # THEN
+    assert len(w.templates) == 2
+    assert w.templates[0].name == "my-func"
+    assert w.templates[1].name == "test"


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, users who submit static methods as `Script` payloads will receive an indentation error. 

Example 

```python
from hera.workflows import DAG, Workflow, script

class Foo:
    @script()
    @staticmethod
    def foo():
        print(42)

with Workflow(generate_name="fv-test-", entrypoint="d") as w:
    with DAG(name="d"):
        Foo.foo()

w.create()
```

```
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/_mixins.py", line 1193, in build_model
    getattr(hera_obj, mapper.builder.__name__)()
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/workflow.py", line 131, in _build_templates
    templates.append(template._build_template())
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/script.py", line 186, in _build_template
    script=self._build_script(),
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/script.py", line 218, in _build_script
    source=self.constructor.generate_source(self),
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/script.py", line 416, in generate_source
    content = roundtrip(inspect.getsource(instance.source)).splitlines()
  File "/Users/flaviuvadan/.virtualenvs/dyno-650429e1-py3.10.9/lib/python3.10/site-packages/hera/workflows/_unparse.py", line 953, in roundtrip
    tree = ast.parse(source)
  File "/Users/flaviuvadan/.pyenv-x86_64/versions/3.10.9/lib/python3.10/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    @script()
IndentationError: unexpected indent
```

This happens because Hera does not dedent + unpack the function. This PR adds the necessary dedent call + function unpacking. After the change:

![Screenshot 2023-09-06 at 3 11 02 PM](https://github.com/argoproj-labs/hera/assets/18152652/424c8422-2267-48d8-a588-901928dfae76)
