### PR TITLE
Add brief CLI doc to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ and its crew were specially protected by the goddess Hera.
 ```python
 from hera.workflows import Steps, Workflow, script
 
+
 @script()
 def echo(message: str):
     print(message)
+
 
 with Workflow(
     generate_name="single-script-",
@@ -73,9 +75,11 @@ w.create()
 ```python
 from hera.workflows import DAG, Workflow, script
 
+
 @script()
 def echo(message: str):
     print(message)
+
 
 with Workflow(
     generate_name="dag-diamond-",
@@ -91,7 +95,8 @@ with Workflow(
 w.create()
 ```
 
-See the [examples](./examples/workflows-examples.md) for a collection of Argo workflow construction and submission via Hera!
+See the [examples](./examples/workflows-examples.md) for a collection of Argo workflow construction and submission via
+Hera!
 
 ## Requirements
 
@@ -124,7 +129,7 @@ global_config.host = "http://localhost:2746"
 global_config.token = ArgoCLITokenGenerator
 
 with Workflow(generate_name="local-test-", entrypoint="c") as w:
-    Container( name="c", image="docker/whalesay", command=["cowsay", "hello"])
+    Container(name="c", image="docker/whalesay", command=["cowsay", "hello"])
 
 w.create()
 ```
@@ -143,6 +148,14 @@ w.create()
 | [GitHub repo](https://github.com/argoproj-labs/hera)     | `python -m pip install git+https://github.com/argoproj-labs/hera --ignore-installed`/`pip install .` |
 
 ### Optional dependencies
+
+#### cli
+
+- Install via `hera[cli]`
+- [Cappa](https://github.com/DanCardin/cappa) is required for the `cli`. The CLI aims to enable GitOps practices,
+  easier debugging, and a more seamless experience with Argo Workflows.
+- The CLI is an experimental feature. At the moment it only supports generating YAML files from workflows via
+  `hera generate yaml`. See `hera generate yaml --help` for more information
 
 #### yaml
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ w.create()
 - Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa) required for the CLI
 - The CLI aims to enable GitOps practices,
   easier debugging, and a more seamless experience with Argo Workflows.
-- The CLI is an experimental feature. At the moment it only supports generating YAML files from workflows via
+- **_The CLI is an experimental feature and subject to change!_** At the moment it only supports generating YAML files from workflows via
   `hera generate yaml`. See `hera generate yaml --help` for more information
 
 #### yaml

--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ w.create()
 
 #### cli
 
-- Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa) required for the CLI
+- Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa)
+  required for the CLI
 - The CLI aims to enable GitOps practices,
   easier debugging, and a more seamless experience with Argo Workflows.
-- **_The CLI is an experimental feature and subject to change!_** At the moment it only supports generating YAML files from workflows via
-  `hera generate yaml`. See `hera generate yaml --help` for more information
+- **_The CLI is an experimental feature and subject to change!_** At the moment it only supports generating YAML files
+  from workflows via `hera generate yaml`. See `hera generate yaml --help` for more information length
 
 #### yaml
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ w.create()
 
 #### cli
 
-- Install via `hera[cli]`
-- [Cappa](https://github.com/DanCardin/cappa) is required for the `cli`. The CLI aims to enable GitOps practices,
+- Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa) required for the CLI
+- The CLI aims to enable GitOps practices,
   easier debugging, and a more seamless experience with Argo Workflows.
 - The CLI is an experimental feature. At the moment it only supports generating YAML files from workflows via
   `hera generate yaml`. See `hera generate yaml --help` for more information


### PR DESCRIPTION
I noticed that we don't have the CLI mentioned at all. I thought about adding some docs about it to the README at least. I am sure we're going to have a dedicated documentation page on RTFD at some point