### PR TITLE
HEP-0001: Add new decorator syntax

### DIFF
--- a/hep/proposals/0000-decorators.md
+++ b/hep/proposals/0000-decorators.md
@@ -143,7 +143,7 @@ class CalculatorInput(hio.Input):
 
 @wt.script  # Adds a new script template to the workflow template called calculator
 def calculator(calc_input: CalculatorInput) -> hio.Output:
-    if calc_input.operation == "add"
+    if calc_input.operation == "add":
         return hio.Output(calc_input.x + calc_input.y)
     return hio.Output(calc_input.x - calc_input.y)
     

--- a/hep/proposals/0000-decorators.md
+++ b/hep/proposals/0000-decorators.md
@@ -1,0 +1,299 @@
+# Meta
+[meta]: #meta
+- Name: Hera Decorator Syntax
+- Start Date: 2024-04-13
+- Author(s): [@samj1912](https://github.com/elliotgunton), [@elliotgunton](https://github.com/elliotgunton)
+- Supersedes: (put "N/A" unless this replaces an existing HEP, then link to that HEP)
+
+# Table of Contents
+[table-of-contents]: #table-of-contents
+- [Meta](#meta)
+- [Table of Contents](#table-of-contents)
+- [Overview](#overview)
+- [Motivation](#motivation)
+- [Proposal](#proposal)
+- [Code Examples](#code-examples)
+  - [Basic Workflow](#basic-workflow)
+  - [DAG Template](#dag-template)
+  - [Steps Template](#steps-template)
+  - [Container Template](#container-template)
+  - [Workflow Template Ref](#workflow-template-ref)
+  - [How to teach (OPTIONAL)](#how-to-teach-optional)
+- [Implementation (OPTIONAL)](#implementation-optional)
+  - [Link to the Implementation PR](#link-to-the-implementation-pr)
+- [Migration (OPTIONAL)](#migration-optional)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Prior Art](#prior-art)
+- [Unresolved Questions (OPTIONAL)](#unresolved-questions-optional)
+
+# Overview
+[overview]: #overview
+
+This HEP introduces a new and powerful decorator based syntax for defining all kinds of Workflows and Templates.
+
+# Motivation
+[motivation]: #motivation
+
+The current context manager based syntax is good but it doesn't map well to template types that contain inputs/outputs. With the `@script` decorator, we have made hera feel extremely Pythonic and it has the added benefit of being runnable locally. We wish to extend this syntax to other template types which will allow for better readability and local testing and it will also standardize the template interface for Argo Workflows.
+
+# Proposal
+
+This HEP proposes that every template be mapped into a decorated function with HeraIO classes as the inputs and outputs.
+
+# Code Examples
+
+## Basic Workflow
+
+```python
+from hera.workflows import WorkflowTemplate
+from hera import io as hio
+
+# We start by defining our Workflow Template
+wt = WorkflowTemplate(name="my-template")
+
+# This defines the a template input
+class MyInput(hio.Input):
+    user: str
+
+@wt.entrypoint  # Sets hello_world as the default entrypoint for the workflow template
+@wt.script  # Adds a new script template to the workflow template called hello_world
+def hello_world(my_input: MyInput) -> hio.Output:
+    output = hio.Output()
+    output.result = f"Hello Hera User: {my_input.user}!"
+    return output
+
+# Allows users to instantiate a workflow template into a workflow
+workflow = wt.run(MyInput(name="happy-hera-user"), wait=True)
+# Returned workflow is a normal hera Workflow class and can be accessed as normal
+assert workflow.status.phase == "Succeeded"
+assert workflow.status.outputs.result == "Hello Hera User: happy-hera-user!"
+```
+
+## DAG Template
+
+```python
+from hera.workflows import WorkflowTemplate
+from hera import io as hio
+from hera.expr import spring
+
+# We start by defining our Workflow Template
+wt = WorkflowTemplate(name="my-template")
+
+@wt.script  # Adds a new script template to the workflow template
+def setup() -> hio.Output:
+    return hio.Output(result="Setting things up")
+
+class ConcatInput(hio.Input):
+    word_a: str
+    word_b: str
+
+@wt.script  # Adds a new script template to the workflow template
+def concat(concat_input: ConcatInput) -> hio.Output:
+    return hio.Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+class WorkerInput(hio.Input):
+    value_a: str
+    value_b: str
+
+class WorkerOutput(hio.Output):
+    value: str
+
+
+# The great outcome of this new syntax is that the template definition
+# vs the template call becomes very explicit.
+# When a template is defined, it is defined via the decorator which registers it
+# When a template is invoked, it is invoked either via the callable syntax or via
+# wt.run() if it is the entrypoint
+# Another great side-effect is that all the templates can also be "run" locally as functions
+@wt.entrypoint
+@wt.dag
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    # We will need to use something like python-varname
+    # to automatically create a task called "setup_task" here.
+    setup_task = setup()
+    # Note how easy it is to reference variables from the DAG template input
+    # or previous tasks.
+    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.result))
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+    # Note, we will automatically construct the dependency graph
+    # based on the input/output relationship between tasks.
+    # Users will still be able to explicitly add dependencies between tasks
+    # using the rshift operator if they wish to define dependencies amongst
+    # tasks that don't share variables directly
+    return WorkerOutput(value=final_task.result)
+```
+
+
+## Steps Template
+
+```python
+from hera.workflows import WorkflowTemplate
+from hera import io as hio
+
+# We start by defining our Workflow Template
+wt = WorkflowTemplate(name="my-template")
+
+# This defines the a template input
+class CalculatorInput(hio.Input):
+    x: int
+    y: int
+    operation: Literal["add", "sub"] = "add"
+
+@wt.script  # Adds a new script template to the workflow template called calculator
+def calculator(calc_input: CalculatorInput) -> hio.Output:
+    if calc_input.operation == "add"
+        return hio.Output(calc_input.x + calc_input.y)
+    return hio.Output(calc_input.x - calc_input.y)
+    
+
+# This defines the another template input
+class FiboInput(hio.Input):
+    num: int
+
+class FiboOutput(hio.Output):
+    num: int
+
+@wt.entrypoint
+@wt.steps  # Adds a new script template to the workflow template called fibonacci
+def fibonacci(fibo: FiboInput) -> FiboOutput:
+    # we will need to validate that users can only run/define certain kinds of expressions here
+    # and throw warnings if they are using syntax that is invalid
+    valid_number = hio.expr(fibo.num > 1)
+    previous_num = calculator(CalculatorInput(x=fibo.num, y=1, operation="sub"), when=valid_number)
+    previous_fibo = fibonacci(FiboInput(num=previous_num.result), when=valid_number)
+    current = calculator(CalculatorInput(x=fibo.num, y=previous_fibo.num), when=valid_number)
+    return FiboOutput(num=valid_number.check(current.num, 1))
+```
+
+
+
+## Container Template
+
+```python
+from hera.workflows import WorkflowTemplate, Container
+from hera import io as hio
+
+# We start by defining our Workflow Template
+wt = WorkflowTemplate(name="my-template")
+
+# This defines the a template input
+class MyInput(hio.Input):
+    user: str = "Hera"
+
+class MyOutput(hio.Output):
+    container_greeting: Annotated[str, Parameter(name="container-greeting")]
+
+@wt.entrypoint
+@wt.container(command=["sh", "-c"], args=["echo {{input.parameters.user}}"])
+def basic_hello_world(my_input: MyInput) -> hio.Output:
+    ...
+
+
+@wt.entrypoint
+@wt.container(command=["sh", "-c"])
+def advanced_hello_world(my_input: MyInput, template: Container) -> MyOutput:
+    # hio.output serves two functions. One, it allows users to create the output class
+    # which allows output path variables to be referenced.
+    # Second, it can be used to "mock" a container template when running locally and allow us to
+    # inject outputs based on inputs.
+    output: MyOutput = hio.output(my_input)
+    # template is a special variable that allows you to reference the template itself and modify
+    # its attributes. This is especially useful when trying to reference input params in args
+    template.args = [f"echo {hio.name(my_input.user)} > {hio.path(output.container_greeting)}"]
+    return output
+```
+
+## Workflow Template Ref
+
+```python
+from hera.workflows import WorkflowTemplate
+from hera import io as hio
+from hera.expr import spring
+
+# We start by defining our Workflow Template
+wt = WorkflowTemplate(name="my-template")
+
+ewt = WorkflowTemplate(name="externally-workflow-template")
+awt = WorkflowTemplate(name="another-workflow-template")
+
+@awt.script  # Adds a new script template to a workflow template called "another-workflow-template"
+def setup() -> hio.Output:
+    return hio.Output(result="Setting things up")
+
+class ConcatInput(hio.Input):
+    word_a: str
+    word_b: str
+
+
+class ConcatOutput(hio.Output):
+    value: str
+
+# Adds a new template ref from an external template
+# This can be auto-generated or typed by the user
+@ewt.template_ref
+def concat(concat_input: ConcatInput) -> ConcatOutput:
+    ...
+    # Note: we can optionally use hio.output(concat_input)
+    # again here to run "local" mock versions of this workflow template ref
+    # this will be useful in local testing
+
+class WorkerInput(hio.Input):
+    value_a: str
+    value_b: str
+
+class WorkerOutput(hio.Output):
+    value: str
+
+
+@wt.entrypoint
+@wt.dag
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    # Note that here setup will be referenced as a workflow template ref
+    # since it belongs in a different workflow template even though it is defined
+    # inside this file
+    setup_task = setup()
+    # concat is a workflow template ref and just serves as a stub
+    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.result))
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.value, word_b=task_b.value))
+    return WorkerOutput(value=final_task.value)
+```
+
+
+
+## How to teach (OPTIONAL)
+
+If applicable, describe the differences between teaching this to existing users and new users.
+
+
+# Implementation (OPTIONAL)
+
+TODO: Add links about https://github.com/alexmojaki/sorcery#select_from, https://github.com/alexmojaki/executing#libraries-that-use-this and https://github.com/pwwang/python-varname
+
+## Link to the Implementation PR
+
+# Migration (OPTIONAL)
+
+This section should document breaks to public API and breaks in compatibility due to this HEP's proposed changes. In addition, it should document the proposed steps that one would need to take to work through these changes.
+
+# Drawbacks
+
+Why should we **not** do this?
+
+# Alternatives
+
+- What other designs have been considered?
+- Why is this proposal the best?
+- What is the impact of not doing this?
+
+# Prior Art
+
+Discuss prior art, both the good and bad.
+
+# Unresolved Questions (OPTIONAL)
+
+- What parts of the design do you expect to be resolved before this gets merged?
+- What parts of the design do you expect to be resolved through implementation of the feature?
+- What related issues do you consider out of scope for this HEP that could be addressed in the future independently of the solution that comes out of this HEP?

--- a/hep/proposals/0000-template.md
+++ b/hep/proposals/0000-template.md
@@ -2,7 +2,7 @@
 [meta]: #meta
 - Name: (fill in the feature name: My Feature)
 - Start Date: (fill in today's date: YYYY-MM-DD)
-- Update data (optional): (fill in today's date: YYYY-MM-DD)
+- Update date (optional): (fill in today's date: YYYY-MM-DD)
 - Author(s): (Github usernames)
 - Supersedes: (put "N/A" unless this replaces an existing HEP, then link to that HEP)
 

--- a/hep/proposals/0001-decorators.md
+++ b/hep/proposals/0001-decorators.md
@@ -19,6 +19,7 @@
   - [Container Template](#container-template)
   - [Template Refs](#template-refs)
   - [Template Sets](#template-sets)
+  - [Fan-outs](#fan-outs)
   - [How to teach](#how-to-teach)
 - [Implementation](#implementation)
 <!-- - [Migration (OPTIONAL)](#migration-optional) -->
@@ -194,7 +195,6 @@ def calculator(calc_input: CalculatorInput) -> hio.Output:
     if calc_input.operation == "add":
         return hio.Output(calc_input.x + calc_input.y)
     return hio.Output(calc_input.x - calc_input.y)
-    
 
 # This defines another template's inputs
 class FiboInput(hio.Input):
@@ -344,27 +344,25 @@ def concat(concat_input: ConcatInput) -> ConcatOutput:
 def my_concat_function(concat_input: ConcatInput) -> ConcatOutput:
     ...
 
-
-class WorkerInput(hio.Input):
+class MyDagInput(hio.Input):
     value_a: str
     value_b: str
 
-class WorkerOutput(hio.Output):
+class MyDagOutput(hio.Output):
     value: str
-
 
 @wt.entrypoint
 @wt.dag
-def worker(worker_input: WorkerInput) -> WorkerOutput:
+def my_dag(my_dag_input: MyDagInput) -> MyDagOutput:
     # Here, the call to `setup` will create a template ref task since it belongs
     # in a different workflow template even though it is defined inside this file
     setup_task = setup()
 
     # concat serves as a stub, and will also become a template ref task
-    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.result))
-    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    task_a = concat(ConcatInput(word_a=my_dag_input.value_a, word_b=setup_task.result))
+    task_b = concat(ConcatInput(word_a=my_dag_input.value_b, word_b=setup_task.result))
     final_task = concat(ConcatInput(word_a=task_a.value, word_b=task_b.value))
-    return WorkerOutput(value=final_task.value)
+    return MyDagOutput(value=final_task.value)
 ```
 
 ## Template Sets
@@ -380,6 +378,200 @@ def setup() -> hio.Output:
     return hio.Output(result="Setting things up")
 
 wt.add_template_set(templates)
+```
+
+## Fan-outs
+
+### Static (items)
+
+#### Basic `with_items`
+
+```python
+from hera.workflows import WorkflowTemplate
+import hera.workflows.io as hio
+
+wt = WorkflowTemplate(name="my-template")
+
+class WorkerInput(hio.Input):
+    value: str
+
+class StorageInput(hio.Input):
+    data: str
+
+@wt.script
+def process_data(worker_input: WorkerInput) -> hio.Output:
+    new_data = worker_input.value * 5  # "a" becomes "aaaaa"
+    return hio.Output(result=new_data)
+
+@wt.script
+def store_data(storage_input: Storage_input) -> None:
+    ...
+
+@wt.entrypoint
+@wt.dag
+def fanout_dag():
+    # Create a task which will fan-out to process the data
+    process_data_task = process_data(WorkerInput(value=hio.Item), with_items=["a", "b", "c", "d", "e"])
+
+    # Task to collect data (fan-in)
+    store_data = store_data(StorageInput(data=process_data_task.result))
+```
+
+#### Dictionary `with_items`
+
+```python
+from hera.workflows import WorkflowTemplate
+import hera.workflows.io as hio
+
+wt = WorkflowTemplate(name="my-template")
+
+class WorkerInput(hio.Input):
+    param_1: str
+    param_2: str
+    param_3: str
+
+class StorageInput(hio.Input):
+    data: str
+
+@wt.script
+def process_data(worker_input: WorkerInput) -> hio.Output:
+    new_data = f"{worker_input.param_1}{worker_input.param_2}{worker_input.param_3}"
+    return hio.Output(result=new_data)
+
+@wt.script
+def store_data(storage_input: Storage_input) -> None:
+    ...
+
+@wt.entrypoint
+@wt.dag
+def fanout_dag():
+    # Use a list of dictionaries for this example, to demonstrate how we can access the keys of the dictionary item
+    my_items = [
+        {
+            "param_1": "A",
+            "param_2": "B",
+            "param_3": "C",
+        },
+        {
+            "param_1": "X",
+            "param_2": "Y",
+            "param_3": "Z",
+        },
+    ]
+    # Create a task which will fan-out to process the data
+    process_data_task = process_data(
+        WorkerInput(
+            param_1=hio.Item["param_1"],  # Access the item's keys via dictionary key syntax on the special `Item` class
+            param_2=hio.Item["param_2"],
+            param_3=hio.Item["param_3"],
+        ),
+        with_items=my_items,
+    )
+
+    # Task to collect data (fan-in)
+    store_data(StorageInput(data=process_data_task.result))
+```
+
+### Dynamic (params)
+
+#### Basic `with_param`
+
+```python
+from hera.workflows import WorkflowTemplate
+import hera.workflows.io as hio
+
+wt = WorkflowTemplate(name="my-template")
+
+class WorkerInput(hio.Input):
+    value: str
+
+class StorageInput(hio.Input):
+    data: str
+
+@wt.script
+def get_data() -> hio.Output:
+    data = random.sample("abcdef", 5)  # e.g. data=['e', 'b', 'a', 'c', 'd']
+    return hio.Output(result=data)
+
+@wt.script
+def process_data(worker_input: WorkerInput) -> hio.Output:
+    new_data = worker_input.value * 5  # "a" becomes "aaaaa"
+    return hio.Output(result=new_data)
+
+@wt.script
+def store_data(storage_input: Storage_input) -> None:
+    ...
+
+@wt.entrypoint
+@wt.dag
+def fanout_dag():
+    # Get data which will be stored in `result`
+    data = get_data()
+
+    # Create a task which will fan-out to process the data
+    process_data_task = process_data(WorkerInput(value=hio.Param), with_param=data.result)
+
+    # Task to collect data (fan-in)
+    store_data(StorageInput(data=process_data_task.result))
+```
+
+#### Dictionary `with_param`
+
+```python
+from hera.workflows import WorkflowTemplate
+import hera.workflows.io as hio
+import random
+
+wt = WorkflowTemplate(name="my-template")
+
+class WorkerInput(hio.Input):
+    value: str
+
+class StorageInput(hio.Input):
+    data: str
+
+@wt.script
+def get_data() -> hio.Output:
+    string = "abcdef"
+    data = {
+        "param_1": random.choice(string)
+        "param_2": random.choice(string)
+        "param_3": random.choice(string)
+    }
+    return hio.Output(result=data)
+
+@wt.script
+def get_data() -> hio.Output:
+    data = random.sample("abcdef", 5)  # e.g. data=['e', 'b', 'a', 'c', 'd']
+    return hio.Output(result=data)
+
+@wt.script
+def process_data(worker_input: WorkerInput) -> hio.Output:
+    new_data = worker_input.value * 5  # "a" becomes "aaaaa"
+    return hio.Output(result=new_data)
+
+@wt.script
+def store_data(storage_input: Storage_input) -> None:
+    ...
+
+@wt.entrypoint
+@wt.dag
+def fanout_dag():
+    # Get data which will be stored in `result`
+    data = get_data()
+
+    # Create a task which will fan-out to process the dynamically-generated data
+    process_data_task = process_data(
+        WorkerInput(
+            param_1=hio.Param["param_1"],  # Access the item's keys via dictionary key syntax on the special `Param` class
+            param_2=hio.Param["param_2"],
+            param_3=hio.Param["param_3"],
+        ),
+        with_items=my_items,
+    )
+
+    # Task to collect data (fan-in)
+    store_data(StorageInput(data=process_data_task.result))
 ```
 
 ## How to teach

--- a/hep/proposals/0001-decorators.md
+++ b/hep/proposals/0001-decorators.md
@@ -440,7 +440,7 @@ class Workflow(...):
 
 # Alternatives
 
-We could keep only the current context manager syntax, however, users still struggle with passing parameters and have to resort to Argo's underlying esoteric YAML syntax, and DAG and Steps templates are not locally executable. Within the existing codebase/design of Hera, alternative such as new classes doesn't make the most sense compared to decorators, as we already have a precedent with the current `script` decorator.
+We could keep only the current context manager syntax, however, users still struggle with passing parameters and have to resort to Argo's underlying esoteric YAML syntax, and DAG and Steps templates are not locally executable. Within the existing codebase/design of Hera, alternatives such as new classes don't make the most sense compared to decorators, as we have already set a precedent with the current `script` decorator.
 
 # Prior Art
 

--- a/hep/proposals/0001-decorators.md
+++ b/hep/proposals/0001-decorators.md
@@ -337,10 +337,9 @@ def worker(worker_input: WorkerInput) -> WorkerOutput:
 
 
 
-## How to teach (OPTIONAL)
+## How to teach
 
-If applicable, describe the differences between teaching this to existing users and new users.
-
+Given the existing `script` decorator is used throughout the walk through and examples, we will need to be clear if and when we replace it with the workflow-specific `script` decorator, as the feature will need to go through the `experimental_features` route. We should then consider re-writing the walkthrough and key examples to use the new decorators. We may want to consider a migration guide or tool to convert from the old `script` to the new to make this easier for ourselves and our users.
 
 # Implementation
 

--- a/hep/proposals/0001-decorators.md
+++ b/hep/proposals/0001-decorators.md
@@ -41,6 +41,9 @@ The current context manager based syntax is good (especially for bridging the ga
 
 This HEP proposes that Argo's DAG, Steps and Container templates be mapped into Hera as decorated functions with HeraIO classes as the inputs and outputs. We will also introduce a new script decorator under the `hera.workflows.workflow.Workflow` class which will enforce use of the script runner along with the HeraIO classes.
 
+> ⚠️ The existing context manager syntax, and the script decorator, will continue to be supported, but they are unlikely
+> to receive any active development of new features.
+
 # Code Examples
 
 ## Basic Workflow

--- a/hep/proposals/0001-decorators.md
+++ b/hep/proposals/0001-decorators.md
@@ -2,7 +2,7 @@
 [meta]: #meta
 - Name: Hera Decorator Syntax
 - Start Date: 2024-04-13
-- Author(s): [@samj1912](https://github.com/elliotgunton), [@elliotgunton](https://github.com/elliotgunton)
+- Author(s): [@samj1912](https://github.com/samj1912), [@elliotgunton](https://github.com/elliotgunton)
 - Supersedes: N/A
 
 # Table of Contents


### PR DESCRIPTION
Adds a new decorator syntax HEP that allows us to call all kinds of template and even makes defining steps and dag templates easier.

This will largely involve an implementation on top of libraries like https://github.com/alexmojaki/executing#executing and https://pypi.org/project/varname/

The eventual goal of this syntax is to allow hera templates to be run locally as well. In order to do that, we will also need to provide appropriate local implementation of the `expr` library.

cc: @elliotgunton, @flaviuvadan 

[Readable version](https://github.com/argoproj-labs/hera/blob/decorator-syntax/hep/proposals/0001-decorators.md)