### PR TITLE
Use http link for authentication walkthrough in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,9 @@ command for port forward!
 
 ### Authenticating in Hera
 
-<!-- This link only works on the readthedocs website, i.e. when viewing docs/README.md -->
 There are a few ways to authenticate in Hera - read more in the
-[authentication walk through](./walk-through/authentication.md) - for now, with the `argo` cli tool installed, this
-example will get you up and running:
+[authentication walk through](https://hera.readthedocs.io/en/stable/walk-through/authentication/) - for now, with the
+`argo` cli tool installed, this example will get you up and running:
 
 ```py
 from hera.workflows import Workflow, Container


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #779 

Decided using the http link to the auth walkthrough from the main README page would work best for now. The walkthrough page won't change much so should be safe to link to stable, and users can change the version they're viewing if needed. I don't think maintaining separate READMEs makes sense at the moment, but we should do that in future.