### PR TITLE
Remap `image_pull_policy` field on `Container` from `ImagePullPolicy` enum to `str`

### DIFF
--- a/scripts/spec.py
+++ b/scripts/spec.py
@@ -122,6 +122,21 @@ for obj_name, field in FIELD_REMAPPINGS.items():
         if existing_field != new_field:
             del curr_property[existing_field]
 
+# there are also some specifications that have to be introduced manually for backwards compatibility purposes. This
+# block allows us to define those specifications and add them to the spec.
+MANUAL_SPECIFICATIONS: List[Tuple[str, Dict]] = [
+    (
+        "io.k8s.api.core.v1.ImagePullPolicy",
+        {
+            "description": "An enum that contains available image pull policy options.",
+            "type": "string",
+            "enum": ["Always", "Never", "IfNotPresent"],
+        },
+    ),
+]
+for obj_name, obj_spec in MANUAL_SPECIFICATIONS:
+    spec["definitions"][obj_name] = obj_spec
+
 # finally, we write the spec to the output file that is passed to use assuming the client wants to perform
 # something with this file
 with open(output_file, "w+") as f:

--- a/src/hera/events/models/io/k8s/api/core/v1.py
+++ b/src/hera/events/models/io/k8s/api/core/v1.py
@@ -141,12 +141,6 @@ class ConfigMapKeySelector(BaseModel):
     )
 
 
-class ImagePullPolicy(Enum):
-    always = "Always"
-    if_not_present = "IfNotPresent"
-    never = "Never"
-
-
 class TerminationMessagePolicy(Enum):
     fallback_to_logs_on_error = "FallbackToLogsOnError"
     file = "File"
@@ -1238,6 +1232,12 @@ class WindowsSecurityContextOptions(BaseModel):
             " precedence."
         ),
     )
+
+
+class ImagePullPolicy(Enum):
+    always = "Always"
+    never = "Never"
+    if_not_present = "IfNotPresent"
 
 
 class CSIVolumeSource(BaseModel):
@@ -2828,7 +2828,7 @@ class Container(BaseModel):
             " StatefulSets."
         ),
     )
-    image_pull_policy: Optional[ImagePullPolicy] = Field(
+    image_pull_policy: Optional[str] = Field(
         default=None,
         alias="imagePullPolicy",
         description=(

--- a/src/hera/events/models/io/k8s/api/core/v1.pyi
+++ b/src/hera/events/models/io/k8s/api/core/v1.pyi
@@ -39,11 +39,6 @@ class ConfigMapKeySelector(BaseModel):
     name: Optional[str]
     optional: Optional[bool]
 
-class ImagePullPolicy(Enum):
-    always: str
-    if_not_present: str
-    never: str
-
 class TerminationMessagePolicy(Enum):
     fallback_to_logs_on_error: str
     file: str
@@ -312,6 +307,11 @@ class WindowsSecurityContextOptions(BaseModel):
     gmsa_credential_spec_name: Optional[str]
     host_process: Optional[bool]
     run_as_user_name: Optional[str]
+
+class ImagePullPolicy(Enum):
+    always: str
+    never: str
+    if_not_present: str
 
 class CSIVolumeSource(BaseModel):
     driver: str
@@ -582,7 +582,7 @@ class Container(BaseModel):
     env: Optional[List[EnvVar]]
     env_from: Optional[List[EnvFromSource]]
     image: str
-    image_pull_policy: Optional[ImagePullPolicy]
+    image_pull_policy: Optional[str]
     lifecycle: Optional[Lifecycle]
     liveness_probe: Optional[Probe]
     name: Optional[str]

--- a/src/hera/workflows/models/io/k8s/api/core/v1.py
+++ b/src/hera/workflows/models/io/k8s/api/core/v1.py
@@ -141,12 +141,6 @@ class ConfigMapKeySelector(BaseModel):
     )
 
 
-class ImagePullPolicy(Enum):
-    always = "Always"
-    if_not_present = "IfNotPresent"
-    never = "Never"
-
-
 class TerminationMessagePolicy(Enum):
     fallback_to_logs_on_error = "FallbackToLogsOnError"
     file = "File"
@@ -2828,7 +2822,7 @@ class Container(BaseModel):
             " StatefulSets."
         ),
     )
-    image_pull_policy: Optional[ImagePullPolicy] = Field(
+    image_pull_policy: Optional[str] = Field(
         default=None,
         alias="imagePullPolicy",
         description=(

--- a/src/hera/workflows/models/io/k8s/api/core/v1.py
+++ b/src/hera/workflows/models/io/k8s/api/core/v1.py
@@ -1234,6 +1234,12 @@ class WindowsSecurityContextOptions(BaseModel):
     )
 
 
+class ImagePullPolicy(Enum):
+    always = "Always"
+    never = "Never"
+    if_not_present = "IfNotPresent"
+
+
 class CSIVolumeSource(BaseModel):
     driver: str = Field(
         ...,

--- a/src/hera/workflows/models/io/k8s/api/core/v1.pyi
+++ b/src/hera/workflows/models/io/k8s/api/core/v1.pyi
@@ -39,11 +39,6 @@ class ConfigMapKeySelector(BaseModel):
     name: Optional[str]
     optional: Optional[bool]
 
-class ImagePullPolicy(Enum):
-    always: str
-    if_not_present: str
-    never: str
-
 class TerminationMessagePolicy(Enum):
     fallback_to_logs_on_error: str
     file: str
@@ -312,6 +307,11 @@ class WindowsSecurityContextOptions(BaseModel):
     gmsa_credential_spec_name: Optional[str]
     host_process: Optional[bool]
     run_as_user_name: Optional[str]
+
+class ImagePullPolicy(Enum):
+    always: str
+    never: str
+    if_not_present: str
 
 class CSIVolumeSource(BaseModel):
     driver: str
@@ -582,7 +582,7 @@ class Container(BaseModel):
     env: Optional[List[EnvVar]]
     env_from: Optional[List[EnvFromSource]]
     image: str
-    image_pull_policy: Optional[ImagePullPolicy]
+    image_pull_policy: Optional[str]
     lifecycle: Optional[Lifecycle]
     liveness_probe: Optional[Probe]
     name: Optional[str]


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #784
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
When an autogenerated object is created through the service the service returns auto generated objects. This means the services relies on autogenerated code _only_. #784 documents how creating an autogen `Workflow` object fails because the value of `Always` does not fit the `Template.container.imagePullPolicy` field. This happens because the returned value is of type `str` (from the Argo Server) while the Python value is an enum of type `ImagePullPolicy`. This is caused by an inconsistency in the OpenAPI specification. Some fields use `str` for image pull policy (look at Events, User Container, etc) while Container uses `ImagePullPolicy`. This PR changes the field in the OpenAPI schema specification so that this Container field is also a `str`. This should solve #784. Our Pydantic configuration is set to use enum values, which means that users who rely on the autogen Container object and pass the ImagePullPolicy object in will have Pydantic automatically extract the `.value` field of that enum. The Hera objects already accommodate both str and ImagePullPolicy, so no breaking change there. 
