### PR TITLE
Selectively xfail upstream examples

### DIFF
--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -15,6 +15,23 @@ from tests.test_examples import CI_MODE, HERA_REGENERATE
 ARGO_REPO_URL = "https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples"
 GITHUB_API_ARGO = "https://api.github.com/repos/argoproj/argo-workflows/git/trees/master?recursive=1"
 UPSTREAM_EXAMPLES_FOLDER = Path("examples/workflows/upstream")
+# A subset of the upstream examples are known to fail, but a majority pass. We'll
+# selectively xfail these examples rather than all until they can be fixed.
+UPSTREAM_EXAMPLE_XFAIL_FILES = [
+    "cluster-workflow-template__clustertemplates.upstream.yaml",
+    "cron-backfill.upstream.yaml",
+    "daemon-nginx.upstream.yaml",
+    "daemon-step.upstream.yaml",
+    "dag-daemon-task.upstream.yaml",
+    "default-pdb-support.upstream.yaml",
+    "influxdb-ci.upstream.yaml",
+    "memoize-simple.upstream.yaml",
+    "pod-gc-strategy-with-label-selector.upstream.yaml",
+    "pod-gc-strategy.upstream.yaml",
+    "timeouts-step.upstream.yaml",
+    "webhdfs-input-output-artifacts.upstream.yaml",
+    "workflow-template__templates.upstream.yaml",
+]
 
 
 def _save_upstream_examples(argo_examples: List[str]) -> None:
@@ -70,13 +87,19 @@ def test_for_missing_examples():
         examples_file.writelines(lines)
 
 
-@pytest.mark.xfail(
-    reason="Multiple workflows in one yaml file not yet supported.\nYAML round trip issues for certain types."
-)
 @pytest.mark.parametrize(
     "file_name",
     [
-        f
+        pytest.param(
+            f,
+            marks=(
+                pytest.mark.xfail(
+                    reason="Multiple workflows in one yaml file not yet supported.\nYAML round trip issues for certain types."
+                )
+                if f in UPSTREAM_EXAMPLE_XFAIL_FILES
+                else ()
+            ),
+        )
         for f in os.listdir(UPSTREAM_EXAMPLES_FOLDER)
         if os.path.isfile(UPSTREAM_EXAMPLES_FOLDER / f) and f.endswith(".upstream.yaml")
     ],


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [-] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
I was taking a look into adding [pydantic v1/v2 support](https://github.com/argoproj-labs/hera/issues/713) (ie: support both at the same time) and wanted to make sure tests worked locally before I made any changes.

When running tests I noticed that there were 196 xpassed tests (ie: tests that were expected to fail but actually passed) and 13 xfailed tests (expected to and did fail). I thought something was wrong w/ my env, but looks like CI for main also seems to have these. It looks like [this is from one parametrized xfail test](https://github.com/argoproj-labs/hera/blob/83b4c67fae94cfe115976a2d89422adbba7dd2db/tests/test_remaining_examples.py#L73) (test_upstream_examples_roundtrip) over lots of files. Given there are only 13 test that are actually failing (see in thread), what do you all think about hard coding those and selectively xfailing for only those? I think that will make things a lot more clear.

Additionally, it might be good to turn on xfail_strict=true so that xpassed tests don't slip through in the future (assuming this wasn't intentional).

---
True failed tests:
```
      13 xfailed
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[workflow-template__templates.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[dag-daemon-task.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[default-pdb-support.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[influxdb-ci.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[pod-gc-strategy.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[daemon-step.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[cron-backfill.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[daemon-nginx.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[pod-gc-strategy-with-label-selector.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[cluster-workflow-template__clustertemplates.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[timeouts-step.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[memoize-simple.upstream.yaml]
         - tests/test_remaining_examples.py:75 test_upstream_examples_roundtrip[webhdfs-input-output-artifacts.upstream.yaml]
```
