### PR TITLE
Add "buildable" protocol.

### DIFF
--- a/docs/examples/workflows-examples.md
+++ b/docs/examples/workflows-examples.md
@@ -107,6 +107,7 @@ Explore the examples through the side bar!
 | [template-defaults](https://github.com/argoproj/argo-workflows/blob/main/examples/template-defaults.yaml) |
 | [testvolume](https://github.com/argoproj/argo-workflows/blob/main/examples/testvolume.yaml) |
 | [timeouts-step](https://github.com/argoproj/argo-workflows/blob/main/examples/timeouts-step.yaml) |
+| [title-and-descriptin-with-markdown](https://github.com/argoproj/argo-workflows/blob/main/examples/title-and-descriptin-with-markdown.yaml) |
 | [work-avoidance](https://github.com/argoproj/argo-workflows/blob/main/examples/work-avoidance.yaml) |
 | [workflow-count-resourcequota](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-count-resourcequota.yaml) |
 | [workflow-event-binding/event-consumer-workfloweventbinding](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-event-binding/event-consumer-workfloweventbinding.yaml) |

--- a/examples/workflows/upstream/title-and-descriptin-with-markdown.upstream.yaml
+++ b/examples/workflows/upstream/title-and-descriptin-with-markdown.upstream.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: title-and-description-with-markdown-
+  labels:
+    workflows.argoproj.io/archive-strategy: "false"
+  annotations:
+    workflows.argoproj.io/title: "**Test Title**"
+    workflows.argoproj.io/description: |
+      `This is a simple hello world example.`
+      You can also run it in Python: https://couler-proj.github.io/couler/examples/#hello-world
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Generator
 
 from hera._cli.base import GenerateYaml
-from hera.workflows.workflow import Workflow
+from hera.workflows.protocol import Buildable
 
 
 def generate_yaml(options: GenerateYaml):
@@ -73,14 +73,14 @@ def expand_paths(source: Path, recursive: bool = False) -> Generator[Path, None,
                 yield path
 
 
-def load_workflows_from_module(path: Path) -> list[Workflow]:
-    """Load the set of `Workflow` objects defined within a given module.
+def load_workflows_from_module(path: Path) -> list[Buildable]:
+    """Load the set of mappable objects defined within a given module.
 
     Arguments:
         path: The path to a given python module
 
     Returns:
-        A list containing all `Workflow` objects defined within that module.
+        A list containing all detected objects defined within that module.
     """
     module_name = path.stem
     spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
@@ -94,7 +94,7 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
 
     result = []
     for item in module.__dict__.values():
-        if isinstance(item, Workflow):
+        if isinstance(item, Buildable) and not isinstance(item, type):
             result.append(item)
 
     return result

--- a/src/hera/workflows/protocol.py
+++ b/src/hera/workflows/protocol.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Union
 
 from typing_extensions import Protocol, runtime_checkable
 
+from hera.shared._pydantic import BaseModel
 from hera.workflows.models import (
     ClusterWorkflowTemplate,
     ContainerSetTemplate,
@@ -35,6 +36,20 @@ TWorkflow = Union[
     WorkflowTemplate,
 ]
 """`TWorkflow` is a union type collection of all the Hera workflow type objects that can manage contexts"""
+
+
+@runtime_checkable
+class Buildable(Protocol):
+    """This runtime protocol indicates that an object can built into a standalone serializable representation."""
+
+    def build(self) -> BaseModel:
+        """Produce a serializable model object."""
+
+    def to_dict(self) -> Any:
+        """Produce a raw python dict structure."""
+
+    def to_yaml(self, *args, **kwargs) -> str:
+        """Produce a yaml string of the `to_dict` representation."""
 
 
 @runtime_checkable

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -345,25 +345,12 @@ class Workflow(
         )
         return _WorkflowModelMapper.build_model(Workflow, self, model_workflow)
 
-    def to_dict(self) -> Any:
-        """Builds the Workflow as an Argo schema Workflow object and returns it as a dictionary."""
-        return self.build().dict(exclude_none=True, by_alias=True)
-
     def __eq__(self, other) -> bool:
         """Verifies equality of `self` with the specified `other`."""
         if other.__class__ is self.__class__:
             return self.to_dict() == other.to_dict()
 
         return False
-
-    def to_yaml(self, *args, **kwargs) -> str:
-        """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
-        if not _yaml:
-            raise ImportError("`PyYAML` is not installed. Install `hera[yaml]` to bring in the extra dependency")
-        # Set some default options if not provided by the user
-        kwargs.setdefault("default_flow_style", False)
-        kwargs.setdefault("sort_keys", False)
-        return _yaml.dump(self.to_dict(), *args, **kwargs)
 
     def create(self, wait: bool = False, poll_interval: int = 5) -> TWorkflow:
         """Creates the Workflow on the Argo cluster.

--- a/tests/cli/examples/custom_object_type/example.py
+++ b/tests/cli/examples/custom_object_type/example.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from hera.shared._pydantic import BaseModel
+from hera.workflows._mixins import BuildableMixin
+from hera.workflows.workflow import Workflow
+
+
+class ExampleTypeInstance(BaseModel):
+    kind: str
+    apiVersion: str
+    name: str
+
+
+class ExampleType(BaseModel, BuildableMixin):
+    name: str
+
+    def build(self) -> ExampleTypeInstance:
+        return ExampleTypeInstance(kind="Example", apiVersion="example.example/v1alpha1", name=self.name)
+
+
+example_type = ExampleType(name="example")
+workflow = Workflow(name=f"{example_type.name}_workflow")

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -267,3 +267,25 @@ def test_relative_imports(capsys):
               image: image
         """
     )
+
+
+@pytest.mark.cli
+def test_custom_object_type(capsys):
+    runner.invoke("tests/cli/examples/custom_object_type")
+
+    output = get_stdout(capsys)
+    assert output == dedent(
+        """\
+        kind: Example
+        apiVersion: example.example/v1alpha1
+        name: example
+
+        ---
+
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          name: example_workflow
+        spec: {}
+        """
+    )


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Addresss https://github.com/argoproj-labs/hera/discussions/914
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Per the above linked discussion, the goal is to enable authoring non-workflow objects that would still benefit from being declaratively described alongside hera objects...and have the hera CLI be able to generate them also. I suppose in an ideal world, they might also be `create`-able also, but that's outside my current interest scope.

---

So I'm not certain whether this is the best way to go about factoring these methods or not. It **seems** like there's perhaps some more methods (to_file, from_*, etc) and attributes (name, generate_name) that might correspond to this sort of "top-level-object that can be produced, whether it's a Workflow or not"

I had originally intended to use ModelMapperMixin, since it seems like **it** would be the right place for many of these things to live, but it's in a private module, and I wasn't sure if it made sense to subclass it outside hera itself.

Whereas as-implemented, it doesn't need to directly depend on hera objects in order to be supported. With that said, I dont know that that's an explicit goal here, I'm just unfamiliar with the design intent of some of these workings.