### PR TITLE
fix macos runners

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,8 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: macos-latest
+            python-version: 3.11
+          - os: macos-latest
+            python-version: 3.12
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
https://github.com/actions/setup-python/issues/852
With macos-latest moving from macos-12 to macos-14, there are fewer available python versions.

This PR pins the previous macos-latest runner to macos-12 and adds entries for python 3.11 and 3.12 available on macos-14.
