### PR TITLE
Check pydantic.VERSION in place of find_spec

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install -E cli
-          poetry run pip install "pydantic<1.10.15"
+          poetry run pip install "pydantic<2"
 
       - name: run ci checks
         run: make ci

--- a/src/hera/shared/_pydantic.py
+++ b/src/hera/shared/_pydantic.py
@@ -1,6 +1,6 @@
 """Module that holds the underlying base Pydantic models for Hera objects."""
 
-from typing import TYPE_CHECKING, Any, Dict, Literal, Type
+from typing import TYPE_CHECKING, Any, Dict, Type
 
 from pydantic import VERSION
 

--- a/src/hera/shared/_pydantic.py
+++ b/src/hera/shared/_pydantic.py
@@ -2,20 +2,20 @@
 
 from typing import TYPE_CHECKING, Any, Dict, Literal, Type
 
-_PYDANTIC_VERSION: Literal[1, 2] = 1
+from pydantic import VERSION
+
+_PYDANTIC_VERSION: int = int(VERSION.split(".")[0])
 # The pydantic v1 interface is used for both pydantic v1 and v2 in order to support
 # users across both versions.
 
-try:
+if _PYDANTIC_VERSION == 2:
     from pydantic.v1 import (  # type: ignore
         Field,
         ValidationError,
         root_validator,
         validator,
     )
-
-    _PYDANTIC_VERSION = 2
-except (ImportError, ModuleNotFoundError):
+else:
     from pydantic import (  # type: ignore[assignment,no-redef]
         Field,
         ValidationError,
@@ -23,18 +23,15 @@ except (ImportError, ModuleNotFoundError):
         validator,
     )
 
-    _PYDANTIC_VERSION = 1
-
-
 # TYPE_CHECKING-guarding specifically the `BaseModel` import helps the type checkers
 # provide proper type checking to models. Without this, both mypy and pyright lose
 # native pydantic hinting for `__init__` arguments.
 if TYPE_CHECKING:
     from pydantic import BaseModel as PydanticBaseModel
 else:
-    try:
+    if _PYDANTIC_VERSION == 2:
         from pydantic.v1 import BaseModel as PydanticBaseModel  # type: ignore
-    except (ImportError, ModuleNotFoundError):
+    else:
         from pydantic import BaseModel as PydanticBaseModel  # type: ignore[assignment,no-redef]
 
 

--- a/src/hera/shared/serialization.py
+++ b/src/hera/shared/serialization.py
@@ -10,9 +10,9 @@ from pydantic import BaseModel
 # for hera internal models, we still need to support v1 base models.
 from hera.shared._pydantic import _PYDANTIC_VERSION
 
-try:
+if _PYDANTIC_VERSION == 2:
     from pydantic.v1 import BaseModel as V1BaseModel  # type: ignore
-except (ImportError, ModuleNotFoundError):
+else:
     V1BaseModel = None  # type: ignore
 
 MISSING = object()

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -28,14 +28,14 @@ try:
 except ImportError:
     from typing_extensions import Annotated, get_args, get_origin  # type: ignore
 
-try:  # pydantic-v1/v2 related imports
+if _PYDANTIC_VERSION == 2:
     from pydantic.type_adapter import TypeAdapter  # type: ignore
     from pydantic.v1 import parse_obj_as  # type: ignore
 
     from hera.workflows.io.v2 import (  # type: ignore
         RunnerOutput as RunnerOutputV2,
     )
-except ImportError:
+else:
     from pydantic import parse_obj_as
 
     from hera.workflows.io.v1 import (  # type: ignore

--- a/src/hera/workflows/io/__init__.py
+++ b/src/hera/workflows/io/__init__.py
@@ -1,8 +1,8 @@
 """Hera IO models."""
 
-from importlib.util import find_spec
+from pydantic import VERSION
 
-if find_spec("pydantic.v1"):
+if VERSION.split(".")[0] == "2":
     from hera.workflows.io.v2 import RunnerInput, RunnerOutput
 else:
     from hera.workflows.io.v1 import RunnerInput, RunnerOutput  # type: ignore

--- a/src/hera/workflows/io/v2.py
+++ b/src/hera/workflows/io/v2.py
@@ -6,6 +6,7 @@ RunnerInput/Output are only defined in this file if Pydantic v2 is installed.
 from collections import ChainMap
 from typing import Any, List, Optional, Union
 
+from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.shared.serialization import MISSING, serialize
 from hera.workflows.artifact import Artifact
 from hera.workflows.parameter import Parameter
@@ -20,9 +21,8 @@ try:
 except ImportError:
     from typing_extensions import Annotated, get_args, get_origin  # type: ignore
 
-from importlib.util import find_spec
 
-if find_spec("pydantic.v1"):
+if _PYDANTIC_VERSION == 2:
     from pydantic import BaseModel
     from pydantic_core import PydanticUndefined
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1021 
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, Hera is incompatible with `pydantic==1.10.15` due to the `v1` submodule alias being added in that patch. This PR changes the use of `find_spec` to instead check `pydantic.VERSION`.