### PR TITLE
Fix inherited_members

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,11 +118,10 @@ plugins:
           options:
             # show_category_heading: true
             show_if_no_docstring: true
-            show_inherited_members: true
+            inherited_members: true
             filters: ["!^_.*$"]
             show_bases: false
             separate_signature: true
-          selection:
             docstring_style: google
           rendering:
             show_source: true


### PR DESCRIPTION
* show_inherited_members is not a valid option
* Merge options and selection. from mkdocstrings.github.io: "Since mkdocstrings 0.19, the YAML selection key is merged into the options key."
  * We are using `mkdocstrings-0.23` in rtd builds

**Pull Request Checklist**
- [x] Fixes #774 
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, subclasses don't show inherited members. This option was intended to be turned on but the name was wrong.
