### PR TITLE
Fix script-decorated-function typing

### DIFF
--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -588,9 +588,9 @@ def _add_type_hints(
 ) -> Callable[
     ...,
     Callable[
-        ScriptIns,  # this adds Script type hints to the underlying function kwargs, i.e. `script`
+        ScriptIns,  # this adds Script type hints to the underlying *library* function kwargs, i.e. `script`
         Callable[  # we will return a function that is a decorator
-            [Callable[FuncIns, FuncR]],  # taking underlying function's inputs
+            [Callable[FuncIns, FuncR]],  # taking underlying *user* function
             Union[  # able to return FuncR | Step | Task | None
                 Callable[FuncIns, FuncR],
                 Callable[StepIns, Optional[Step]],


### PR DESCRIPTION
* Function signature is now left intact when called elsewhere
* Script decorator still suggests Script kwargs
* Also allows call site typing to use Step/Task type hints

**Pull Request Checklist**
- [x] Fixes #1017 
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
See issue for "before" screenshots.

For "after":

Script decorator type hints:
![image](https://github.com/argoproj-labs/hera/assets/17798778/627e1918-b785-453c-a0e6-fa3f3e39617b)

Function call type hints:
![image](https://github.com/argoproj-labs/hera/assets/17798778/56a36c2d-290e-451d-ae3e-0141aea32ef5)


Task/Step type hints (`arguments`, `when`, `name` etc):
![image](https://github.com/argoproj-labs/hera/assets/17798778/f0adead2-eaa4-47c0-b7be-1e71d902f6dc)

