### PR TITLE
Tidy up runner tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from hera.shared import global_config
@@ -10,10 +8,3 @@ def global_config_fixture():
     global_config.reset()
     yield global_config
     global_config.reset()
-
-
-@pytest.fixture
-def environ_annotations_fixture():
-    os.environ["hera__script_annotations"] = ""
-    yield
-    del os.environ["hera__script_annotations"]

--- a/tests/script_runner/annotated_outputs.py
+++ b/tests/script_runner/annotated_outputs.py
@@ -22,7 +22,7 @@ def empty_str_param() -> Annotated[str, Parameter(name="empty-str")]:
 
 
 @script()
-def none_param() -> Annotated[type(None), Parameter(name="null-str")]:
+def none_param() -> Annotated[type(None), Parameter(name="null-str")]:  # type: ignore
     return None
 
 


### PR DESCRIPTION
While working on #991 I found the runner tests quite messy. This PR cleans up the `test_runner.py` file (changes are in test files only).

* global_config doesn't need setting when using the runner, only the environment variables
* Use monkeypatch.setenv instead of os.environ
* Remove environ_annotations_fixture to make tests more explicit/obvious

