### PR TITLE
Move Hera's copyright from Dyno Therapeutics to "The Hera Authors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2021 Dyno Therapeutics, Inc.
+   Copyright (C) 2024 The Hera Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
We've had multiple discussions about this topic in the past few months. We already took the step to move from MIT to Apache 2.0 and we needed to switch the copyright as well. Dyno Therapeutics reviewed this change and approved it internally. This PR changes the copyright from `2021 Dyno Therapeutics Inc` to `2024 The Hera Authors`.