### PR TITLE
Fix script_annotations_artifact_passing example

### DIFF
--- a/docs/examples/workflows/script_annotations_artifact_passing.md
+++ b/docs/examples/workflows/script_annotations_artifact_passing.md
@@ -8,21 +8,20 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows.volume import Volume
-
     try:
         from typing import Annotated  # type: ignore
     except ImportError:
         from typing_extensions import Annotated  # type: ignore
 
 
+    from pathlib import Path
     from hera.shared import global_config
     from hera.workflows import (
         Artifact,
+        ArtifactLoader,
         Parameter,
         Steps,
         Workflow,
-        models as m,
         script,
     )
 
@@ -38,8 +37,14 @@ This example will reuse the outputs volume across script steps.
 
 
     @script(constructor="runner")
-    def use_artifact(successor_in: Annotated[int, Artifact(name="successor_in")]):
+    def use_artifact(
+        successor_in: Annotated[
+            int,
+            Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
+        ]
+    ):
         print(successor_in)
+        print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
     with Workflow(
@@ -101,6 +106,7 @@ This example will reuse the outputs volume across script steps.
       - inputs:
           artifacts:
           - name: successor_in
+            path: /my-path
         name: use-artifact
         script:
           args:

--- a/examples/workflows/script-annotations-artifact-passing.yaml
+++ b/examples/workflows/script-annotations-artifact-passing.yaml
@@ -45,6 +45,7 @@ spec:
   - inputs:
       artifacts:
       - name: successor_in
+        path: /my-path
     name: use-artifact
     script:
       args:

--- a/examples/workflows/script_annotations_artifact_passing.py
+++ b/examples/workflows/script_annotations_artifact_passing.py
@@ -1,21 +1,20 @@
 """This example will reuse the outputs volume across script steps."""
 
 
-from hera.workflows.volume import Volume
-
 try:
     from typing import Annotated  # type: ignore
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 
 
+from pathlib import Path
 from hera.shared import global_config
 from hera.workflows import (
     Artifact,
+    ArtifactLoader,
     Parameter,
     Steps,
     Workflow,
-    models as m,
     script,
 )
 
@@ -31,8 +30,14 @@ def output_artifact(
 
 
 @script(constructor="runner")
-def use_artifact(successor_in: Annotated[int, Artifact(name="successor_in")]):
+def use_artifact(
+    successor_in: Annotated[
+        int,
+        Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
+    ]
+):
     print(successor_in)
+    print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
 with Workflow(


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes example
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, the script annotation artifact passing example is wrong because it doesn't specify a Path in the input or use an ArtifactLoader. However, the path will not generally be used in the function, so in future we might populate this automatically.

The Script guide was correct, so didn't need to change anything there.