### PR TITLE
Use /tmp for all the autogenerated files

### DIFF
--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -184,15 +184,14 @@ def _save_annotated_return_outputs(
 
 def _get_outputs_path(destination: Union[Parameter, Artifact]) -> Path:
     """Get the path from the destination annotation using the defined outputs directory."""
-    path = Path(os.environ.get("hera__outputs_directory", "hera/outputs"))
-    if destination.name:
-        if isinstance(destination, Parameter):
-            path = path / f"parameters/{destination.name}"
-        elif isinstance(destination, Artifact):
-            if destination.path:
-                path = Path(destination.path)
-            else:
-                path = path / f"artifacts/{destination.name}"
+    path = Path(os.environ.get("hera__outputs_directory", "tmp/hera/outputs"))
+    if isinstance(destination, Parameter) and destination.name:
+        path = path / f"parameters/{destination.name}"
+    elif isinstance(destination, Artifact):
+        if destination.path:
+            path = Path(destination.path)
+        elif destination.name:
+            path = path / f"artifacts/{destination.name}"
     return path
 
 

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -704,7 +704,7 @@ class RunnerScriptConstructor(ScriptConstructor, ExperimentalMixin):
     outputs_directory: Optional[str] = None
     """Used for saving outputs when defined using annotations."""
 
-    DEFAULT_HERA_OUTPUTS_DIRECTORY: str = "/hera/outputs"
+    DEFAULT_HERA_OUTPUTS_DIRECTORY: str = "/tmp/hera/outputs"
     """Used as the default value for when the outputs_directory is not set"""
 
     def transform_values(self, cls: Type[Script], values: Any) -> Any:

--- a/tests/script_annotations_outputs/script_annotations_output_multiple_calls.py
+++ b/tests/script_annotations_outputs/script_annotations_output_multiple_calls.py
@@ -1,0 +1,31 @@
+try:
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
+
+from pathlib import Path
+
+from hera.shared import global_config
+from hera.workflows import Parameter, Workflow, script
+from hera.workflows.steps import Steps
+
+global_config.experimental_features["script_runner"] = True
+global_config.experimental_features["script_annotations"] = True
+
+
+@script(constructor="runner")
+def script_param_in_fun_sig(
+    a_number: Annotated[int, Parameter(name="a_number")],
+    successor: Annotated[Path, Parameter(name="successor", output=True)],
+):
+    successor.save(a_number + 1)
+
+
+with Workflow(generate_name="test-outputs-", entrypoint="my-steps") as w:
+    with Steps(name="my-steps") as s:
+        script_param_in_fun_sig(arguments={"a_number": 2})
+        with s.parallel() as ps:
+            script_param_in_fun_sig(arguments={"a_number": 3})
+            script_param_in_fun_sig(arguments={"a_number": 4})
+            script_param_in_fun_sig(arguments={"a_number": 5})
+            script_param_in_fun_sig(arguments={"a_number": 6})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -56,12 +56,12 @@ def test(entrypoint, kwargs_list, expected_output, global_config_fixture, enviro
         (
             "tests.script_annotations_outputs.script_annotations_output:script_param",
             [{"name": "a_number", "value": "3"}],
-            [{"path": "hera/outputs/parameters/successor", "value": "4"}],
+            [{"path": "tmp/hera/outputs/parameters/successor", "value": "4"}],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_artifact",
             [{"name": "a_number", "value": "3"}],
-            [{"path": "hera/outputs/artifacts/successor", "value": "4"}],
+            [{"path": "tmp/hera/outputs/artifacts/successor", "value": "4"}],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_artifact_path",
@@ -72,42 +72,42 @@ def test(entrypoint, kwargs_list, expected_output, global_config_fixture, enviro
             "tests.script_annotations_outputs.script_annotations_output:script_artifact_and_param",
             [{"name": "a_number", "value": "3"}],
             [
-                {"path": "hera/outputs/parameters/successor", "value": "4"},
-                {"path": "hera/outputs/artifacts/successor", "value": "5"},
+                {"path": "tmp/hera/outputs/parameters/successor", "value": "4"},
+                {"path": "tmp/hera/outputs/artifacts/successor", "value": "5"},
             ],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_two_params",
             [{"name": "a_number", "value": "3"}],
             [
-                {"path": "hera/outputs/parameters/successor", "value": "4"},
-                {"path": "hera/outputs/parameters/successor2", "value": "5"},
+                {"path": "tmp/hera/outputs/parameters/successor", "value": "4"},
+                {"path": "tmp/hera/outputs/parameters/successor2", "value": "5"},
             ],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_two_artifacts",
             [{"name": "a_number", "value": "3"}],
             [
-                {"path": "hera/outputs/artifacts/successor", "value": "4"},
-                {"path": "hera/outputs/artifacts/successor2", "value": "5"},
+                {"path": "tmp/hera/outputs/artifacts/successor", "value": "4"},
+                {"path": "tmp/hera/outputs/artifacts/successor2", "value": "5"},
             ],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_outputs_in_function_signature",
             [{"name": "a_number", "value": "3"}],
             [
-                {"path": "hera/outputs/parameters/successor", "value": "4"},
-                {"path": "hera/outputs/artifacts/successor2", "value": "5"},
+                {"path": "tmp/hera/outputs/parameters/successor", "value": "4"},
+                {"path": "tmp/hera/outputs/artifacts/successor2", "value": "5"},
             ],
         ),
         (
             "tests.script_annotations_outputs.script_annotations_output:script_param_artifact_in_function_signature_and_return_type",
             [{"name": "a_number", "value": "3"}],
             [
-                {"path": "hera/outputs/parameters/successor", "value": "4"},
-                {"path": "hera/outputs/artifacts/successor2", "value": "5"},
-                {"path": "hera/outputs/parameters/successor3", "value": "6"},
-                {"path": "hera/outputs/artifacts/successor4", "value": "7"},
+                {"path": "tmp/hera/outputs/parameters/successor", "value": "4"},
+                {"path": "tmp/hera/outputs/artifacts/successor2", "value": "5"},
+                {"path": "tmp/hera/outputs/parameters/successor3", "value": "6"},
+                {"path": "tmp/hera/outputs/artifacts/successor4", "value": "7"},
             ],
         ),
     ],
@@ -128,7 +128,7 @@ def test_script_annotations_outputs(
     global_config_fixture.experimental_features["script_annotations"] = True
     global_config_fixture.experimental_features["script_runner"] = True
 
-    outputs_directory = str(tmp_path_fixture / "hera/outputs")
+    outputs_directory = str(tmp_path_fixture / "tmp/hera/outputs")
     global_config_fixture.set_class_defaults(RunnerScriptConstructor, outputs_directory=outputs_directory)
 
     monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path_fixture))

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -88,19 +88,19 @@ def test_double_default_throws_a_value_error(global_config_fixture):
         (
             "script_annotations_output_param_in_func",
             {"parameters": [{"name": "a_number"}]},
-            {"parameters": [{"name": "successor", "valueFrom": {"path": "/hera/outputs/parameters/successor"}}]},
+            {"parameters": [{"name": "successor", "valueFrom": {"path": "/tmp/hera/outputs/parameters/successor"}}]},
         ),
         (
             "script_annotations_output_artifact_in_func",
             {"parameters": [{"name": "a_number"}]},
-            {"artifacts": [{"name": "successor", "path": "/hera/outputs/artifacts/successor"}]},
+            {"artifacts": [{"name": "successor", "path": "/tmp/hera/outputs/artifacts/successor"}]},
         ),
         (
             "script_annotations_output_param_and_artifact_in_func",
             {"parameters": [{"name": "a_number"}]},
             {
-                "parameters": [{"name": "successor", "valueFrom": {"path": "/hera/outputs/parameters/successor"}}],
-                "artifacts": [{"name": "successor2", "path": "/hera/outputs/artifacts/successor2"}],
+                "parameters": [{"name": "successor", "valueFrom": {"path": "/tmp/hera/outputs/parameters/successor"}}],
+                "artifacts": [{"name": "successor2", "path": "/tmp/hera/outputs/artifacts/successor2"}],
             },
         ),
         (
@@ -108,12 +108,12 @@ def test_double_default_throws_a_value_error(global_config_fixture):
             {"parameters": [{"name": "a_number"}]},
             {
                 "parameters": [
-                    {"name": "successor", "valueFrom": {"path": "/hera/outputs/parameters/successor"}},
-                    {"name": "successor3", "valueFrom": {"path": "/hera/outputs/parameters/successor3"}},
+                    {"name": "successor", "valueFrom": {"path": "/tmp/hera/outputs/parameters/successor"}},
+                    {"name": "successor3", "valueFrom": {"path": "/tmp/hera/outputs/parameters/successor3"}},
                 ],
                 "artifacts": [
-                    {"name": "successor2", "path": "/hera/outputs/artifacts/successor2"},
-                    {"name": "successor4", "path": "/hera/outputs/artifacts/successor4"},
+                    {"name": "successor2", "path": "/tmp/hera/outputs/artifacts/successor2"},
+                    {"name": "successor4", "path": "/tmp/hera/outputs/artifacts/successor4"},
                 ],
             },
         ),
@@ -121,8 +121,8 @@ def test_double_default_throws_a_value_error(global_config_fixture):
             "script_annotations_output_in_func_no_name",
             {"parameters": [{"name": "a_number"}]},
             {
-                "parameters": [{"name": "successor", "valueFrom": {"path": "/hera/outputs/parameters/successor"}}],
-                "artifacts": [{"name": "successor2", "path": "/hera/outputs/artifacts/successor2"}],
+                "parameters": [{"name": "successor", "valueFrom": {"path": "/tmp/hera/outputs/parameters/successor"}}],
+                "artifacts": [{"name": "successor2", "path": "/tmp/hera/outputs/artifacts/successor2"}],
             },
         ),
         (


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

Following a discussion with @samj1912  and @elliotgunton, this PR puts all the generated files in `/tmp/hera/outputs` instead of just `/tmp/hera`