### PR TITLE
Save dummy outputs when runner script raises an exception

### DIFF
--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -326,6 +326,47 @@ def _save_annotated_return_outputs(
     return None
 
 
+def _save_dummy_outputs(
+    output_annotations: List[
+        Union[Tuple[type, Union[Parameter, Artifact]], Union[Type[RunnerOutputV1], Type[RunnerOutputV2]]]
+    ],
+) -> None:
+    """Save dummy values into the outputs specified.
+
+    This function is used at runtime by the Hera Runner to create files in the container so that Argo
+    does not log confusing error messages that obfuscate the real error, which look like:
+    ```
+    msg="cannot save parameter /tmp/hera-outputs/parameters/my-parameter"
+    argo=true
+    error="open /tmp/hera-outputs/parameters/my-parameter: no such file or directory"`
+    ```
+
+    The output annotations are used to write files using the schema:
+    <parent_directory>/artifacts/<name>
+    <parent_directory>/parameters/<name>
+    If the artifact path or parameter value_from.path is specified, that is used instead.
+    <parent_directory> can be provided by the user or is set to /tmp/hera-outputs by default
+    """
+    for dest in output_annotations:
+        if isinstance(dest, (RunnerOutputV1, RunnerOutputV2)):
+            if os.environ.get("hera__script_pydantic_io", None) is None:
+                raise ValueError("hera__script_pydantic_io environment variable is not set")
+
+            for field, _ in dest.__fields__:
+                if field in {"exit_code", "result"}:
+                    continue
+
+                annotation = dest._get_output(field)
+                path = _get_outputs_path(annotation)
+                _write_to_path(path, "")
+        else:
+            if not dest[1].name:
+                raise ValueError("The name was not provided for one of the outputs.")
+
+            path = _get_outputs_path(dest[1])
+            _write_to_path(path, "")
+
+
 def _get_outputs_path(destination: Union[Parameter, Artifact]) -> Path:
     """Get the path from the destination annotation using the defined outputs directory."""
     path = Path(os.environ.get("hera__outputs_directory", "/tmp/hera-outputs"))
@@ -403,7 +444,11 @@ def _runner(entrypoint: str, kwargs_list: List) -> Any:
         if output_annotations:
             # This will save outputs returned from the function only. Any function parameters/artifacts marked as
             # outputs should be written to within the function itself.
-            output = _save_annotated_return_outputs(function(**kwargs), output_annotations)
+            try:
+                output = _save_annotated_return_outputs(function(**kwargs), output_annotations)
+            except Exception as e:
+                _save_dummy_outputs(output_annotations)
+                raise e
             return output or None
 
     return function(**kwargs)

--- a/tests/script_runner/annotated_outputs.py
+++ b/tests/script_runner/annotated_outputs.py
@@ -85,6 +85,20 @@ def script_param_no_name(a_number) -> Annotated[int, Parameter()]:
 
 
 @script()
+def script_param_otuput_raises_index_error() -> Annotated[int, Parameter(name="param-output")]:
+    """Raise an IndexError."""
+    a_list = []
+    return a_list[0]
+
+
+@script()
+def script_artifact_output_raises_index_error() -> Annotated[int, Artifact(name="artifact-output")]:
+    """Raise an IndexError."""
+    a_list = []
+    return a_list[0]
+
+
+@script()
 def script_outputs_in_function_signature(
     a_number: Annotated[int, Parameter(name="a_number")],
     successor: Annotated[Path, Parameter(name="successor", output=True)],

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -296,6 +296,11 @@ def test_runner_annotated_parameter_inputs(
             [],
             [{"subpath": "tmp/hera/outputs/parameters/dict-of-str", "value": '{"my-key": "my-value"}'}],
         ),
+        (
+            "script_raises_an_error",
+            [],
+            [{"subpath": "tmp/hera/outputs/parameters/an-output", "value": ""}],
+        ),
     ],
 )
 def test_script_annotations_outputs(
@@ -329,6 +334,58 @@ def test_script_annotations_outputs(
     output = _runner(f"{output_tests_module.__name__}:{function_name}", kwargs_list)
     # THEN
     assert output is None, "Runner should not return values directly when using return Annotations"
+    for file in expected_files:
+        assert Path(tmp_path / file["subpath"]).is_file()
+        assert Path(tmp_path / file["subpath"]).read_text() == file["value"]
+
+
+@pytest.mark.parametrize(
+    "function_name,expected_error,expected_files",
+    [
+        (
+            "script_param_otuput_raises_index_error",
+            IndexError,
+            [{"subpath": "tmp/hera-outputs/parameters/param-output", "value": ""}],
+        ),
+        (
+            "script_artifact_output_raises_index_error",
+            IndexError,
+            [{"subpath": "tmp/hera-outputs/artifacts/artifact-output", "value": ""}],
+        ),
+    ],
+)
+def test_script_raising_error_still_outputs(
+    function_name,
+    expected_error: type,
+    expected_files: List[Dict[str, str]],
+    global_config_fixture: GlobalConfig,
+    environ_annotations_fixture: None,
+    tmp_path: Path,
+    monkeypatch,
+):
+    """Test that the output annotations are parsed correctly and save outputs to correct destinations."""
+    for file in expected_files:
+        assert not Path(tmp_path / file["subpath"]).is_file()
+    # GIVEN
+    global_config_fixture.experimental_features["script_annotations"] = True
+
+    outputs_directory = str(tmp_path / "tmp/hera-outputs")
+    global_config_fixture.set_class_defaults(RunnerScriptConstructor, outputs_directory=outputs_directory)
+
+    monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path))
+    os.environ["hera__outputs_directory"] = outputs_directory
+
+    # Force a reload of the test module, as the runner performs "importlib.import_module", which
+    # may fetch a cached version
+    import tests.script_runner.annotated_outputs as output_tests_module
+
+    importlib.reload(output_tests_module)
+
+    # WHEN
+    with pytest.raises(expected_error):
+        _runner(f"{output_tests_module.__name__}:{function_name}", [])
+
+    # THEN
     for file in expected_files:
         assert Path(tmp_path / file["subpath"]).is_file()
         assert Path(tmp_path / file["subpath"]).read_text() == file["value"]
@@ -671,11 +728,10 @@ def test_runner_pydantic_inputs_params(
 
 
 @pytest.mark.parametrize(
-    "entrypoint,kwargs_list,expected_files,pydantic_mode",
+    "entrypoint,expected_files,pydantic_mode",
     [
         pytest.param(
             "tests.script_runner.pydantic_io_v1:pydantic_output_parameters",
-            [],
             [
                 {"subpath": "tmp/hera-outputs/parameters/my_output_str", "value": "a string!"},
                 {"subpath": "tmp/hera-outputs/parameters/second-output", "value": "my-val"},
@@ -687,7 +743,6 @@ def test_runner_pydantic_inputs_params(
 )
 def test_runner_pydantic_output_params(
     entrypoint,
-    kwargs_list,
     expected_files,
     pydantic_mode,
     global_config_fixture: GlobalConfig,
@@ -708,7 +763,7 @@ def test_runner_pydantic_output_params(
     os.environ["hera__outputs_directory"] = outputs_directory
 
     # WHEN
-    output = _runner(entrypoint, kwargs_list)
+    output = _runner(entrypoint, [])
 
     # THEN
     assert isinstance(output, RunnerOutput)


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #948 
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
When running a script via the Hera Runner, if it raises an error, the declared outputs of the (script) template are not created as files in the container, leading to confusing Argo logs such as:

```
msg="cannot save parameter /tmp/hera-outputs/parameters/my-parameter"
argo=true
error="open /tmp/hera-outputs/parameters/my-parameter: no such file or directory"`
```

This PR makes the runner catch the exception, write dummy values, then pass the exception up.