### PR TITLE
refactor: Define a root class from which workflow resources inherit.

### DIFF
--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Generator, Iterable, List
 
 from hera._cli.base import GenerateYaml
-from hera.workflows.workflow import Workflow
+from hera.workflows.resource_base import ResourceBase
 
 
 def generate_yaml(options: GenerateYaml):
@@ -94,14 +94,14 @@ def filter_paths(
         yield path
 
 
-def load_workflows_from_module(path: Path) -> list[Workflow]:
-    """Load the set of `Workflow` objects defined within a given module.
+def load_workflows_from_module(path: Path) -> list[ResourceBase]:
+    """Load the set of mappable objects defined within a given module.
 
     Arguments:
         path: The path to a given python module
 
     Returns:
-        A list containing all `Workflow` objects defined within that module.
+        A list containing all detected objects defined within that module.
     """
     module_name = path.stem
     spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
@@ -115,7 +115,7 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
 
     result = []
     for item in module.__dict__.values():
-        if isinstance(item, Workflow):
+        if isinstance(item, ResourceBase) and not isinstance(item, type):
             result.append(item)
 
     return result

--- a/src/hera/_yaml.py
+++ b/src/hera/_yaml.py
@@ -23,12 +23,23 @@ else:
     _yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
 
 
-def dump(*args, **kwargs) -> str:
-    """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
+def _get_yaml():
     if not _yaml:
         raise ImportError("`PyYAML` is not installed. Install `hera[yaml]` to bring in the extra dependency")
+
+    return _yaml
+
+
+def dump(*args, **kwargs) -> str:
+    """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
+    yaml = _get_yaml()
 
     # Set some default options if not provided by the user
     kwargs.setdefault("default_flow_style", False)
     kwargs.setdefault("sort_keys", False)
-    return _yaml.dump(*args, **kwargs)
+    return yaml.dump(*args, **kwargs)
+
+
+def safe_load(*args, **kwargs):
+    yaml = _get_yaml()
+    return yaml.safe_load(*args, **kwargs)

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -3,14 +3,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-from pathlib import Path
-
-try:
-    from inspect import get_annotations  # type: ignore
-except ImportError:
-    from hera.workflows._inspect import get_annotations  # type: ignore
-from collections import ChainMap
-from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,13 +17,8 @@ from typing import (
     cast,
 )
 
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
-
 from hera.shared import BaseMixin, global_config
-from hera.shared._pydantic import BaseModel, get_fields, root_validator, validator
+from hera.shared._pydantic import root_validator, validator
 from hera.shared.serialization import serialize
 from hera.workflows._context import SubNodeMixin, _context
 from hera.workflows.artifact import Artifact
@@ -80,7 +67,7 @@ from hera.workflows.models import (
     VolumeMount,
 )
 from hera.workflows.parameter import Parameter
-from hera.workflows.protocol import Templatable, TWorkflow
+from hera.workflows.protocol import Templatable
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import Volume, _BaseVolume
@@ -88,14 +75,6 @@ from hera.workflows.volume import Volume, _BaseVolume
 if TYPE_CHECKING:
     from hera.workflows.steps import Step
     from hera.workflows.task import Task
-
-_yaml: Optional[ModuleType] = None
-try:
-    import yaml
-
-    _yaml = yaml
-except ImportError:
-    _yaml = None
 
 
 T = TypeVar("T")
@@ -111,7 +90,9 @@ def normalize_to_list(v: Optional[OneOrMany]) -> Optional[List]:
     return [v]
 
 
-def normalize_to_list_or(*valid_types: Type) -> Callable[[Optional[OneOrMany]], Optional[List]]:
+def normalize_to_list_or(
+    *valid_types: Type,
+) -> Callable[[Optional[OneOrMany]], Optional[List]]:
     """Normalize given value to a list if not None."""
 
     def normalize_to_list_if_not_valid_type(v: Optional[OneOrMany]) -> Optional[List]:
@@ -1107,7 +1088,10 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
 
         obj = next((output for output in artifacts if output.name == name), None)
         if obj is not None:
-            return Artifact(name=name, from_=f"{{{{{subtype}.{self.name}.outputs.artifacts.{name}}}}}")
+            return Artifact(
+                name=name,
+                from_=f"{{{{{subtype}.{self.name}.outputs.artifacts.{name}}}}}",
+            )
         raise KeyError(f"No output artifact named `{name}` found")
 
     def get_parameters_as(self, name: str) -> Parameter:
@@ -1177,131 +1161,6 @@ def _get_params_from_items(with_items: List[Any]) -> Optional[List[Parameter]]:
         else:
             return [Parameter(name=n, value=f"{{{{item.{n}}}}}") for n in el.keys()]
     return [Parameter(name=n, value=f"{{{{item.{n}}}}}") for n in with_items[0].keys()]
-
-
-def _set_model_attr(model: BaseModel, attrs: List[str], value: Any):
-    # The `attrs` list represents a path to an attribute in `model`, whose attributes
-    # are BaseModels themselves. Therefore we use `getattr` to get a reference to the final
-    # BaseModel set to `curr`, then call `setattr` on that BaseModel, using the last attribute
-    # name in attrs, and the value passed in.
-    curr: BaseModel = model
-    for attr in attrs[:-1]:
-        curr = getattr(curr, attr)
-
-    setattr(curr, attrs[-1], value)
-
-
-def _get_model_attr(model: BaseModel, attrs: List[str]) -> Any:
-    # This is almost the same as _set_model_attr.
-    # The `attrs` list represents a path to an attribute in `model`, whose attributes
-    # are BaseModels themselves. Therefore we use `getattr` to get a reference to the final
-    # BaseModel set to `curr`, then `getattr` on that BaseModel, using the last attribute
-    # name in attrs.
-    curr: BaseModel = model
-    for attr in attrs[:-1]:
-        curr = getattr(curr, attr)
-
-    return getattr(curr, attrs[-1])
-
-
-class ModelMapperMixin(BaseMixin):
-    class ModelMapper:
-        def __init__(self, model_path: str, hera_builder: Optional[Callable] = None):
-            self.model_path = None
-            self.builder = hera_builder
-
-            if not model_path:
-                # Allows overriding parent attribute annotations to remove the mapping
-                return
-
-            self.model_path = model_path.split(".")
-            curr_class: Type[BaseModel] = self._get_model_class()
-            for key in self.model_path:
-                fields = get_fields(curr_class)
-                if key not in fields:
-                    raise ValueError(f"Model key '{key}' does not exist in class {curr_class}")
-                curr_class = fields[key].outer_type_
-
-        @classmethod
-        def _get_model_class(cls) -> Type[BaseModel]:
-            raise NotImplementedError
-
-        @classmethod
-        def build_model(
-            cls, hera_class: Type[ModelMapperMixin], hera_obj: ModelMapperMixin, model: TWorkflow
-        ) -> TWorkflow:
-            assert isinstance(hera_obj, ModelMapperMixin)
-
-            for attr, annotation in hera_class._get_all_annotations().items():
-                if get_origin(annotation) is Annotated and isinstance(
-                    get_args(annotation)[1], ModelMapperMixin.ModelMapper
-                ):
-                    mapper = get_args(annotation)[1]
-                    # Value comes from builder function if it exists on hera_obj, otherwise directly from the attr
-                    value = (
-                        getattr(hera_obj, mapper.builder.__name__)()
-                        if mapper.builder is not None
-                        else getattr(hera_obj, attr)
-                    )
-                    if value is not None:
-                        _set_model_attr(model, mapper.model_path, value)
-
-            return model
-
-    @classmethod
-    def _get_all_annotations(cls) -> ChainMap:
-        """Gets all annotations of this class and any parent classes."""
-        return ChainMap(*(get_annotations(c) for c in cls.__mro__))
-
-    @classmethod
-    def _from_model(cls, model: BaseModel) -> ModelMapperMixin:
-        """Parse from given model to cls's type."""
-        hera_obj = cls()
-
-        for attr, annotation in cls._get_all_annotations().items():
-            if get_origin(annotation) is Annotated and isinstance(
-                get_args(annotation)[1], ModelMapperMixin.ModelMapper
-            ):
-                mapper = get_args(annotation)[1]
-                if mapper.model_path:
-                    value = _get_model_attr(model, mapper.model_path)
-                    if value is not None:
-                        setattr(hera_obj, attr, value)
-
-        return hera_obj
-
-    @classmethod
-    def _from_dict(cls, model_dict: Dict, model: Type[BaseModel]) -> ModelMapperMixin:
-        """Parse from given model_dict, using the given model type to call its parse_obj."""
-        model_workflow = model.parse_obj(model_dict)
-        return cls._from_model(model_workflow)
-
-    @classmethod
-    def from_dict(cls, model_dict: Dict) -> ModelMapperMixin:
-        """Parse from given model_dict."""
-        raise NotImplementedError
-
-    @classmethod
-    def _from_yaml(cls, yaml_str: str, model: Type[BaseModel]) -> ModelMapperMixin:
-        """Parse from given yaml string, using the given model type to call its parse_obj."""
-        if not _yaml:
-            raise ImportError("PyYAML is not installed")
-        return cls._from_dict(_yaml.safe_load(yaml_str), model)
-
-    @classmethod
-    def from_yaml(cls, yaml_str: str) -> ModelMapperMixin:
-        """Parse from given yaml_str."""
-        raise NotImplementedError
-
-    @classmethod
-    def _from_file(cls, yaml_file: Union[Path, str], model: Type[BaseModel]) -> ModelMapperMixin:
-        yaml_file = Path(yaml_file)
-        return cls._from_yaml(yaml_file.read_text(encoding="utf-8"), model)
-
-    @classmethod
-    def from_file(cls, yaml_file: Union[Path, str]) -> ModelMapperMixin:
-        """Parse from given yaml_file."""
-        raise NotImplementedError
 
 
 class ExperimentalMixin(BaseMixin):

--- a/src/hera/workflows/cluster_workflow_template.py
+++ b/src/hera/workflows/cluster_workflow_template.py
@@ -1,6 +1,8 @@
 """Module that provides Hera objects for cluster workflow templates."""
+from typing import ClassVar, Type
+
 from hera.exceptions import NotFound
-from hera.shared._pydantic import validator
+from hera.shared._pydantic import BaseModel, validator
 from hera.workflows.models import (
     ClusterWorkflowTemplate as _ModelClusterWorkflowTemplate,
     ClusterWorkflowTemplateCreateRequest,
@@ -16,6 +18,8 @@ class ClusterWorkflowTemplate(WorkflowTemplate):
 
     Since cluster workflow templates are scoped at the cluster level, they are available globally in the cluster.
     """
+
+    mapped_model: ClassVar[Type[BaseModel]] = _ModelClusterWorkflowTemplate
 
     @validator("namespace", pre=True, always=True)
     def _set_namespace(cls, v):

--- a/src/hera/workflows/cluster_workflow_template.py
+++ b/src/hera/workflows/cluster_workflow_template.py
@@ -2,7 +2,7 @@
 from typing import ClassVar, Type
 
 from hera.exceptions import NotFound
-from hera.shared._pydantic import BaseModel, validator
+from hera.shared._pydantic import PydanticBaseModel, validator
 from hera.workflows.models import (
     ClusterWorkflowTemplate as _ModelClusterWorkflowTemplate,
     ClusterWorkflowTemplateCreateRequest,
@@ -19,7 +19,7 @@ class ClusterWorkflowTemplate(WorkflowTemplate):
     Since cluster workflow templates are scoped at the cluster level, they are available globally in the cluster.
     """
 
-    mapped_model: ClassVar[Type[BaseModel]] = _ModelClusterWorkflowTemplate
+    mapped_model: ClassVar[Type[PydanticBaseModel]] = _ModelClusterWorkflowTemplate
 
     @validator("namespace", pre=True, always=True)
     def _set_namespace(cls, v):

--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -12,7 +12,7 @@ except ImportError:
     from typing_extensions import Annotated  # type: ignore
 
 from hera.exceptions import NotFound
-from hera.shared._pydantic import BaseModel, PydanticBaseModel
+from hera.shared._pydantic import PydanticBaseModel
 from hera.workflows.models import (
     CreateCronWorkflowRequest,
     CronWorkflow as _ModelCronWorkflow,
@@ -36,8 +36,9 @@ class CronWorkflow(Workflow, traverse_mro=False):
         spec. See [CronWorkflowSpec](https://argoproj.github.io/argo-workflows/fields/#cronworkflow) for more details.
     """
 
-    mapped_model: ClassVar[Type[BaseModel]] = _ModelCronWorkflow
+    mapped_model: ClassVar[Type[PydanticBaseModel]] = _ModelCronWorkflow
 
+    # These need to be redefined due to `traverse_mro=False`
     api_version: Annotated[Optional[str], ModelMapper("api_version")] = None
     kind: Annotated[Optional[str], ModelMapper("kind")] = None
 

--- a/src/hera/workflows/resource_base.py
+++ b/src/hera/workflows/resource_base.py
@@ -1,0 +1,197 @@
+"""Define the base classes used to produce k8s CRDs."""
+from __future__ import annotations
+
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
+
+try:
+    from inspect import get_annotations  # type: ignore
+except ImportError:
+    from hera.workflows._inspect import get_annotations  # type: ignore
+from pathlib import Path
+
+try:
+    from typing import Annotated, get_args, get_origin  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
+
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self  # type: ignore
+
+from hera import _yaml
+from hera.shared import BaseMixin
+from hera.shared._pydantic import PydanticBaseModel, get_fields
+
+
+class ModelMapper:
+    """Maps a model attribute to the attribute path of the produced resource.
+
+    For example `foo: MopdelMapper("metadata.name")` would map the annotated object's
+    `foo` attribute to the "metadata" -> "name" field on the final k8s resource.
+    """
+
+    def __init__(self, model_path: str, hera_builder: Optional[Callable] = None):
+        """Accept the `model_path` to map to."""
+        self.model_path = None
+        self.builder = hera_builder
+
+        if not model_path:
+            # Allows overriding parent attribute annotations to remove the mapping
+            return
+
+        self.model_path = model_path.split(".")
+
+    @classmethod
+    def build_model(
+        cls,
+        hera_class: Type[ResourceBase],
+        hera_obj: ResourceBase,
+        model: PydanticBaseModel,
+        *,
+        traverse_mro: bool = True,
+    ):
+        """Builds an instance of a `ResourceBase` into the destination model type."""
+        assert isinstance(hera_obj, ResourceBase), type(hera_obj)
+
+        for attr, mapper, _ in hera_class._iter_model_mappers(traverse_mro=traverse_mro):
+            # Value comes from builder function if it exists on hera_obj, otherwise directly from the attr
+            value = (
+                getattr(hera_obj, mapper.builder.__name__)() if mapper.builder is not None else getattr(hera_obj, attr)
+            )
+            if value is not None:
+                _set_model_attr(model, mapper.model_path, value)
+
+        return model
+
+
+class ResourceBase(BaseMixin):
+    """Base class for top-level Hera CRDs.
+
+    Subclasses should supply a `mapped_model` attribute, which is the Pydantic model
+    which represents the final k8s resource.
+
+    Note, this class will validate that the annotated attributes map to real fields on the `mapped_model`.
+    """
+
+    mapped_model: ClassVar[Type[PydanticBaseModel]]
+
+    def __init_subclass__(cls, *, traverse_mro=True, **kwargs):
+        """Validate that the annotated `ModelMapper` paths map to real destination fields."""
+        for _, model_mapper, _ in cls._iter_model_mappers(traverse_mro=traverse_mro):
+            curr_cls = cls.mapped_model
+
+            for key in model_mapper.model_path:
+                fields = get_fields(curr_cls)
+                if key not in fields:
+                    raise ValueError(f"Model key '{key}' does not exist in class {curr_cls.__qualname__}")
+                curr_cls = fields[key].outer_type_
+
+        super().__init_subclass__(**kwargs)
+
+    @classmethod
+    def _iter_model_mappers(cls, traverse_mro: bool = True):
+        mro = cls.__mro__
+        if not traverse_mro:
+            mro = (cls,)
+
+        # Due to child subclasses being able to override parent fields, traversing the mro might
+        # yield the same attribute more than once, which wont make sense. Track seen fields, and only
+        # handle each one once.
+        handled_fields = set()
+
+        annotations = ((attr, annotation, c) for c in mro for attr, annotation in get_annotations(c).items())
+        for attr, annotation, c in annotations:
+            if get_origin(annotation) is Annotated and isinstance(get_args(annotation)[1], ModelMapper):
+                model_mapper = get_args(annotation)[1]
+
+                if attr in handled_fields:
+                    continue
+                handled_fields.add(attr)
+
+                # This check must happen after dealing with handled_fields, since leaf classes might
+                # override fields to unset `model_path` to disable them.
+                if not model_mapper.model_path:
+                    continue
+
+                yield attr, model_mapper, c
+
+    def build(self) -> PydanticBaseModel:
+        """Builds the Workflow as an Argo schema Workflow object."""
+        raise NotImplementedError()
+
+    def to_dict(self) -> dict:
+        """Builds the Workflow as an Argo schema Workflow object and returns it as a dictionary."""
+        return self.build().dict(exclude_none=True, by_alias=True)
+
+    def to_yaml(self, *args, **kwargs) -> str:
+        """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
+        return _yaml.dump(self.to_dict(), *args, **kwargs)
+
+    @classmethod
+    def _from_model(cls, model: PydanticBaseModel) -> Self:
+        """Parse from given model to cls's type."""
+        hera_obj = cls()
+
+        for attr, mapper, _ in cls._iter_model_mappers():
+            value = _get_model_attr(model, mapper.model_path)
+            if value is not None:
+                setattr(hera_obj, attr, value)
+
+        return hera_obj
+
+    @classmethod
+    def _from_dict(cls, model_dict: Dict, model: Type[PydanticBaseModel]) -> Self:
+        """Parse from given model_dict, using the given model type to call its parse_obj."""
+        model_workflow = model.parse_obj(model_dict)
+        return cls._from_model(model_workflow)
+
+    @classmethod
+    def from_dict(cls, model_dict: Dict) -> Self:
+        """Parse from given model_dict."""
+        raise NotImplementedError
+
+    @classmethod
+    def _from_yaml(cls, yaml_str: str, model: Type[PydanticBaseModel]) -> Self:
+        """Parse from given yaml string, using the given model type to call its parse_obj."""
+        return cls._from_dict(_yaml.safe_load(yaml_str), model)
+
+    @classmethod
+    def from_yaml(cls, yaml_str: str) -> Self:
+        """Parse from given yaml_str."""
+        raise NotImplementedError
+
+    @classmethod
+    def _from_file(cls, yaml_file: Union[Path, str], model: Type[PydanticBaseModel]) -> Self:
+        yaml_file = Path(yaml_file)
+        return cls._from_yaml(yaml_file.read_text(encoding="utf-8"), model)
+
+    @classmethod
+    def from_file(cls, yaml_file: Union[Path, str]) -> Self:
+        """Parse from given yaml_file."""
+        raise NotImplementedError
+
+
+def _set_model_attr(model: PydanticBaseModel, attrs: List[str], value: Any):
+    # The `attrs` list represents a path to an attribute in `model`, whose attributes
+    # are BaseModels themselves. Therefore we use `getattr` to get a reference to the final
+    # BaseModel set to `curr`, then call `setattr` on that BaseModel, using the last attribute
+    # name in attrs, and the value passed in.
+    curr: PydanticBaseModel = model
+    for attr in attrs[:-1]:
+        curr = getattr(curr, attr)
+
+    setattr(curr, attrs[-1], value)
+
+
+def _get_model_attr(model: PydanticBaseModel, attrs: List[str]) -> Any:
+    # This is almost the same as _set_model_attr.
+    # The `attrs` list represents a path to an attribute in `model`, whose attributes
+    # are BaseModels themselves. Therefore we use `getattr` to get a reference to the final
+    # BaseModel set to `curr`, then `getattr` on that BaseModel, using the last attribute
+    # name in attrs.
+    curr: PydanticBaseModel = model
+    for attr in attrs[:-1]:
+        curr = getattr(curr, attr)
+
+    return getattr(curr, attrs[-1])

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -149,8 +149,6 @@ class Workflow(
     mapped_model: ClassVar[Type[PydanticBaseModel]] = _ModelWorkflow
 
     # Workflow fields - https://argoproj.github.io/argo-workflows/fields/#workflow
-    api_version: Annotated[Optional[str], ModelMapper("api_version")] = None
-    kind: Annotated[Optional[str], ModelMapper("kind")] = None
     status: Annotated[Optional[_ModelWorkflowStatus], ModelMapper("status")] = None
 
     # ObjectMeta fields - https://argoproj.github.io/argo-workflows/fields/#objectmeta
@@ -276,12 +274,6 @@ class Workflow(
     def _set_workflows_service(cls, v):
         if v is None:
             return WorkflowsService()
-        return v
-
-    @validator("kind", pre=True, always=True, allow_reuse=True)
-    def _set_kind(cls, v):
-        if v is None:
-            return cls.__name__  # type: ignore
         return v
 
     @validator("namespace", pre=True, always=True, allow_reuse=True)

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -4,7 +4,9 @@ See https://argoproj.github.io/argo-workflows/workflow-templates/
 for more on WorkflowTemplates.
 """
 from pathlib import Path
-from typing import Dict, Optional, Type, Union, cast
+from typing import ClassVar, Dict, Optional, Type, Union, cast
+
+from hera.shared._pydantic import BaseModel
 
 try:
     from typing import Annotated  # type: ignore
@@ -12,8 +14,7 @@ except ImportError:
     from typing_extensions import Annotated  # type: ignore
 
 from hera.exceptions import NotFound
-from hera.shared._pydantic import BaseModel, validator
-from hera.workflows._mixins import ModelMapperMixin
+from hera.shared._pydantic import validator
 from hera.workflows.models import (
     ObjectMeta,
     WorkflowSpec as _ModelWorkflowSpec,
@@ -24,13 +25,8 @@ from hera.workflows.models import (
     WorkflowTemplateUpdateRequest,
 )
 from hera.workflows.protocol import TWorkflow
-from hera.workflows.workflow import _TRUNCATE_LENGTH, Workflow, _WorkflowModelMapper
-
-
-class _WorkflowTemplateModelMapper(_WorkflowModelMapper):
-    @classmethod
-    def _get_model_class(cls) -> Type[BaseModel]:
-        return _ModelWorkflowTemplate  # type: ignore
+from hera.workflows.resource_base import ModelMapper, Self
+from hera.workflows.workflow import _TRUNCATE_LENGTH, Workflow
 
 
 class WorkflowTemplate(Workflow):
@@ -40,8 +36,10 @@ class WorkflowTemplate(Workflow):
     them from your Workflows.
     """
 
+    mapped_model: ClassVar[Type[BaseModel]] = _ModelWorkflowTemplate
+
     # Removes status mapping
-    status: Annotated[Optional[_ModelWorkflowStatus], _WorkflowTemplateModelMapper("")] = None
+    status: Annotated[Optional[_ModelWorkflowStatus], ModelMapper("")] = None
 
     # WorkflowTemplate fields match Workflow exactly except for `status`, which WorkflowTemplate
     # does not have - https://argoproj.github.io/argo-workflows/fields/#workflowtemplate
@@ -109,10 +107,10 @@ class WorkflowTemplate(Workflow):
             spec=_ModelWorkflowSpec(),
         )
 
-        return _WorkflowTemplateModelMapper.build_model(WorkflowTemplate, self, model_workflow)
+        return ModelMapper.build_model(WorkflowTemplate, self, model_workflow)
 
     @classmethod
-    def from_dict(cls, model_dict: Dict) -> ModelMapperMixin:
+    def from_dict(cls, model_dict: Dict) -> Self:
         """Create a WorkflowTemplate from a WorkflowTemplate contained in a dict.
 
         Examples:
@@ -123,7 +121,7 @@ class WorkflowTemplate(Workflow):
         return cls._from_dict(model_dict, _ModelWorkflowTemplate)
 
     @classmethod
-    def from_yaml(cls, yaml_str: str) -> ModelMapperMixin:
+    def from_yaml(cls, yaml_str: str) -> Self:
         """Create a WorkflowTemplate from a WorkflowTemplate contained in a YAML string.
 
         Examples:
@@ -132,7 +130,7 @@ class WorkflowTemplate(Workflow):
         return cls._from_yaml(yaml_str, _ModelWorkflowTemplate)
 
     @classmethod
-    def from_file(cls, yaml_file: Union[Path, str]) -> ModelMapperMixin:
+    def from_file(cls, yaml_file: Union[Path, str]) -> Self:
         """Create a WorkflowTemplate from a WorkflowTemplate contained in a YAML file.
 
         Examples:

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -6,7 +6,7 @@ for more on WorkflowTemplates.
 from pathlib import Path
 from typing import ClassVar, Dict, Optional, Type, Union, cast
 
-from hera.shared._pydantic import BaseModel
+from hera.shared._pydantic import PydanticBaseModel
 
 try:
     from typing import Annotated  # type: ignore
@@ -36,7 +36,7 @@ class WorkflowTemplate(Workflow):
     them from your Workflows.
     """
 
-    mapped_model: ClassVar[Type[BaseModel]] = _ModelWorkflowTemplate
+    mapped_model: ClassVar[Type[PydanticBaseModel]] = _ModelWorkflowTemplate
 
     # Removes status mapping
     status: Annotated[Optional[_ModelWorkflowStatus], ModelMapper("")] = None

--- a/tests/cli/examples/custom_object_type/example.py
+++ b/tests/cli/examples/custom_object_type/example.py
@@ -1,23 +1,31 @@
 from __future__ import annotations
 
+from typing import ClassVar, Type
+
 from typing_extensions import Annotated
 
-from hera.shared._pydantic import BaseModel
+from hera.shared._pydantic import BaseModel, Field
 from hera.workflows.resource_base import ModelMapper, ResourceBase
 from hera.workflows.workflow import Workflow
 
 
 class ExampleTypeInstance(BaseModel):
     kind: str
-    apiVersion: str
+    api_version: Annotated[str, Field(alias="apiVersion")]
     name: str
 
 
 class ExampleType(ResourceBase):
+    mapped_model: ClassVar[Type] = ExampleTypeInstance
+
     name: Annotated[str, ModelMapper("name")]
 
     def build(self) -> ExampleTypeInstance:
-        return ExampleTypeInstance(kind="Example", apiVersion="example.example/v1alpha1", name=self.name)
+        return ExampleTypeInstance(
+            kind="Example",
+            api_version="example.example/v1alpha1",
+            name=self.name,
+        )
 
 
 example_type = ExampleType(name="example")

--- a/tests/cli/examples/custom_object_type/example.py
+++ b/tests/cli/examples/custom_object_type/example.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing_extensions import Annotated
+
+from hera.shared._pydantic import BaseModel
+from hera.workflows.resource_base import ModelMapper, ResourceBase
+from hera.workflows.workflow import Workflow
+
+
+class ExampleTypeInstance(BaseModel):
+    kind: str
+    apiVersion: str
+    name: str
+
+
+class ExampleType(ResourceBase):
+    name: Annotated[str, ModelMapper("name")]
+
+    def build(self) -> ExampleTypeInstance:
+        return ExampleTypeInstance(kind="Example", apiVersion="example.example/v1alpha1", name=self.name)
+
+
+example_type = ExampleType(name="example")
+workflow = Workflow(name=f"{example_type.name}_workflow")

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -281,3 +281,24 @@ def test_include_and_exclude(capsys):
 
     output = get_stdout(capsys)
     assert output == workflow_template_output
+
+
+def test_custom_object_type(capsys):
+    runner.invoke("tests/cli/examples/custom_object_type")
+
+    output = get_stdout(capsys)
+    assert output == dedent(
+        """\
+        kind: Example
+        apiVersion: example.example/v1alpha1
+        name: example
+
+        ---
+
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          name: example_workflow
+        spec: {}
+        """
+    )

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -3,12 +3,14 @@ from typing import ClassVar, Type
 import pytest
 from typing_extensions import Annotated
 
-from hera.shared._pydantic import BaseModel, PydanticBaseModel
+from hera.shared._pydantic import BaseModel, Field, PydanticBaseModel
 from hera.workflows.resource_base import ModelMapper, ResourceBase
 
 
 def test_bad_model_mapper():
     class DestModel(BaseModel):
+        api_version: str
+        kind: str
         good: bool
 
     with pytest.raises(ValueError) as e:
@@ -32,3 +34,23 @@ def test_missing_mapped_model():
         "test_missing_mapped_model.<locals>.BadResource must define a `mapped_model` attribute, which specifies the Pydantic model to which this resource's attributes map."
         == str(e.value)
     )
+
+
+def test_valid_resource_base():
+    class DestModel(BaseModel):
+        api_version: Annotated[str, Field(alias="apiVersion")] = "v1alpha1"
+        kind: str = ""
+        good: bool = False
+
+    class GoodResource(ResourceBase):
+        mapped_model: ClassVar[Type[PydanticBaseModel]] = DestModel
+
+        good: Annotated[bool, ModelMapper("good")]
+
+    resource = GoodResource(good=True)
+    result = resource.to_dict()
+    assert result == {
+        "apiVersion": "v1alpha1",
+        "kind": "GoodResource",
+        "good": True,
+    }

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -1,0 +1,21 @@
+from typing import ClassVar, Type
+
+import pytest
+from typing_extensions import Annotated
+
+from hera.shared._pydantic import BaseModel
+from hera.workflows.resource_base import ModelMapper, ResourceBase
+
+
+def test_bad_model_mapper():
+    class DestModel(BaseModel):
+        good: bool
+
+    with pytest.raises(ValueError) as e:
+
+        class BadResource(ResourceBase):
+            mapped_model: ClassVar[Type[BaseModel]] = DestModel
+            good: Annotated[bool, ModelMapper("good")]
+            bar: Annotated[bool, ModelMapper("bad.field")]
+
+    assert "Model key 'bad' does not exist in class test_bad_model_mapper.<locals>.DestModel" == str(e.value)

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Type
 import pytest
 from typing_extensions import Annotated
 
-from hera.shared._pydantic import BaseModel
+from hera.shared._pydantic import BaseModel, PydanticBaseModel
 from hera.workflows.resource_base import ModelMapper, ResourceBase
 
 
@@ -14,8 +14,21 @@ def test_bad_model_mapper():
     with pytest.raises(ValueError) as e:
 
         class BadResource(ResourceBase):
-            mapped_model: ClassVar[Type[BaseModel]] = DestModel
+            mapped_model: ClassVar[Type[PydanticBaseModel]] = DestModel
             good: Annotated[bool, ModelMapper("good")]
             bar: Annotated[bool, ModelMapper("bad.field")]
 
     assert "Model key 'bad' does not exist in class test_bad_model_mapper.<locals>.DestModel" == str(e.value)
+
+
+def test_missing_mapped_model():
+    with pytest.raises(AttributeError) as e:
+
+        class BadResource(ResourceBase):
+            good: Annotated[bool, ModelMapper("good")]
+            bar: Annotated[bool, ModelMapper("bad.field")]
+
+    assert (
+        "test_missing_mapped_model.<locals>.BadResource must define a `mapped_model` attribute, which specifies the Pydantic model to which this resource's attributes map."
+        == str(e.value)
+    )


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Addresses the problem given by https://github.com/argoproj-labs/hera/discussions/914 / https://github.com/argoproj-labs/hera/pull/917 in a different way
- [ ] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
First i'll summarize the above prior PR/discussion. (feel free to correct any bad k8s/workflows terminology below 😬)

Basically the "issue" is that certain CRDs ([ExternalSecret](https://external-secrets.io/v0.4.4/api-externalsecret/) and `ServiceAccount` are the ones in particular that I've needed) need to be referenced by name during the construction of a hera workflow. And in the case of both of these objects (in my case), they're only being created for the express purpose of the workflows they're being used with.

(perhaps the argument could be made that something like `ServiceAccount` **should** have a native hera representation. But it feels like ExternalSecret is probably out of scope, and/or that generally there would be kinds of CRDs that will inevitably be too niche to be in scope).

Thus, it would be really convenient to be able to author the (very small) amount of k8s manifest required to create those objects from within python/hera itself, and have it be created (again in my case through `hera generate yaml`) automatically alongside the workflows themselves.

As I understand it, all the argo `Workflow.*` objects are themselves CRDs, so my PR takes the tack that there could be a base class from which all the existing hera top-level object types (CRDs) inherit. So far I've named it `ResourceBase`. This base class provides a bunch of the common methods that would be applicable to all CRDs, and generally the shape that subclasses should abide by. For the most part, this class looks a lot like the existing `ModelMapperMixin`, with some additional stolen methods from `Workflow`.

Doing this basically just enables external consumers to also subclass `ResourceBase` and gain the benefits. Namely that the CLI will treat those objects as though they were the same as `Workflow` (or siblings) in `generate yaml` or other future commands.

---
sidebar, I think there is perhaps some missing test coverage (which i'll look into, if you like the PR), as far as this PR goes. I had initially failed to define a `mapped_model` attribute on `WorkflowTemplate`, which I'd have expected to make it produce idk...and incorrect `kind: Workflow` or something.