### PR TITLE
Fix `null` string in args_path; add tests

### DIFF
--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -265,7 +265,10 @@ def _run():
     output of a Python function submitted via a `Script.source` field results in outputs sent to stdout.
     """
     args = _parse_args()
-    kwargs_list = json.loads(args.args_path.read_text() or r"[]")
+    # 1. Protect against trying to json.loads on empty files with inner `or r"[]`
+    # 2. Protect against files containing `null` as text with outer `or []` (as a result of using
+    #    `{{inputs.parameters}}` where the parameters key doesn't exist in `inputs`)
+    kwargs_list = json.loads(args.args_path.read_text() or r"[]") or []
     result = _runner(args.entrypoint, kwargs_list)
     if not result:
         return


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #724
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, empty kwargs in a script runner function throws a type error as the `kwargs_list` is actually `None`. This PR fixes the json.load line and adds test for the two scenarios of an empty file, and the string `null` being in the file
