### PR TITLE
Fix errors with underscores in labels 

### DIFF
--- a/docs/examples/workflows/script_annotations_inputs.md
+++ b/docs/examples/workflows/script_annotations_inputs.md
@@ -34,8 +34,8 @@
         print(an_artifact)
 
 
-    with Workflow(generate_name="test-input-annotations-", entrypoint="my_steps") as w:
-        with Steps(name="my_steps") as s:
+    with Workflow(generate_name="test-input-annotations-", entrypoint="my-steps") as w:
+        with Steps(name="my-steps") as s:
             echo_all(
                 arguments=[
                     Parameter(name="an_int", value=1),
@@ -54,9 +54,9 @@
     metadata:
       generateName: test-input-annotations-
     spec:
-      entrypoint: my_steps
+      entrypoint: my-steps
       templates:
-      - name: my_steps
+      - name: my-steps
         steps:
         - - arguments:
               artifacts:

--- a/docs/examples/workflows/script_annotations_outputs.md
+++ b/docs/examples/workflows/script_annotations_outputs.md
@@ -39,8 +39,8 @@
         return a_number + 3, a_number + 4
 
 
-    with Workflow(generate_name="test-output-annotations-", entrypoint="my_steps") as w:
-        with Steps(name="my_steps") as s:
+    with Workflow(generate_name="test-output-annotations-", entrypoint="my-steps") as w:
+        with Steps(name="my-steps") as s:
             script_param_artifact_in_function_signature_and_return_type(arguments={"a_number": 3})
     ```
 
@@ -52,9 +52,9 @@
     metadata:
       generateName: test-output-annotations-
     spec:
-      entrypoint: my_steps
+      entrypoint: my-steps
       templates:
-      - name: my_steps
+      - name: my-steps
         steps:
         - - arguments:
               parameters:
@@ -96,9 +96,9 @@
           source: '{{inputs.parameters}}'
           volumeMounts:
           - mountPath: user/chosen/outputs
-            name: hera__outputs_directory
+            name: hera-outputs-directory
         volumes:
         - emptyDir: {}
-          name: hera__outputs_directory
+          name: hera-outputs-directory
     ```
 

--- a/examples/workflows/script-annotations-inputs.yaml
+++ b/examples/workflows/script-annotations-inputs.yaml
@@ -3,9 +3,9 @@ kind: Workflow
 metadata:
   generateName: test-input-annotations-
 spec:
-  entrypoint: my_steps
+  entrypoint: my-steps
   templates:
-  - name: my_steps
+  - name: my-steps
     steps:
     - - arguments:
           artifacts:

--- a/examples/workflows/script-annotations-outputs.yaml
+++ b/examples/workflows/script-annotations-outputs.yaml
@@ -3,9 +3,9 @@ kind: Workflow
 metadata:
   generateName: test-output-annotations-
 spec:
-  entrypoint: my_steps
+  entrypoint: my-steps
   templates:
-  - name: my_steps
+  - name: my-steps
     steps:
     - - arguments:
           parameters:
@@ -47,7 +47,7 @@ spec:
       source: '{{inputs.parameters}}'
       volumeMounts:
       - mountPath: user/chosen/outputs
-        name: hera__outputs_directory
+        name: hera-outputs-directory
     volumes:
     - emptyDir: {}
-      name: hera__outputs_directory
+      name: hera-outputs-directory

--- a/examples/workflows/script_annotations_inputs.py
+++ b/examples/workflows/script_annotations_inputs.py
@@ -24,8 +24,8 @@ def echo_all(
     print(an_artifact)
 
 
-with Workflow(generate_name="test-input-annotations-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-input-annotations-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_all(
             arguments=[
                 Parameter(name="an_int", value=1),

--- a/examples/workflows/script_annotations_outputs.py
+++ b/examples/workflows/script_annotations_outputs.py
@@ -29,6 +29,6 @@ def script_param_artifact_in_function_signature_and_return_type(
     return a_number + 3, a_number + 4
 
 
-with Workflow(generate_name="test-output-annotations-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-output-annotations-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_artifact_in_function_signature_and_return_type(arguments={"a_number": 3})

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -309,7 +309,7 @@ class Script(
     def _create_hera_outputs_volume(self) -> None:
         """Create the new volume as an EmptyDirVolume if needed for the automatic saving of the hera outputs."""
         assert isinstance(self.constructor, RunnerScriptConstructor)
-        new_volume = EmptyDirVolume(name="hera__outputs_directory", mount_path=self.constructor.outputs_directory)
+        new_volume = EmptyDirVolume(name="hera-outputs-directory", mount_path=self.constructor.outputs_directory)
 
         if not isinstance(self.volumes, list) and self.volumes is not None:
             self.volumes = [self.volumes]

--- a/tests/script_annotations_artifacts/script_annotations_artifact_file.py
+++ b/tests/script_annotations_artifacts/script_annotations_artifact_file.py
@@ -22,6 +22,6 @@ def read_artifact(
     return an_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my-artifact", from_="somewhere")])

--- a/tests/script_annotations_artifacts/script_annotations_artifact_file_with_path.py
+++ b/tests/script_annotations_artifacts/script_annotations_artifact_file_with_path.py
@@ -22,6 +22,6 @@ def read_artifact(
     return an_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my-artifact", from_="somewhere")])

--- a/tests/script_annotations_artifacts/script_annotations_artifact_object.py
+++ b/tests/script_annotations_artifacts/script_annotations_artifact_object.py
@@ -27,6 +27,6 @@ def read_artifact(
     return an_artifact.a + an_artifact.b
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my-artifact", from_="somewhere")])

--- a/tests/script_annotations_artifacts/script_annotations_artifact_path.py
+++ b/tests/script_annotations_artifacts/script_annotations_artifact_path.py
@@ -21,6 +21,6 @@ def read_artifact(an_artifact: Annotated[Path, Artifact(name="my-artifact", path
     return an_artifact.read_text()
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my-artifact", from_="somewhere")])

--- a/tests/script_annotations_artifacts/script_annotations_artifact_wrong_loader.py
+++ b/tests/script_annotations_artifacts/script_annotations_artifact_wrong_loader.py
@@ -22,6 +22,6 @@ def read_artifact(
     return an_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my-artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_new.py
@@ -29,6 +29,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_old.py
@@ -20,6 +20,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_new.py
@@ -31,6 +31,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_old.py
@@ -22,6 +22,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_new.py
@@ -29,6 +29,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_old.py
@@ -20,6 +20,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_new.py
@@ -37,6 +37,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_old.py
@@ -28,6 +28,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_new.py
@@ -39,6 +39,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_old.py
@@ -30,6 +30,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_new.py
@@ -29,6 +29,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_old.py
@@ -20,6 +20,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_new.py
@@ -18,6 +18,6 @@ def read_artifact(my_artifact: Annotated[str, Artifact(name="my_artifact", path=
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_old.py
@@ -10,6 +10,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_new.py
@@ -20,6 +20,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_old.py
@@ -10,6 +10,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
@@ -18,6 +18,6 @@ def read_artifact(my_artifact: Annotated[str, Artifact(name="my_artifact", path=
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_old.py
@@ -10,6 +10,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_new.py
@@ -34,6 +34,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_old.py
@@ -25,6 +25,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_new.py
@@ -29,6 +29,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_old.py
@@ -20,6 +20,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_new.py
@@ -37,6 +37,6 @@ def read_artifact(
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_old.py
@@ -28,6 +28,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_new.py
@@ -18,6 +18,6 @@ def read_artifact(my_artifact: Annotated[str, Artifact(name="my_artifact", path=
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_old.py
@@ -10,6 +10,6 @@ def read_artifact(my_artifact) -> str:
     return my_artifact
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         read_artifact(arguments=[Artifact(name="my_artifact", from_="somewhere")])

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_alias.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_alias.py
@@ -20,6 +20,6 @@ def echo(
     print(a_name)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo(arguments={"a_name": "hello there"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_new.py
@@ -24,6 +24,6 @@ def echo_all(
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_all(arguments={"an_int": 1, "a_bool": True, "a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_old.py
@@ -18,6 +18,6 @@ def echo_all(an_int, a_bool, a_string):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_all(arguments={"an_int": 1, "a_bool": True, "a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_default_both.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_default_both.py
@@ -24,7 +24,7 @@ def echo_old(an_int: Annotated[int, Parameter(name="another_name")] = 1):
     print(an_int)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_new(arguments={"an_int": 1})
         echo_old(arguments={"an_int": 1})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_default_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_default_new.py
@@ -28,8 +28,8 @@ def echo_string(a_string: Annotated[str, Parameter(default="a")]):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_default_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_default_old.py
@@ -19,8 +19,8 @@ def echo_string(a_string="a"):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_description_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_description_new.py
@@ -28,8 +28,8 @@ def echo_string(a_string: Annotated[str, Parameter(description="a_string paramet
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_description_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_description_old.py
@@ -20,8 +20,8 @@ def echo_string(a_string):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_new.py
@@ -28,8 +28,8 @@ def echo_string(a_string: Annotated[str, Parameter(enum=["a", "b", "c"])]):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_old.py
@@ -20,8 +20,8 @@ def echo_string(a_string):
     print(a_string)
 
 
-with Workflow(generate_name="test-artifacts-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         echo_int(arguments={"an_int": 1})
         echo_boolean(arguments={"a_bool": True})
         echo_string(arguments={"a_string": "a"})

--- a/tests/script_annotations_outputs/script_annotations_output.py
+++ b/tests/script_annotations_outputs/script_annotations_output.py
@@ -81,11 +81,23 @@ def script_outputs_in_function_signature(
     successor2.write_text(str(a_number + 2))
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+@script(constructor="runner")
+def script_param_artifact_in_function_signature_and_return_type(
+    a_number: Annotated[int, Parameter(name="a_number")],
+    successor: Annotated[Path, Parameter(name="successor", output=True)],
+    successor2: Annotated[Path, Artifact(name="successor2", output=True)],
+) -> Tuple[Annotated[int, Parameter(name="successor3")], Annotated[int, Artifact(name="successor4")]]:
+    successor.write_text(str(a_number + 1))
+    successor2.write_text(str(a_number + 2))
+    return a_number + 3, a_number + 4
+
+
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param(arguments={"a_number": 3})
         script_artifact(arguments={"a_number": 3})
         script_artifact_path(arguments={"a_number": 3})
         script_artifact_and_param(arguments={"a_number": 3})
         script_two_params(arguments={"a_number": 3})
         script_two_artifacts(arguments={"a_number": 3})
+        script_param_artifact_in_function_signature_and_return_type(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_artifact_in_func.py
+++ b/tests/script_annotations_outputs/script_annotations_output_artifact_in_func.py
@@ -23,6 +23,6 @@ def script_artifact_in_fun_sig(
     successor.write_text(a_number + 1)
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_artifact_in_fun_sig(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_custom_output_directory.py
+++ b/tests/script_annotations_outputs/script_annotations_output_custom_output_directory.py
@@ -24,6 +24,6 @@ def script_param_in_fun_sig(
     successor.write_text(str(a_number + 1))
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_in_fun_sig(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_in_func_no_name.py
+++ b/tests/script_annotations_outputs/script_annotations_output_in_func_no_name.py
@@ -22,9 +22,9 @@ def script_param_in_fun_sig(
     successor2: Annotated[Path, Artifact(output=True)],
 ):
     successor.write_text(a_number + 1)
-    successor.write_text(a_number + 2)
+    successor2.write_text(a_number + 2)
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_in_fun_sig(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_param_and_artifact_in_func.py
+++ b/tests/script_annotations_outputs/script_annotations_output_param_and_artifact_in_func.py
@@ -22,9 +22,9 @@ def script_param_in_fun_sig(
     successor2: Annotated[Path, Artifact(name="successor2", output=True)],
 ):
     successor.write_text(a_number + 1)
-    successor.write_text(a_number + 2)
+    successor2.write_text(a_number + 2)
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_in_fun_sig(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_param_and_artifact_mix.py
+++ b/tests/script_annotations_outputs/script_annotations_output_param_and_artifact_mix.py
@@ -27,6 +27,6 @@ def script_param_artifact_mixed(
     return a_number + 3, a_number + 4
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_artifact_mixed(arguments={"a_number": 3})

--- a/tests/script_annotations_outputs/script_annotations_output_param_in_func.py
+++ b/tests/script_annotations_outputs/script_annotations_output_param_in_func.py
@@ -23,6 +23,6 @@ def script_param_in_fun_sig(
     successor.save(a_number + 1)
 
 
-with Workflow(generate_name="test-outputs-", entrypoint="my_steps") as w:
-    with Steps(name="my_steps") as s:
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
         script_param_in_fun_sig(arguments={"a_number": 3})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -100,6 +100,16 @@ def test(entrypoint, kwargs_list, expected_output, global_config_fixture, enviro
                 {"path": "hera/outputs/artifacts/successor2", "value": "5"},
             ],
         ),
+        (
+            "tests.script_annotations_outputs.script_annotations_output:script_param_artifact_in_function_signature_and_return_type",
+            [{"name": "a_number", "value": "3"}],
+            [
+                {"path": "hera/outputs/parameters/successor", "value": "4"},
+                {"path": "hera/outputs/artifacts/successor2", "value": "5"},
+                {"path": "hera/outputs/parameters/successor3", "value": "6"},
+                {"path": "hera/outputs/artifacts/successor4", "value": "7"},
+            ],
+        ),
     ],
 )
 def test_script_annotations_outputs(
@@ -112,6 +122,8 @@ def test_script_annotations_outputs(
     monkeypatch,
 ):
     """Test that the output annotations are parsed correctly and save outputs to correct destinations."""
+    for file in expected_files:
+        assert not Path(tmp_path_fixture / file["path"]).is_file()
     # GIVEN
     global_config_fixture.experimental_features["script_annotations"] = True
     global_config_fixture.experimental_features["script_runner"] = True

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -73,8 +73,8 @@ def test_double_default_throws_a_value_error(global_config_fixture):
     """Test asserting that it is not possible to define default in the annotation and normal Python."""
     global_config_fixture.experimental_features["script_annotations"] = True
     with pytest.raises(ValueError) as e:
-        with Workflow(generate_name="test-default-", entrypoint="my_steps") as w:
-            with Steps(name="my_steps"):
+        with Workflow(generate_name="test-default-", entrypoint="my-steps") as w:
+            with Steps(name="my-steps"):
                 echo_int()
 
         w.to_dict()


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

When submitting a workflow with the new outputs annotation, this error occurs:

```
[spec.volumes[2].name: Invalid value: "hera__outputs_directory": a lowercase RFC 1123 label must consist 
of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character 
(e.g. 'my-name', or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), 
spec.containers[0].volumeMounts[0].name: Not found: "hera__outputs_directory", 
spec.containers[1].volumeMounts[0].name: Not found: "hera__outputs_directory"]
```

This PR fixes the issue by changing the underscores to dashes in labels: Volumes and Steps. It also renames env variables to use capital letters.