### PR TITLE
fix(UserContainer): Fix a small bug in ImagePullPolicy mapper and add tests for error cases

### DIFF
--- a/src/hera/workflows/user_container.py
+++ b/src/hera/workflows/user_container.py
@@ -26,7 +26,7 @@ class UserContainer(_ModelUserContainer):
     volumes: Optional[List[_BaseVolume]] = None
 
     def _build_image_pull_policy(self) -> Optional[str]:
-        """Processes the image pull policy field and returns a generated `ImagePullPolicy` enum."""
+        """Processes the image pull policy field and optionally returns a string value from `ImagePullPolicy` enum."""
         if self.image_pull_policy is None:
             return None
         elif isinstance(self.image_pull_policy, ImagePullPolicy):
@@ -37,10 +37,8 @@ class UserContainer(_ModelUserContainer):
             # the following 2 are "normal" entries
             **{ipp.name: ipp for ipp in ImagePullPolicy},
             **{ipp.value: ipp for ipp in ImagePullPolicy},
-            # some users might submit the policy without underscores
-            **{ipp.value.lower().replace("_", ""): ipp for ipp in ImagePullPolicy},
-            # some users might submit the policy in lowercase
-            **{ipp.name.lower(): ipp for ipp in ImagePullPolicy},
+            # some users might submit the policy in lowercase & without underscores
+            **{ipp.value.lower(): ipp for ipp in ImagePullPolicy},
         }
         try:
             return ImagePullPolicy[policy_mapper[self.image_pull_policy].name].value

--- a/tests/test_unit/test_user_container.py
+++ b/tests/test_unit/test_user_container.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hera.workflows.models import (
     ImagePullPolicy,
     UserContainer as ModelUserContainer,
@@ -9,11 +11,23 @@ from hera.workflows.volume import Volume
 
 class TestUserContainer:
     def test_build_image_pull_policy(self) -> None:
+        # Normal cases
+        assert (
+            UserContainer(name="test", image_pull_policy="if_not_present")._build_image_pull_policy() == "IfNotPresent"
+        )
+        assert (
+            UserContainer(name="test", image_pull_policy="ifnotpresent")._build_image_pull_policy() == "IfNotPresent"
+        )
+
         assert UserContainer(name="test", image_pull_policy="Always")._build_image_pull_policy() == "Always"
         assert (
             UserContainer(name="test", image_pull_policy=ImagePullPolicy.always)._build_image_pull_policy() == "Always"
         )
         assert UserContainer(name="test")._build_image_pull_policy() is None
+
+        # Error cases
+        with pytest.raises(KeyError):
+            UserContainer(name="test", image_pull_policy="maybe")._build_image_pull_policy()
 
     def test_builds_volume_mounts(self) -> None:
         uc: ModelUserContainer = UserContainer(


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
When checking for string values of `image_pull_policy` in the `UserContainer` class, the current implementation was adding redundant items in the `policy_mapper` dict as it was confusing the `name` and `value` properties.

This PR simplifies this logic while covering the same use cases, and adds tests for normal and error cases.