### PR TITLE
Add upper bound for pydantic 1 tests in CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install -E cli
-          poetry run pip install "pydantic<2"
+          poetry run pip install "pydantic<1.10.15"
 
       - name: run ci checks
         run: make ci


### PR DESCRIPTION
Pydantic 1.10.15 added a `v1` namespace which broke how we check for which version we're on, which in turn broke our pydantic v1 compatibility tests.