### PR TITLE
Add RunnerException experimental feature

### DIFF
--- a/docs/walk-through/advanced-hera-features.md
+++ b/docs/walk-through/advanced-hera-features.md
@@ -135,6 +135,38 @@ global_config.experimental_features["script_pydantic_io"] = True
 
 Read the full guide on script pydantic IO in [the script user guide](../user-guides/script-runner-io.md).
 
+### Script Runner Exception
+
+The `hera.workflows.runner.RunnerException` class allows you to raise an error from your function, while still
+outputting values from your Argo template, along with an optional exit code. If the exit code is set, the container will
+exit with the given exit code, otherwise, the Exception will be raised up which will allow you to see the full stack
+trace from the container logs.
+
+To enable the `RunnerException` class, you must set the `experimental_feature` flag `script_runner_exception`.
+
+```py
+global_config.experimental_features["script_runner_exception"] = True
+```
+
+We encourage you to play around with the `RunnerException` class to try different things! It's very much an experimental
+feature that we want feedback on - please leave feedback in
+[GitHub discussions](https://github.com/argoproj-labs/hera/discussions) or the
+[CNCF Slack](https://cloud-native.slack.com/archives/C03NRMD9KPY)!
+
+An initial suggestion might be to use an all-exception `try`/`except` in your function to be able to convert the
+exception into a `RunnerException`, meaning you still get outputs from the container, along with the stack trace in the
+logs:
+
+```py
+@script(constructor="runner")
+def use_flakey_function() -> Annotated[int, Parameter(name="my-int")]:
+    try:
+        my_int = flakey_function()
+    except Exception as e:
+        raise RunnerException(-1) from e
+
+    return my_int
+```
 
 ## Graduated features
 

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -218,8 +218,13 @@ def _runner(entrypoint: str, kwargs_list: List) -> Any:
         if output_annotations:
             # This will save outputs returned from the function only. Any function parameters/artifacts marked as
             # outputs should be written to within the function itself.
+            from hera.workflows.runner import RunnerException
+
             try:
                 output = _save_annotated_return_outputs(function(**kwargs), output_annotations)
+            except RunnerException as e:
+                _save_annotated_return_outputs(e.outputs, output_annotations)
+                raise e
             except Exception as e:
                 _save_dummy_outputs(output_annotations)
                 raise e

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -224,6 +224,9 @@ def _runner(entrypoint: str, kwargs_list: List) -> Any:
                 output = _save_annotated_return_outputs(function(**kwargs), output_annotations)
             except RunnerException as e:
                 _save_annotated_return_outputs(e.outputs, output_annotations)
+                if e.exit_code is not None:
+                    exit(e.exit_code)
+
                 raise e
             except Exception as e:
                 _save_dummy_outputs(output_annotations)

--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -1,6 +1,30 @@
 """The entrypoint for the Hera Runner when running on Argo."""
 
+import os
+from typing import Any, Tuple, Union
+
 from hera.workflows._runner.util import _run
+
+
+class RunnerException(Exception):
+    """An exception class that can hold outputs to write to file on Argo before passing the exception up.
+
+    Note: Must be enabled via hera.shared.global_config.experimental_features.
+    """
+
+    def __init__(self, outputs: Union[Tuple[Any], Any]) -> None:
+        """Initialise the RunnerException with outputs to be written that match the function output annotations."""
+        if os.environ.get("hera__script_runner_exception", None) is None:
+            raise ValueError(
+                (
+                    "Unable to instantiate {} since it is an experimental feature."
+                    " Please turn on experimental features by setting "
+                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
+                    " Note that experimental features are unstable and subject to breaking changes."
+                ).format(RunnerException, "script_runner_exception")
+            )
+        self.outputs = outputs
+
 
 if __name__ == "__main__":
     _run()

--- a/src/hera/workflows/runner.py
+++ b/src/hera/workflows/runner.py
@@ -1,7 +1,7 @@
 """The entrypoint for the Hera Runner when running on Argo."""
 
 import os
-from typing import Any, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 from hera.workflows._runner.util import _run
 
@@ -12,7 +12,7 @@ class RunnerException(Exception):
     Note: Must be enabled via hera.shared.global_config.experimental_features.
     """
 
-    def __init__(self, outputs: Union[Tuple[Any], Any]) -> None:
+    def __init__(self, outputs: Union[Tuple[Any], Any], exit_code: Optional[int] = None) -> None:
         """Initialise the RunnerException with outputs to be written that match the function output annotations."""
         if os.environ.get("hera__script_runner_exception", None) is None:
             raise ValueError(
@@ -24,6 +24,7 @@ class RunnerException(Exception):
                 ).format(RunnerException, "script_runner_exception")
             )
         self.outputs = outputs
+        self.exit_code = exit_code
 
 
 if __name__ == "__main__":

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -830,6 +830,8 @@ class RunnerScriptConstructor(ScriptConstructor):
                 script.env.append(EnvVar(name="hera__pydantic_mode", value=str(self.pydantic_mode)))
             if global_config.experimental_features["script_pydantic_io"]:
                 script.env.append(EnvVar(name="hera__script_pydantic_io", value=""))
+            if global_config.experimental_features["script_runner_exception"]:
+                script.env.append(EnvVar(name="hera__script_runner_exception", value=""))
         return script
 
 

--- a/tests/script_runner/runner_exception.py
+++ b/tests/script_runner/runner_exception.py
@@ -15,3 +15,8 @@ global_config.experimental_features["script_annotations"] = True
 @script()
 def script_param() -> Annotated[int, Parameter(name="my-param")]:
     raise RunnerException(123)
+
+
+@script()
+def script_param_with_exit_code() -> Annotated[int, Parameter(name="my-param")]:
+    raise RunnerException(123, exit_code=1)

--- a/tests/script_runner/runner_exception.py
+++ b/tests/script_runner/runner_exception.py
@@ -1,0 +1,17 @@
+"""Test the correctness of the Output annotations. The test uses the runner to check the outputs and if they save correctly to files."""
+
+try:
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
+
+from hera.shared import global_config
+from hera.workflows import Parameter, script
+from hera.workflows.runner import RunnerException
+
+global_config.experimental_features["script_annotations"] = True
+
+
+@script()
+def script_param() -> Annotated[int, Parameter(name="my-param")]:
+    raise RunnerException(123)


### PR DESCRIPTION
* Allows users to raise a custom error that will output values to Argo before forwarding the exception from the Hera runner

This features offers some improvements over the `_save_dummy_outputs` function added as part of #977. The `RunnerException` class is intended to be subclassed by users to let them raise a custom error, while still outputting values from the Argo Dag/Step node. This comes from some suggestions we had internally.