### PR TITLE
fix: Improve linting/editor experience for hera models.

### DIFF
--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from hera.auth import TokenGenerator
-from hera.shared._pydantic import BaseModel, root_validator
+from hera.shared._pydantic import BaseModel, get_fields, root_validator
 
 TBase = TypeVar("TBase", bound="BaseMixin")
 TypeTBase = Type[TBase]
@@ -119,7 +119,7 @@ class _GlobalConfig:
             cls: The class to set defaults for.
             kwargs: The default values to set.
         """
-        invalid_keys = set(kwargs) - set(cls.__fields__)
+        invalid_keys = set(kwargs) - set(get_fields(cls))
         if invalid_keys:
             raise ValueError(f"Invalid keys for class {cls}: {invalid_keys}")
         self._defaults[cls].update(kwargs)
@@ -143,7 +143,7 @@ class BaseMixin(BaseModel):
         this method. We also tried other ways including creating a metaclass that invokes hera_init after init,
         but that always broke auto-complete for IDEs like VSCode.
         """
-        super()._init_private_attributes()
+        super()._init_private_attributes()  # type: ignore
         self.__hera_init__()
 
     def __hera_init__(self):

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -31,7 +31,7 @@ except ImportError:
     from typing_extensions import Annotated, get_args, get_origin  # type: ignore
 
 from hera.shared import BaseMixin, global_config
-from hera.shared._pydantic import BaseModel, root_validator, validator
+from hera.shared._pydantic import BaseModel, get_fields, root_validator, validator
 from hera.shared.serialization import serialize
 from hera.workflows._context import SubNodeMixin, _context
 from hera.workflows.artifact import Artifact
@@ -1211,9 +1211,10 @@ class ModelMapperMixin(BaseMixin):
             self.model_path = model_path.split(".")
             curr_class: Type[BaseModel] = self._get_model_class()
             for key in self.model_path:
-                if key not in curr_class.__fields__:
+                fields = get_fields(curr_class)
+                if key not in fields:
                     raise ValueError(f"Model key '{key}' does not exist in class {curr_class}")
-                curr_class = curr_class.__fields__[key].outer_type_
+                curr_class = fields[key].outer_type_
 
         @classmethod
         def _get_model_class(cls) -> Type[BaseModel]:


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Today, hera models seem to receive no editor/linter support for the `__init__` arguments of hera models.

This **seems** to be solely from the necessary try/except imports used to support both pydantic v1 and v2. Both mypy and pyright will bail on and not yield useful types when you do this. But it can be hacked around with some **more** conditionals imports 😅

Today:
<img width="1219" alt="Screenshot 2024-01-31 at 2 19 19 PM" src="https://github.com/argoproj-labs/hera/assets/701548/6bcddeab-58c3-4205-836b-58ec24c23f03">
<img width="367" alt="Screenshot 2024-01-31 at 2 19 27 PM" src="https://github.com/argoproj-labs/hera/assets/701548/35148eb6-5a08-4987-a215-ee6580b3ea36">

With this change:
<img width="1224" alt="Screenshot 2024-01-31 at 2 18 27 PM" src="https://github.com/argoproj-labs/hera/assets/701548/76e06cad-ebe0-4f4a-b6be-25bf8c3070c4">
<img width="1341" alt="Screenshot 2024-01-31 at 2 18 36 PM" src="https://github.com/argoproj-labs/hera/assets/701548/b711663d-5539-4c16-a043-7bcb83ed2ad6">