### PR TITLE
fix image pull policy prediction

### DIFF
--- a/examples/workflows/scripts/script_with_image_pull_policy.py
+++ b/examples/workflows/scripts/script_with_image_pull_policy.py
@@ -9,3 +9,5 @@ def task_with_image_pull_policy():
 
 with Workflow(generate_name="script-with-image-pull-policy-", entrypoint="task-with-image-pull-policy") as w:
     task_with_image_pull_policy()
+
+w.to_yaml()

--- a/examples/workflows/scripts/script_with_image_pull_policy.py
+++ b/examples/workflows/scripts/script_with_image_pull_policy.py
@@ -9,5 +9,3 @@ def task_with_image_pull_policy():
 
 with Workflow(generate_name="script-with-image-pull-policy-", entrypoint="task-with-image-pull-policy") as w:
     task_with_image_pull_policy()
-
-w.to_yaml()

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -233,7 +233,7 @@ class ContainerMixin(BaseMixin):
     termination_message_policy: Optional[TerminationMessagePolicy] = None
     tty: Optional[bool] = None
 
-    def _build_image_pull_policy(self) -> Optional[ImagePullPolicy]:
+    def _build_image_pull_policy(self) -> Optional[str]:
         """Processes the image pull policy field and returns a generated `ImagePullPolicy` enum."""
         if self.image_pull_policy is None:
             return None

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -238,7 +238,7 @@ class ContainerMixin(BaseMixin):
         if self.image_pull_policy is None:
             return None
         elif isinstance(self.image_pull_policy, ImagePullPolicy):
-            return self.image_pull_policy
+            return self.image_pull_policy.value
 
         # this helps map image pull policy values as a convenience
         policy_mapper = {
@@ -251,7 +251,7 @@ class ContainerMixin(BaseMixin):
             **{ipp.name.lower(): ipp for ipp in ImagePullPolicy},
         }
         try:
-            return ImagePullPolicy[policy_mapper[self.image_pull_policy].name]
+            return ImagePullPolicy[policy_mapper[self.image_pull_policy].name].value
         except KeyError as e:
             raise KeyError(
                 f"Supplied image policy {self.image_pull_policy} is not valid. "

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -100,7 +100,6 @@ class ContainerNode(ContainerMixin, VolumeMountMixin, ResourceMixin, EnvMixin, S
 
     def _build_container_node(self) -> _ModelContainerNode:
         """Builds the generated `ContainerNode`."""
-        image_pull_policy = self._build_image_pull_policy()
         return _ModelContainerNode(
             args=self.args,
             command=self.command,
@@ -108,7 +107,7 @@ class ContainerNode(ContainerMixin, VolumeMountMixin, ResourceMixin, EnvMixin, S
             env=self._build_env(),
             env_from=self._build_env_from(),
             image=self.image,
-            image_pull_policy=None if image_pull_policy is None else image_pull_policy.value,
+            image_pull_policy=self._build_image_pull_policy(),
             lifecycle=self.lifecycle,
             liveness_probe=self.liveness_probe,
             name=self.name,

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -191,7 +191,6 @@ class Script(
 
     def _build_script(self) -> _ModelScriptTemplate:
         assert isinstance(self.constructor, ScriptConstructor)
-        image_pull_policy = self._build_image_pull_policy()
         if _output_annotations_used(cast(Callable, self.source)) and isinstance(
             self.constructor, RunnerScriptConstructor
         ):
@@ -211,7 +210,7 @@ class Script(
                 env_from=self._build_env_from(),
                 image=self.image,
                 # `image_pull_policy` in script wants a string not an `ImagePullPolicy` object
-                image_pull_policy=None if image_pull_policy is None else image_pull_policy.value,
+                image_pull_policy=self._build_image_pull_policy(),
                 lifecycle=self.lifecycle,
                 liveness_probe=self.liveness_probe,
                 name=self.container_name,

--- a/tests/test_unit/test_container.py
+++ b/tests/test_unit/test_container.py
@@ -1,0 +1,17 @@
+import pytest
+
+from hera.workflows._mixins import ContainerMixin
+from hera.workflows.models import ImagePullPolicy
+
+
+class TestContainerMixin:
+    def test_image_pull_policy(self):
+        with pytest.raises(KeyError):
+            ContainerMixin(image_pull_policy="test")._build_image_pull_policy()
+        assert ContainerMixin(image_pull_policy=None)._build_image_pull_policy() is None
+        assert (
+            ContainerMixin(image_pull_policy=ImagePullPolicy.always)._build_image_pull_policy()
+            == ImagePullPolicy.always.value
+        )
+        assert ContainerMixin(image_pull_policy="always")._build_image_pull_policy() == ImagePullPolicy.always.value
+        assert ContainerMixin(image_pull_policy="Always")._build_image_pull_policy() == ImagePullPolicy.always.value

--- a/tests/test_unit/test_mixins.py
+++ b/tests/test_unit/test_mixins.py
@@ -10,10 +10,10 @@ from hera.workflows.models import (
 
 class TestContainerMixin:
     def test_build_image_pull_policy(self) -> None:
-        assert ContainerMixin(image_pull_policy="Always")._build_image_pull_policy() == ImagePullPolicy.always
+        assert ContainerMixin(image_pull_policy="Always")._build_image_pull_policy() == ImagePullPolicy.always.value
         assert (
             ContainerMixin(image_pull_policy=ImagePullPolicy.always)._build_image_pull_policy()
-            == ImagePullPolicy.always
+            == ImagePullPolicy.always.value
         )
         assert ContainerMixin()._build_image_pull_policy() is None
 

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -6,7 +6,7 @@ import pytest
 
 from hera.workflows.container import Container
 from hera.workflows.exceptions import InvalidTemplateCall
-from hera.workflows.models import WorkflowCreateRequest
+from hera.workflows.models import WorkflowCreateRequest, ImagePullPolicy
 from hera.workflows.parameter import Parameter
 from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService
@@ -121,3 +121,15 @@ def test_returns_expected_workflow_link():
         name="test", workflows_service=WorkflowsService(host="https://localhost:8443/argo/", namespace="my-namespace")
     )
     assert w.get_workflow_link() == "https://localhost:8443/argo/workflows/my-namespace/test?tab=workflow"
+
+
+def test_builds_successfully_using_containers():
+    with Workflow(name="my-workflow", namespace="argo") as w:
+        Container(image_pull_policy=ImagePullPolicy.always)
+
+    w.to_yaml()
+
+    with Workflow(name="my-workflow", namespace="argo") as w:
+        Container(image_pull_policy="Always")
+
+    w.to_yaml()

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -6,7 +6,7 @@ import pytest
 
 from hera.workflows.container import Container
 from hera.workflows.exceptions import InvalidTemplateCall
-from hera.workflows.models import WorkflowCreateRequest, ImagePullPolicy
+from hera.workflows.models import ImagePullPolicy, WorkflowCreateRequest
 from hera.workflows.parameter import Parameter
 from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #888
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

A prior release adjusted the type of the `image_pull_policy` field to `str` to address the difference between the `ImagePullPolicy` enum type and the pure `str` type. That broke instances in which the `ImagePullPolicy` enum was used. This PR fixes that bug