### PR TITLE
Fix `to` generating to folder and refactor tests

### DIFF
--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -11,10 +11,13 @@ from typing import Generator, Iterable, List
 from hera._cli.base import GenerateYaml
 from hera.workflows.workflow import Workflow
 
+DEFAULT_EXTENSION = ".yaml"
 YAML_EXTENSIONS = {".yml", ".yaml"}
+
 
 def _write_workflow_to_yaml(target_file: Path, content: str):
     target_file.write_text(content)
+
 
 def generate_yaml(options: GenerateYaml):
     """Generate yaml from Python Workflow definitions.
@@ -38,7 +41,7 @@ def generate_yaml(options: GenerateYaml):
 
     # When `to` write file(s) to disk, otherwise output everything to stdout.
     if options.to:
-        dest_is_file = options.to.suffix in YAML_EXTENSIONS
+        dest_is_file = options.to.suffix.lower() in YAML_EXTENSIONS
 
         if dest_is_file:
             os.makedirs(options.to.parent, exist_ok=True)
@@ -50,7 +53,7 @@ def generate_yaml(options: GenerateYaml):
             os.makedirs(options.to, exist_ok=True)
 
             for dest_path, content in path_to_output:
-                _write_workflow_to_yaml((options.to / dest_path).with_suffix(".yaml"), content)
+                _write_workflow_to_yaml((options.to / dest_path).with_suffix(DEFAULT_EXTENSION), content)
 
     else:
         output = join_workflows(o for _, o in path_to_output)

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -11,6 +11,10 @@ from typing import Generator, Iterable, List
 from hera._cli.base import GenerateYaml
 from hera.workflows.workflow import Workflow
 
+YAML_EXTENSIONS = {".yml", ".yaml"}
+
+def _write_workflow_to_yaml(target_file: Path, content: str):
+    target_file.write_text(content)
 
 def generate_yaml(options: GenerateYaml):
     """Generate yaml from Python Workflow definitions.
@@ -34,18 +38,19 @@ def generate_yaml(options: GenerateYaml):
 
     # When `to` write file(s) to disk, otherwise output everything to stdout.
     if options.to:
-        dest_is_file = os.path.exists(options.to) and options.to.is_file()
+        dest_is_file = options.to.suffix in YAML_EXTENSIONS
 
         if dest_is_file:
+            os.makedirs(options.to.parent, exist_ok=True)
+
             output = join_workflows(o for _, o in path_to_output)
-            options.to.write_text(output)
+            _write_workflow_to_yaml(options.to, output)
 
         else:
             os.makedirs(options.to, exist_ok=True)
 
             for dest_path, content in path_to_output:
-                full_path = (options.to / dest_path).with_suffix(".yaml")
-                full_path.write_text(content)
+                _write_workflow_to_yaml((options.to / dest_path).with_suffix(".yaml"), content)
 
     else:
         output = join_workflows(o for _, o in path_to_output)

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock, call, mock_open, patch
 


### PR DESCRIPTION
* Previously, if a user specifies a `to` option such as `foo.yaml`, the cli will create the target as a folder `foo.yaml/`. This change inspects the suffix of the `to` path; if it is a recognised "yaml" extension, we create the file's parents, and writes the workflow to the file. We therefore do not need to check if the target exists
* The commit also refactors some code for testability and simplifies the tests themselves for readability to avoid magic number accesses
