### PR TITLE
feat: Perform dynamic import such that local relative imports functio…

### DIFF
--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -82,10 +82,12 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
     Returns:
         A list containing all `Workflow` objects defined within that module.
     """
-    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module_name = path.stem
+    spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
     assert spec
 
     module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
 
     assert spec.loader
     spec.loader.exec_module(module)

--- a/tests/cli/examples/relative_imports/file1.py
+++ b/tests/cli/examples/relative_imports/file1.py
@@ -1,0 +1,3 @@
+from hera.workflows import Container
+
+on_exit = Container(image="image")

--- a/tests/cli/examples/relative_imports/file2.py
+++ b/tests/cli/examples/relative_imports/file2.py
@@ -1,0 +1,6 @@
+from hera.workflows import Workflow
+
+from .file1 import on_exit
+
+with Workflow(name="relative_import", on_exit=on_exit) as workflow:
+    workflow._add_sub(on_exit)

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -4,6 +4,7 @@ from unittest.mock import mock_open, patch
 
 import cappa
 import pytest
+from cappa.testing import CommandRunner
 
 from hera._cli.base import Hera
 
@@ -74,6 +75,9 @@ whole_folder_output = "\n---\n\n".join(
         workflow_template_output,
     ]
 )
+
+
+runner = CommandRunner(Hera, base_args=["generate", "yaml"])
 
 
 @pytest.mark.cli
@@ -244,3 +248,22 @@ def test_source_folder_output_folder():
 
     content2 = open_patch.new.return_value.write.mock_calls[2][1][0]
     assert content2 == single_workflow_output
+
+
+@pytest.mark.cli
+def test_relative_imports(capsys):
+    runner.invoke("tests/cli/examples/relative_imports")
+
+    output = get_stdout(capsys)
+    assert output == dedent(
+        """\
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          name: relative_import
+        spec:
+          templates:
+          - container:
+              image: image
+        """
+    )


### PR DESCRIPTION
…n correctly.

**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Given a folder structure like:

```python
folder/
  foo.py
  bar.py
```

Currently, files containing workflows cannot reference other python modules, local to the point of import.

i.e. `from .foo import ...` from inside `bar.py`.

This PR updates the way the dynamic import occurs such that local imports **do** function correctly.

What does **not** yet appear to work correctly is if the referenced code can be imported where absolute imports to a root package would function correctly. I suspect that for that to work, the FROM argument would need to reference a source `module.path` rather than a path to a file.