### PR TITLE
enable CronWorkflow.from_dict() to work with subclasses

### DIFF
--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -161,7 +161,7 @@ class CronWorkflow(Workflow):
     def _from_model(cls, model: BaseModel) -> ModelMapperMixin:
         """Parse from given model to cls's type."""
         assert isinstance(model, _ModelCronWorkflow)
-        hera_cron_workflow = CronWorkflow(schedule="")
+        hera_cron_workflow = cls(schedule="")
 
         for attr, annotation in cls._get_all_annotations().items():
             if get_origin(annotation) is Annotated and isinstance(


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, when subclassing CronWorkflow, the `from_dict` method returns an instance of CronWorkflow rather than the subclass.

This PR changes the creation of the instance to use `cls` rather than `CronWorkflow`, so that `from_dict` returns an instance of the subclass.
