### PR TITLE
Dedent dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,10 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "America/New_York"
-      labels:
-        - "python"
-        - "semver:patch"
-        - "type:dependency-upgrade"
+    labels:
+      - "python"
+      - "semver:patch"
+      - "type:dependency-upgrade"
     groups:
       patches:  # groups all patches into 1 PR
         update-types:


### PR DESCRIPTION
[CI](https://github.com/argoproj-labs/hera/runs/23618695838) had error

```
The property '#/updates/0/schedule' contains additional properties ["labels"] outside of the schema when none are allowed
```