### PR TITLE
Remove ArgumentsMixin from wrong classes

### DIFF
--- a/docs/examples/workflows/loops/dynamic_fanout_container.md
+++ b/docs/examples/workflows/loops/dynamic_fanout_container.md
@@ -22,7 +22,6 @@ More details can be found here: https://github.com/argoproj-labs/hera-workflows/
     fanout = Container(
         name="fanout",
         inputs=[Parameter(name="value")],
-        arguments=[Parameter(name="value", value="{{item.value}}")],
         image="alpine:latest",
         command=["echo", "{{inputs.parameters.value}}"],
     )
@@ -33,7 +32,9 @@ More details can be found here: https://github.com/argoproj-labs/hera-workflows/
             # this can be anything! e.g. fetch from some API, then in parallel process all entities; chunk database records
             # and process them in parallel, etc.
             g = generate()
-            f = fanout(with_param=g.result)  # this make the task fan out over the `with_param`
+            f = fanout(
+                arguments={"value": "{{item.value}}"}, with_param=g.result
+            )  # this make the task fan out over the `with_param`
             g >> f
     ```
 

--- a/examples/workflows/loops/dynamic_fanout_container.py
+++ b/examples/workflows/loops/dynamic_fanout_container.py
@@ -16,7 +16,6 @@ generate = Container(
 fanout = Container(
     name="fanout",
     inputs=[Parameter(name="value")],
-    arguments=[Parameter(name="value", value="{{item.value}}")],
     image="alpine:latest",
     command=["echo", "{{inputs.parameters.value}}"],
 )
@@ -27,5 +26,7 @@ with Workflow(generate_name="dynamic-fanout-container-", entrypoint="d") as w:
         # this can be anything! e.g. fetch from some API, then in parallel process all entities; chunk database records
         # and process them in parallel, etc.
         g = generate()
-        f = fanout(with_param=g.result)  # this make the task fan out over the `with_param`
+        f = fanout(
+            arguments={"value": "{{item.value}}"}, with_param=g.result
+        )  # this make the task fan out over the `with_param`
         g >> f

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -352,12 +352,9 @@ class CallableTemplateMixin(BaseMixin):
 
     def _get_arguments(self, **kwargs) -> List:
         """Returns a list of arguments from the kwargs given to the template call."""
-        # these are the already set parameters. If a user has already set a parameter argument, then Hera
-        # uses the user-provided value rather than the inferred value
         kwargs_arguments = kwargs.get("arguments", [])
         kwargs_arguments = kwargs_arguments if isinstance(kwargs_arguments, List) else [kwargs_arguments]  # type: ignore
-        arguments = self.arguments if hasattr(self, "arguments") and self.arguments else [] + kwargs_arguments
-        return list(filter(lambda x: x is not None, arguments))
+        return kwargs_arguments
 
     def _get_parameter_names(self, arguments: List) -> Set[str]:
         """Returns the union of parameter names from the given arguments' parameter objects and dictionary keys."""

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -533,7 +533,7 @@ class VolumeMountMixin(VolumeMixin):
 
 
 class ArgumentsMixin(BaseMixin):
-    """`ArgumentsMixin` provides the ability to set the `arguments` field on the inheriting object."""
+    """`ArgumentsMixin` provides the ability to set the `arguments` field on the inheriting object (only Tasks, Steps and Workflows use arguments)."""
 
     arguments: ArgumentsT = None
     _normalize_arguments = validator("arguments", allow_reuse=True)(normalize_to_list_or(ModelArguments))

--- a/src/hera/workflows/container.py
+++ b/src/hera/workflows/container.py
@@ -10,7 +10,6 @@ from typing import List, Optional
 
 from hera.workflows._meta_mixins import CallableTemplateMixin
 from hera.workflows._mixins import (
-    ArgumentsMixin,
     ContainerMixin,
     EnvIOMixin,
     ResourceMixin,
@@ -26,7 +25,6 @@ from hera.workflows.models import (
 
 
 class Container(
-    ArgumentsMixin,
     EnvIOMixin,
     ContainerMixin,
     TemplateMixin,

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -6,7 +6,6 @@ from typing import Any, List, Optional, Union
 
 from hera.workflows._meta_mixins import CallableTemplateMixin, ContextMixin
 from hera.workflows._mixins import (
-    ArgumentsMixin,
     ContainerMixin,
     EnvIOMixin,
     EnvMixin,
@@ -26,7 +25,7 @@ from hera.workflows.models import (
 )
 
 
-class ContainerNode(ArgumentsMixin, ContainerMixin, VolumeMountMixin, ResourceMixin, EnvMixin, SubNodeMixin):
+class ContainerNode(ContainerMixin, VolumeMountMixin, ResourceMixin, EnvMixin, SubNodeMixin):
     """A regular container that can be used as part of a `hera.workflows.ContainerSet`.
 
     See Also:

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, List, Optional, Union
 
 from hera.workflows._meta_mixins import CallableTemplateMixin, ContextMixin
-from hera.workflows._mixins import ArgumentsMixin, IOMixin, TemplateMixin
+from hera.workflows._mixins import IOMixin, TemplateMixin
 from hera.workflows.exceptions import InvalidType
 from hera.workflows.models import (
     DAGTask,
@@ -20,7 +20,6 @@ from hera.workflows.task import Task
 
 
 class DAG(
-    ArgumentsMixin,
     IOMixin,
     TemplateMixin,
     CallableTemplateMixin,

--- a/src/hera/workflows/data.py
+++ b/src/hera/workflows/data.py
@@ -5,11 +5,11 @@ from typing import List, Union
 from hera.expr._node import Node
 from hera.workflows import models as m
 from hera.workflows._meta_mixins import CallableTemplateMixin
-from hera.workflows._mixins import ArgumentsMixin, IOMixin, TemplateMixin
+from hera.workflows._mixins import IOMixin, TemplateMixin
 from hera.workflows.artifact import Artifact
 
 
-class Data(ArgumentsMixin, TemplateMixin, IOMixin, CallableTemplateMixin):
+class Data(TemplateMixin, IOMixin, CallableTemplateMixin):
     """`Data` implements the Argo data template representation.
 
     Data can be used to indicate that some data, identified by a `source`, should be processed via the specified

--- a/src/hera/workflows/http_template.py
+++ b/src/hera/workflows/http_template.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 from hera.workflows._meta_mixins import CallableTemplateMixin
-from hera.workflows._mixins import ArgumentsMixin, IOMixin, TemplateMixin
+from hera.workflows._mixins import IOMixin, TemplateMixin
 from hera.workflows.models import (
     HTTP as _ModelHTTP,
     HTTPBodySource,
@@ -12,7 +12,7 @@ from hera.workflows.models import (
 )
 
 
-class HTTP(ArgumentsMixin, TemplateMixin, IOMixin, CallableTemplateMixin):
+class HTTP(TemplateMixin, IOMixin, CallableTemplateMixin):
     """`HTTP` is an implementation of the HTTP template that supports executing HTTP actions in a step/task."""
 
     url: str

--- a/src/hera/workflows/resource.py
+++ b/src/hera/workflows/resource.py
@@ -3,7 +3,7 @@
 from typing import List, Optional, Union
 
 from hera.workflows._meta_mixins import CallableTemplateMixin
-from hera.workflows._mixins import ArgumentsMixin, IOMixin, SubNodeMixin, TemplateMixin
+from hera.workflows._mixins import IOMixin, SubNodeMixin, TemplateMixin
 from hera.workflows.cron_workflow import CronWorkflow
 from hera.workflows.models import (
     ManifestFrom,
@@ -14,7 +14,7 @@ from hera.workflows.workflow import Workflow
 from hera.workflows.workflow_template import WorkflowTemplate
 
 
-class Resource(ArgumentsMixin, CallableTemplateMixin, TemplateMixin, SubNodeMixin, IOMixin):
+class Resource(CallableTemplateMixin, TemplateMixin, SubNodeMixin, IOMixin):
     """`Resource` is a representation of a K8s resource that can be created by Argo.
 
     The resource is a callable step that can be invoked in a DAG/Workflow. The resource can create any K8s resource,

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -31,7 +31,6 @@ from hera.shared._pydantic import _PYDANTIC_VERSION, root_validator, validator
 from hera.workflows._context import _context
 from hera.workflows._meta_mixins import CallableTemplateMixin
 from hera.workflows._mixins import (
-    ArgumentsMixin,
     ContainerMixin,
     EnvIOMixin,
     ResourceMixin,
@@ -108,7 +107,6 @@ class ScriptConstructor(BaseMixin):
 
 
 class Script(
-    ArgumentsMixin,
     EnvIOMixin,
     CallableTemplateMixin,
     ContainerMixin,

--- a/src/hera/workflows/suspend.py
+++ b/src/hera/workflows/suspend.py
@@ -10,7 +10,7 @@ See https://argoproj.github.io/argo-workflows/intermediate-inputs/ for more on i
 from typing import List, Optional, Union
 
 from hera.workflows._meta_mixins import CallableTemplateMixin
-from hera.workflows._mixins import ArgumentsMixin, TemplateMixin
+from hera.workflows._mixins import TemplateMixin
 from hera.workflows.models import (
     Inputs,
     Outputs,
@@ -21,7 +21,6 @@ from hera.workflows.parameter import Parameter
 
 
 class Suspend(
-    ArgumentsMixin,
     TemplateMixin,
     CallableTemplateMixin,
 ):


### PR DESCRIPTION
* Followup to #1047 where we split out ArgumentsMixin from CallableTemplateMixin, I realised ArgumentsMixin shouldn't be on actual templates (like DAG and Steps), but only on Task, Step or Workflows
* Updated dynamic_fanout_container example as setting arguments on a Container should not be possible