### PR TITLE
[WIP] Add failing test for Hera runner output serialization

### DIFF
--- a/examples/workflows/callable_script.py
+++ b/examples/workflows/callable_script.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 try:
     from typing import Annotated  # type: ignore
@@ -32,6 +32,7 @@ global_config.experimental_features["script_annotations"] = True
 class Input(BaseModel):
     a: int
     b: str = "foo"
+    c: Union[str, int, float]
 
 
 # An optional pydantic output type
@@ -73,8 +74,9 @@ def str_function(input: str) -> Output:
 def function_kebab(
     a_but_kebab: Annotated[int, Parameter(name="a-but-kebab")] = 2,
     b_but_kebab: Annotated[str, Parameter(name="b-but-kebab")] = "foo",
+    c_but_kebab: Annotated[float, Parameter(name="c-but-kebab")] = 42.0,
 ) -> Output:
-    return Output(output=[Input(a=a_but_kebab, b=b_but_kebab)])
+    return Output(output=[Input(a=a_but_kebab, b=b_but_kebab, c=c_but_kebab)])
 
 
 @script()
@@ -84,8 +86,8 @@ def function_kebab_object(input_values: Annotated[Input, Parameter(name="input-v
 
 with Workflow(name="my-workflow") as w:
     with Steps(name="my-steps") as s:
-        my_function(arguments={"input": Input(a=2, b="bar")})
-        str_function(arguments={"input": Input(a=2, b="bar").json()})
-        another_function(arguments={"inputs": [Input(a=2, b="bar"), Input(a=2, b="bar")]})
+        my_function(arguments={"input": Input(a=2, b="bar", c=42)})
+        str_function(arguments={"input": Input(a=2, b="bar", c=42).json()})
+        another_function(arguments={"inputs": [Input(a=2, b="bar", c=42), Input(a=2, b="bar", c=42.0)]})
         function_kebab(arguments={"a-but-kebab": 3, "b-but-kebab": "bar"})
-        function_kebab_object(arguments={"input-values": Input(a=3, b="bar")})
+        function_kebab_object(arguments={"input-values": Input(a=3, b="bar", c="42")})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,13 +14,13 @@ from hera.workflows.runner import _runner
     [
         (
             "examples.workflows.callable_script:my_function",
-            [{"name": "input", "value": '{"a": 2, "b": "bar"}'}],
-            '{"output": [{"a": 2, "b": "bar"}]}',
+            [{"name": "input", "value": '{"a": 2, "b": "bar", "c": 42}'}],
+            '{"output": [{"a": 2, "b": "bar", "c": 42}]}',
         ),
         (
             "examples.workflows.callable_script:another_function",
-            [{"name": "inputs", "value": '[{"a": 2, "b": "bar"}, {"a": 2, "b": "bar"}]'}],
-            '{"output": [{"a": 2, "b": "bar"}, {"a": 2, "b": "bar"}]}',
+            [{"name": "inputs", "value": '[{"a": 2, "b": "bar", "c": 42}, {"a": 2, "b": "bar", "c": 42.0}]'}],
+            '{"output": [{"a": 2, "b": "bar", "c": 42}, {"a": 2, "b": "bar", "c": 42.0}]}',
         ),
         (
             "examples.workflows.callable_script:str_function",
@@ -29,13 +29,17 @@ from hera.workflows.runner import _runner
         ),
         (
             "examples.workflows.callable_script:function_kebab",
-            [{"name": "a-but-kebab", "value": "3"}, {"name": "b-but-kebab", "value": "bar"}],
-            '{"output": [{"a": 3, "b": "bar"}]}',
+            [
+                {"name": "a-but-kebab", "value": "3"},
+                {"name": "b-but-kebab", "value": "bar"},
+                {"name": "c-but-kebab", "value": "42.0"},
+            ],
+            '{"output": [{"a": 3, "b": "bar", "c": 42.0}]}',
         ),
         (
             "examples.workflows.callable_script:function_kebab_object",
-            [{"name": "input-values", "value": '{"a": 3, "b": "bar"}'}],
-            '{"output": [{"a": 3, "b": "bar"}]}',
+            [{"name": "input-values", "value": '{"a": 3, "b": "bar", "c": "abc"}'}],
+            '{"output": [{"a": 3, "b": "bar", "c": "abc"}]}',
         ),
     ],
 )


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
@lancour discovered that typing a field as a union such as `str | int | float` + using the Hera runner results in `int` + `float` being serialized as `str`. This is likely caused by the way serialization occurs during runner validation here. My guess is that it happens somewhere around https://github.com/argoproj-labs/hera/blob/main/src/hera/workflows/runner.py#L234

This PR only adds a failing test to illustrate how an expected integer is actually a string, hence it fails. Still working through the code
