### PR TITLE
Add "patches" group to dependabot to use one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         - "python"
         - "semver:patch"
         - "type:dependency-upgrade"
+    groups:
+      patches:  # groups all patches into 1 PR
+        update-types:
+          - "patch"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1025 

Uses the [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) feature of dependabot
