### PR TITLE
New dag decorator

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -33,7 +33,7 @@ jobs:
           cache: "poetry"
 
       - name: Install dependencies
-        run: poetry install -E cli
+        run: poetry install --all-extras
 
       - name: run ci checks
         run: make ci
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install -E cli
+          poetry install --all-extras
           poetry run pip install "pydantic<2"
 
       - name: run ci checks
@@ -95,8 +95,6 @@ jobs:
   workflow-tests:
     name: run workflow tests
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
 
     runs-on: ubuntu-latest
 
@@ -114,7 +112,7 @@ jobs:
           cache: "poetry"
 
       - name: Install dependencies
-        run: poetry install -E cli
+        run: poetry install --all-extras
 
       - name: setup k3d cluster
         run: make install-k3d

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ codegen: models services examples init-files
 check-codegen: ## Check if the code is up to date
 check-codegen:
 	@$(MAKE) codegen
-	git diff --exit-code || "Code is not up-to-date. Please run 'make codegen'"
+	@git diff --exit-code || echo "Code is not up-to-date. Please run 'make codegen'"
 
 .PHONY: format
 format: ## Format and sort imports for source, tests, examples, etc.

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ examples:  ## Generate documentation files for examples
 
 .PHONY: regenerate-example
 regenerate-example:  ## Regenerates the yaml for a single example, using EXAMPLE_FILENAME envvar
-regenerate-example: install-3.8
+regenerate-example: install
 	@HERA_REGENERATE=1 poetry run python -m pytest -k $(EXAMPLE_FILENAME)
 
 .PHONY: regenerate-test-data

--- a/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
@@ -1,0 +1,132 @@
+# New Dag Decorator Artifacts
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from typing_extensions import Annotated
+
+    from hera.shared import global_config
+    from hera.workflows import Artifact, Input, Output, Workflow
+
+    global_config.experimental_features["script_annotations"] = True
+    global_config.experimental_features["script_pydantic_io"] = True
+
+
+    w = Workflow(generate_name="my-workflow-")
+
+
+    class ArtifactOutput(Output):
+        an_artifact: Annotated[str, Artifact(name="an-artifact")]
+
+
+    class ConcatInput(Input):
+        word_a: Annotated[str, Artifact(name="word_a")]
+        word_b: Annotated[str, Artifact(name="word_b")]
+
+
+    @w.script()
+    def concat(concat_input: ConcatInput) -> ArtifactOutput:
+        return ArtifactOutput(an_artifact=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+    class WorkerInput(Input):
+        artifact_a: Annotated[str, Artifact(name="artifact_a")]
+        artifact_b: Annotated[str, Artifact(name="artifact_b")]
+
+
+    @w.set_entrypoint
+    @w.dag()
+    def worker(worker_input: WorkerInput) -> ArtifactOutput:
+        concat_1 = concat(
+            ConcatInput(
+                word_a=worker_input.artifact_a,
+                word_b=worker_input.artifact_b,
+            )
+        )
+
+        concat_2 = concat(
+            ConcatInput(
+                word_a=concat_1.an_artifact,
+                word_b=concat_1.an_artifact,
+            ),
+            name="concat-2-custom-name",
+        )
+
+        return ArtifactOutput(an_artifact=concat_2.an_artifact)
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: my-workflow-
+    spec:
+      entrypoint: worker
+      templates:
+      - inputs:
+          artifacts:
+          - name: word_a
+            path: /tmp/hera-inputs/artifacts/word_a
+          - name: word_b
+            path: /tmp/hera-inputs/artifacts/word_b
+        name: concat
+        outputs:
+          artifacts:
+          - name: an-artifact
+            path: /tmp/hera-outputs/artifacts/an-artifact
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_dag_decorator_artifacts:concat
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - dag:
+          tasks:
+          - arguments:
+              artifacts:
+              - from: '{{inputs.artifacts.artifact_a}}'
+                name: word_a
+              - from: '{{inputs.artifacts.artifact_b}}'
+                name: word_b
+            name: concat_1
+            template: concat
+          - arguments:
+              artifacts:
+              - from: '{{tasks.concat_1.outputs.artifacts.an-artifact}}'
+                name: word_a
+              - from: '{{tasks.concat_1.outputs.artifacts.an-artifact}}'
+                name: word_b
+            depends: concat_1
+            name: concat-2-custom-name
+            template: concat
+        inputs:
+          artifacts:
+          - name: artifact_a
+            path: /tmp/hera-inputs/artifacts/artifact_a
+          - name: artifact_b
+            path: /tmp/hera-inputs/artifacts/artifact_b
+        name: worker
+        outputs:
+          artifacts:
+          - from: '{{tasks.concat-2-custom-name.outputs.artifacts.an-artifact}}'
+            name: an-artifact
+    ```
+

--- a/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
@@ -15,6 +15,7 @@
 
     global_config.experimental_features["script_annotations"] = True
     global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
 
     w = Workflow(generate_name="my-workflow-")

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -13,6 +13,7 @@
 
     global_config.experimental_features["script_annotations"] = True
     global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
 
     w = Workflow(generate_name="my-workflow-")

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -1,0 +1,267 @@
+# New Dag Decorator Inner Dag
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.shared import global_config
+    from hera.workflows import Input, Output, Workflow
+
+    global_config.experimental_features["script_annotations"] = True
+    global_config.experimental_features["script_pydantic_io"] = True
+
+
+    w = Workflow(generate_name="my-workflow-")
+
+
+    class SetupOutput(Output):
+        environment_parameter: str
+
+
+    @w.script()
+    def setup() -> SetupOutput:
+        return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+    class ConcatInput(Input):
+        word_a: str
+        word_b: str
+
+
+    @w.script()
+    def concat(concat_input: ConcatInput) -> Output:
+        return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+    class WorkerInput(Input):
+        value_a: str
+        value_b: str
+
+
+    class WorkerOutput(Output):
+        value: str
+
+
+    @w.dag()
+    def worker(worker_input: WorkerInput) -> WorkerOutput:
+        setup_task = setup()
+        task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.environment_parameter))
+        task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+        final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+        return WorkerOutput(value=final_task.result)
+
+    @w.set_entrypoint
+    @w.dag()
+    def outer_dag(worker_input: WorkerInput) -> WorkerOutput:
+        sub_dag_a = worker(WorkerInput(value_a="dag_a", value_b=worker_input.value_a))
+        sub_dag_b = worker(WorkerInput(value_a="dag_b", value_b=worker_input.value_b))
+
+        sub_dag_c = worker(WorkerInput(value_a=sub_dag_a.value, value_b=sub_dag_b.value))
+
+        return WorkerOutput(value=sub_dag_c.value)
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: my-workflow-
+    spec:
+      entrypoint: outer-dag
+      templates:
+      - name: setup
+        outputs:
+          parameters:
+          - name: environment_parameter
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/environment_parameter
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_dag_decorator_inner_dag:setup
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - inputs:
+          parameters:
+          - name: word_a
+          - name: word_b
+        name: concat
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_dag_decorator_inner_dag:concat
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - dag:
+          tasks:
+          - name: setup_task
+            template: setup
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_a}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
+            depends: setup_task
+            name: task_a
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_b}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.result}}'
+            depends: setup_task
+            name: task_b
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.task_a.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.task_b.outputs.result}}'
+            depends: task_a && task_b
+            name: final_task
+            template: concat
+        inputs:
+          parameters:
+          - name: value_a
+          - name: value_b
+        name: worker
+        outputs:
+          parameters:
+          - name: value
+            valueFrom:
+              parameter: '{{tasks.final_task.outputs.result}}'
+      - dag:
+          tasks:
+          - name: setup_task
+            template: setup
+          - arguments:
+              parameters:
+              - name: word_a
+                value: dag_a
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
+            depends: setup_task
+            name: task_a
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_a}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.result}}'
+            depends: setup_task
+            name: task_b
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.task_a.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.task_b.outputs.result}}'
+            depends: task_a && task_b
+            name: final_task
+            template: concat
+          - depends: final_task
+            name: setup_task
+            template: setup
+          - arguments:
+              parameters:
+              - name: word_a
+                value: dag_b
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
+            depends: setup_task
+            name: task_a
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_b}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.result}}'
+            depends: setup_task
+            name: task_b
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.task_a.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.task_b.outputs.result}}'
+            depends: task_a && task_b
+            name: final_task
+            template: concat
+          - depends: final_task
+            name: setup_task
+            template: setup
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.final_task.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
+            depends: setup_task
+            name: task_a
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.final_task.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.result}}'
+            depends: setup_task
+            name: task_b
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.task_a.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.task_b.outputs.result}}'
+            depends: task_a && task_b
+            name: final_task
+            template: concat
+        inputs:
+          parameters:
+          - name: value_a
+          - name: value_b
+        name: outer-dag
+        outputs:
+          parameters:
+          - name: value
+            valueFrom:
+              parameter: '{{tasks.final_task.outputs.result}}'
+    ```
+

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -55,6 +55,7 @@
 
         return WorkerOutput(value=final_task.result)
 
+
     @w.set_entrypoint
     @w.dag()
     def outer_dag(worker_input: WorkerInput) -> WorkerOutput:
@@ -164,95 +165,31 @@
               parameter: '{{tasks.final_task.outputs.result}}'
       - dag:
           tasks:
-          - name: setup_task
-            template: setup
           - arguments:
               parameters:
-              - name: word_a
+              - name: value_a
                 value: dag_a
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
-            depends: setup_task
-            name: task_a
-            template: concat
-          - arguments:
-              parameters:
-              - name: word_a
+              - name: value_b
                 value: '{{inputs.parameters.value_a}}'
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.result}}'
-            depends: setup_task
-            name: task_b
-            template: concat
+            name: sub_dag_a
+            template: worker
           - arguments:
               parameters:
-              - name: word_a
-                value: '{{tasks.task_a.outputs.result}}'
-              - name: word_b
-                value: '{{tasks.task_b.outputs.result}}'
-            depends: task_a && task_b
-            name: final_task
-            template: concat
-          - depends: final_task
-            name: setup_task
-            template: setup
-          - arguments:
-              parameters:
-              - name: word_a
+              - name: value_a
                 value: dag_b
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
-            depends: setup_task
-            name: task_a
-            template: concat
-          - arguments:
-              parameters:
-              - name: word_a
+              - name: value_b
                 value: '{{inputs.parameters.value_b}}'
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.result}}'
-            depends: setup_task
-            name: task_b
-            template: concat
+            name: sub_dag_b
+            template: worker
           - arguments:
               parameters:
-              - name: word_a
-                value: '{{tasks.task_a.outputs.result}}'
-              - name: word_b
-                value: '{{tasks.task_b.outputs.result}}'
-            depends: task_a && task_b
-            name: final_task
-            template: concat
-          - depends: final_task
-            name: setup_task
-            template: setup
-          - arguments:
-              parameters:
-              - name: word_a
-                value: '{{tasks.final_task.outputs.result}}'
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
-            depends: setup_task
-            name: task_a
-            template: concat
-          - arguments:
-              parameters:
-              - name: word_a
-                value: '{{tasks.final_task.outputs.result}}'
-              - name: word_b
-                value: '{{tasks.setup_task.outputs.result}}'
-            depends: setup_task
-            name: task_b
-            template: concat
-          - arguments:
-              parameters:
-              - name: word_a
-                value: '{{tasks.task_a.outputs.result}}'
-              - name: word_b
-                value: '{{tasks.task_b.outputs.result}}'
-            depends: task_a && task_b
-            name: final_task
-            template: concat
+              - name: value_a
+                value: '{{tasks.sub_dag_a.outputs.parameters.value}}'
+              - name: value_b
+                value: '{{tasks.sub_dag_b.outputs.parameters.value}}'
+            depends: sub_dag_a && sub_dag_b
+            name: sub_dag_c
+            template: worker
         inputs:
           parameters:
           - name: value_a
@@ -262,6 +199,6 @@
           parameters:
           - name: value
             valueFrom:
-              parameter: '{{tasks.final_task.outputs.result}}'
+              parameter: '{{tasks.sub_dag_c.outputs.parameters.value}}'
     ```
 

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -16,6 +16,7 @@
 
     global_config.experimental_features["script_annotations"] = True
     global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
 
     w = Workflow(generate_name="my-workflow-")
@@ -135,6 +136,8 @@
           - default: ''
             name: word_a
           - name: word_b
+          - default: '{"reverse": false}'
+            name: concat_config
         name: concat
         script:
           args:
@@ -163,6 +166,8 @@
                 value: '{{inputs.parameters.value_a}}'
               - name: word_b
                 value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}{{tasks.setup_task.outputs.parameters.dummy-param}}'
+              - name: concat_config
+                value: '{"reverse": false}'
             depends: setup_task
             name: task_a
             template: concat
@@ -172,6 +177,8 @@
                 value: '{{inputs.parameters.value_b}}'
               - name: word_b
                 value: '{{tasks.setup_task.outputs.result}}'
+              - name: concat_config
+                value: '{"reverse": false}'
             depends: setup_task
             name: task_b
             template: concat
@@ -181,6 +188,8 @@
                 value: '{{tasks.task_a.outputs.result}}'
               - name: word_b
                 value: '{{tasks.task_b.outputs.result}}'
+              - name: concat_config
+                value: '{"reverse": false}'
             depends: task_a && task_b
             name: final_task
             template: concat
@@ -191,6 +200,8 @@
           - name: value_b
           - default: '42'
             name: an_int_value
+          - default: '{"param_1": "Hello", "param_2": "world"}'
+            name: a_basemodel
         name: worker
         outputs:
           parameters:

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -1,0 +1,173 @@
+# New Dag Decorator Params
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from typing_extensions import Annotated
+
+    from hera.shared import global_config
+    from hera.workflows import Input, Output, Parameter, Workflow
+
+    global_config.experimental_features["script_annotations"] = True
+    global_config.experimental_features["script_pydantic_io"] = True
+
+
+    w = Workflow(generate_name="my-workflow-")
+
+
+    class SetupOutput(Output):
+        environment_parameter: str
+        an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]
+
+
+    @w.script()
+    def setup() -> SetupOutput:
+        return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+    class ConcatInput(Input):
+        word_a: Annotated[str, Parameter(name="word_a", default="")]
+        word_b: str
+
+
+    @w.script()
+    def concat(concat_input: ConcatInput) -> Output:
+        return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+    class WorkerInput(Input):
+        value_a: str = "my default"
+        value_b: str
+        an_int_value: int = 42
+
+
+    class WorkerOutput(Output):
+        value: str
+
+
+    @w.set_entrypoint
+    @w.dag()
+    def worker(worker_input: WorkerInput) -> WorkerOutput:
+        setup_task = setup()
+        task_a = concat(
+            ConcatInput(
+                word_a=worker_input.value_a,
+                word_b=setup_task.environment_parameter + str(setup_task.an_annotated_parameter),
+            )
+        )
+        task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+        final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+        return WorkerOutput(value=final_task.result)
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: my-workflow-
+    spec:
+      entrypoint: worker
+      templates:
+      - name: setup
+        outputs:
+          parameters:
+          - name: environment_parameter
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/environment_parameter
+          - name: dummy-param
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/dummy-param
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_dag_decorator_params:setup
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - inputs:
+          parameters:
+          - default: ''
+            name: word_a
+          - name: word_b
+        name: concat
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_dag_decorator_params:concat
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - dag:
+          tasks:
+          - name: setup_task
+            template: setup
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_a}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}{{tasks.setup_task.outputs.parameters.dummy-param}}'
+            depends: setup_task
+            name: task_a
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{inputs.parameters.value_b}}'
+              - name: word_b
+                value: '{{tasks.setup_task.outputs.result}}'
+            depends: setup_task
+            name: task_b
+            template: concat
+          - arguments:
+              parameters:
+              - name: word_a
+                value: '{{tasks.task_a.outputs.result}}'
+              - name: word_b
+                value: '{{tasks.task_b.outputs.result}}'
+            depends: task_a && task_b
+            name: final_task
+            template: concat
+        inputs:
+          parameters:
+          - default: my default
+            name: value_a
+          - name: value_b
+          - default: '42'
+            name: an_int_value
+        name: worker
+        outputs:
+          parameters:
+          - name: value
+            valueFrom:
+              parameter: '{{tasks.final_task.outputs.result}}'
+    ```
+

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -27,7 +27,7 @@
 
     @w.script()
     def setup() -> SetupOutput:
-        return SetupOutput(environment_parameter="linux", result="Setting things up")
+        return SetupOutput(environment_parameter="linux", an_annotated_parameter=42, result="Setting things up")
 
 
     class ConcatInput(Input):

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -8,6 +8,7 @@
 === "Hera"
 
     ```python linenums="1"
+    from pydantic import BaseModel
     from typing_extensions import Annotated
 
     from hera.shared import global_config
@@ -20,14 +21,24 @@
     w = Workflow(generate_name="my-workflow-")
 
 
+    class SetupConfig(BaseModel):
+        a_param: str
+
+
     class SetupOutput(Output):
         environment_parameter: str
-        an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]
+        an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]  # use an annotated non-str
+        setup_config: Annotated[SetupConfig, Parameter(name="setup-config")]  # use a pydantic BaseModel
 
 
     @w.script()
     def setup() -> SetupOutput:
-        return SetupOutput(environment_parameter="linux", an_annotated_parameter=42, result="Setting things up")
+        return SetupOutput(
+            environment_parameter="linux",
+            an_annotated_parameter=42,
+            setup_config=SetupConfig(a_param="test"),
+            result="Setting things up",
+        )
 
 
     class ConcatInput(Input):
@@ -85,6 +96,9 @@
           - name: dummy-param
             valueFrom:
               path: /tmp/hera-outputs/parameters/dummy-param
+          - name: setup-config
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/setup-config
         script:
           args:
           - -m

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -41,20 +41,34 @@
         )
 
 
+    class ConcatConfig(BaseModel):
+        reverse: bool
+
+
     class ConcatInput(Input):
         word_a: Annotated[str, Parameter(name="word_a", default="")]
         word_b: str
+        concat_config: ConcatConfig = ConcatConfig(reverse=False)
 
 
     @w.script()
     def concat(concat_input: ConcatInput) -> Output:
-        return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+        res = f"{concat_input.word_a} {concat_input.word_b}"
+        if concat_input.reverse:
+            res = res[::-1]
+        return Output(result=res)
+
+
+    class WorkerConfig(BaseModel):
+        param_1: str
+        param_2: str
 
 
     class WorkerInput(Input):
         value_a: str = "my default"
         value_b: str
         an_int_value: int = 42
+        a_basemodel: WorkerConfig = WorkerConfig(param_1="Hello", param_2="world")
 
 
     class WorkerOutput(Output):

--- a/docs/examples/workflows/experimental/new_decorators_basic_script.md
+++ b/docs/examples/workflows/experimental/new_decorators_basic_script.md
@@ -13,6 +13,7 @@
 
     global_config.experimental_features["script_annotations"] = True
     global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
     w = WorkflowTemplate(name="my-template")
 

--- a/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
@@ -1,0 +1,65 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: my-workflow-
+spec:
+  entrypoint: worker
+  templates:
+  - inputs:
+      artifacts:
+      - name: word_a
+        path: /tmp/hera-inputs/artifacts/word_a
+      - name: word_b
+        path: /tmp/hera-inputs/artifacts/word_b
+    name: concat
+    outputs:
+      artifacts:
+      - name: an-artifact
+        path: /tmp/hera-outputs/artifacts/an-artifact
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_dag_decorator_artifacts:concat
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - dag:
+      tasks:
+      - arguments:
+          artifacts:
+          - from: '{{inputs.artifacts.artifact_a}}'
+            name: word_a
+          - from: '{{inputs.artifacts.artifact_b}}'
+            name: word_b
+        name: concat_1
+        template: concat
+      - arguments:
+          artifacts:
+          - from: '{{tasks.concat_1.outputs.artifacts.an-artifact}}'
+            name: word_a
+          - from: '{{tasks.concat_1.outputs.artifacts.an-artifact}}'
+            name: word_b
+        depends: concat_1
+        name: concat-2-custom-name
+        template: concat
+    inputs:
+      artifacts:
+      - name: artifact_a
+        path: /tmp/hera-inputs/artifacts/artifact_a
+      - name: artifact_b
+        path: /tmp/hera-inputs/artifacts/artifact_b
+    name: worker
+    outputs:
+      artifacts:
+      - from: '{{tasks.concat-2-custom-name.outputs.artifacts.an-artifact}}'
+        name: an-artifact

--- a/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
@@ -1,0 +1,112 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: my-workflow-
+spec:
+  entrypoint: outer-dag
+  templates:
+  - name: setup
+    outputs:
+      parameters:
+      - name: environment_parameter
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/environment_parameter
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_dag_decorator_inner_dag:setup
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - inputs:
+      parameters:
+      - name: word_a
+      - name: word_b
+    name: concat
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_dag_decorator_inner_dag:concat
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - dag:
+      tasks:
+      - name: setup_task
+        template: setup
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{inputs.parameters.value_a}}'
+          - name: word_b
+            value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}'
+        depends: setup_task
+        name: task_a
+        template: concat
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{inputs.parameters.value_b}}'
+          - name: word_b
+            value: '{{tasks.setup_task.outputs.result}}'
+        depends: setup_task
+        name: task_b
+        template: concat
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{tasks.task_a.outputs.result}}'
+          - name: word_b
+            value: '{{tasks.task_b.outputs.result}}'
+        depends: task_a && task_b
+        name: final_task
+        template: concat
+    inputs:
+      parameters:
+      - name: value_a
+      - name: value_b
+    name: worker
+    outputs:
+      parameters:
+      - name: value
+        valueFrom:
+          parameter: '{{tasks.final_task.outputs.result}}'
+  - dag:
+      tasks:
+      - name: sub_dag_a
+        template: worker
+      - name: sub_dag_b
+        template: worker
+      - depends: sub_dag_a && sub_dag_b
+        name: sub_dag_c
+        template: worker
+    inputs:
+      parameters:
+      - name: value_a
+      - name: value_b
+    name: outer-dag
+    outputs:
+      parameters:
+      - name: value
+        valueFrom:
+          parameter: '{{tasks.sub_dag_c.outputs.parameters.value}}'

--- a/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
@@ -93,11 +93,29 @@ spec:
           parameter: '{{tasks.final_task.outputs.result}}'
   - dag:
       tasks:
-      - name: sub_dag_a
+      - arguments:
+          parameters:
+          - name: value_a
+            value: dag_a
+          - name: value_b
+            value: '{{inputs.parameters.value_a}}'
+        name: sub_dag_a
         template: worker
-      - name: sub_dag_b
+      - arguments:
+          parameters:
+          - name: value_a
+            value: dag_b
+          - name: value_b
+            value: '{{inputs.parameters.value_b}}'
+        name: sub_dag_b
         template: worker
-      - depends: sub_dag_a && sub_dag_b
+      - arguments:
+          parameters:
+          - name: value_a
+            value: '{{tasks.sub_dag_a.outputs.parameters.value}}'
+          - name: value_b
+            value: '{{tasks.sub_dag_b.outputs.parameters.value}}'
+        depends: sub_dag_a && sub_dag_b
         name: sub_dag_c
         template: worker
     inputs:

--- a/examples/workflows/experimental/new-dag-decorator-params.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-params.yaml
@@ -14,6 +14,9 @@ spec:
       - name: dummy-param
         valueFrom:
           path: /tmp/hera-outputs/parameters/dummy-param
+      - name: setup-config
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/setup-config
     script:
       args:
       - -m

--- a/examples/workflows/experimental/new-dag-decorator-params.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-params.yaml
@@ -39,6 +39,8 @@ spec:
       - default: ''
         name: word_a
       - name: word_b
+      - default: '{"reverse": false}'
+        name: concat_config
     name: concat
     script:
       args:
@@ -67,6 +69,8 @@ spec:
             value: '{{inputs.parameters.value_a}}'
           - name: word_b
             value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}{{tasks.setup_task.outputs.parameters.dummy-param}}'
+          - name: concat_config
+            value: '{"reverse": false}'
         depends: setup_task
         name: task_a
         template: concat
@@ -76,6 +80,8 @@ spec:
             value: '{{inputs.parameters.value_b}}'
           - name: word_b
             value: '{{tasks.setup_task.outputs.result}}'
+          - name: concat_config
+            value: '{"reverse": false}'
         depends: setup_task
         name: task_b
         template: concat
@@ -85,6 +91,8 @@ spec:
             value: '{{tasks.task_a.outputs.result}}'
           - name: word_b
             value: '{{tasks.task_b.outputs.result}}'
+          - name: concat_config
+            value: '{"reverse": false}'
         depends: task_a && task_b
         name: final_task
         template: concat
@@ -95,6 +103,8 @@ spec:
       - name: value_b
       - default: '42'
         name: an_int_value
+      - default: '{"param_1": "Hello", "param_2": "world"}'
+        name: a_basemodel
     name: worker
     outputs:
       parameters:

--- a/examples/workflows/experimental/new-dag-decorator-params.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-params.yaml
@@ -1,0 +1,100 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: my-workflow-
+spec:
+  entrypoint: worker
+  templates:
+  - name: setup
+    outputs:
+      parameters:
+      - name: environment_parameter
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/environment_parameter
+      - name: dummy-param
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/dummy-param
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_dag_decorator_params:setup
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - inputs:
+      parameters:
+      - default: ''
+        name: word_a
+      - name: word_b
+    name: concat
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_dag_decorator_params:concat
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - dag:
+      tasks:
+      - name: setup_task
+        template: setup
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{inputs.parameters.value_a}}'
+          - name: word_b
+            value: '{{tasks.setup_task.outputs.parameters.environment_parameter}}{{tasks.setup_task.outputs.parameters.dummy-param}}'
+        depends: setup_task
+        name: task_a
+        template: concat
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{inputs.parameters.value_b}}'
+          - name: word_b
+            value: '{{tasks.setup_task.outputs.result}}'
+        depends: setup_task
+        name: task_b
+        template: concat
+      - arguments:
+          parameters:
+          - name: word_a
+            value: '{{tasks.task_a.outputs.result}}'
+          - name: word_b
+            value: '{{tasks.task_b.outputs.result}}'
+        depends: task_a && task_b
+        name: final_task
+        template: concat
+    inputs:
+      parameters:
+      - default: my default
+        name: value_a
+      - name: value_b
+      - default: '42'
+        name: an_int_value
+    name: worker
+    outputs:
+      parameters:
+      - name: value
+        valueFrom:
+          parameter: '{{tasks.final_task.outputs.result}}'

--- a/examples/workflows/experimental/new_dag_decorator_artifacts.py
+++ b/examples/workflows/experimental/new_dag_decorator_artifacts.py
@@ -1,0 +1,50 @@
+from typing_extensions import Annotated
+
+from hera.shared import global_config
+from hera.workflows import Artifact, Input, Output, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class ArtifactOutput(Output):
+    an_artifact: Annotated[str, Artifact(name="an-artifact")]
+
+
+class ConcatInput(Input):
+    word_a: Annotated[str, Artifact(name="word_a")]
+    word_b: Annotated[str, Artifact(name="word_b")]
+
+
+@w.script()
+def concat(concat_input: ConcatInput) -> ArtifactOutput:
+    return ArtifactOutput(an_artifact=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+class WorkerInput(Input):
+    artifact_a: Annotated[str, Artifact(name="artifact_a")]
+    artifact_b: Annotated[str, Artifact(name="artifact_b")]
+
+
+@w.set_entrypoint
+@w.dag()
+def worker(worker_input: WorkerInput) -> ArtifactOutput:
+    concat_1 = concat(
+        ConcatInput(
+            word_a=worker_input.artifact_a,
+            word_b=worker_input.artifact_b,
+        )
+    )
+
+    concat_2 = concat(
+        ConcatInput(
+            word_a=concat_1.an_artifact,
+            word_b=concat_1.an_artifact,
+        ),
+        name="concat-2-custom-name",
+    )
+
+    return ArtifactOutput(an_artifact=concat_2.an_artifact)

--- a/examples/workflows/experimental/new_dag_decorator_artifacts.py
+++ b/examples/workflows/experimental/new_dag_decorator_artifacts.py
@@ -5,6 +5,7 @@ from hera.workflows import Artifact, Input, Output, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/examples/workflows/experimental/new_dag_decorator_inner_dag.py
+++ b/examples/workflows/experimental/new_dag_decorator_inner_dag.py
@@ -1,0 +1,57 @@
+from hera.shared import global_config
+from hera.workflows import Input, Output, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class SetupOutput(Output):
+    environment_parameter: str
+
+
+@w.script()
+def setup() -> SetupOutput:
+    return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+class ConcatInput(Input):
+    word_a: str
+    word_b: str
+
+
+@w.script()
+def concat(concat_input: ConcatInput) -> Output:
+    return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+class WorkerInput(Input):
+    value_a: str
+    value_b: str
+
+
+class WorkerOutput(Output):
+    value: str
+
+
+@w.dag()
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    setup_task = setup()
+    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.environment_parameter))
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+    return WorkerOutput(value=final_task.result)
+
+
+@w.set_entrypoint
+@w.dag()
+def outer_dag(worker_input: WorkerInput) -> WorkerOutput:
+    sub_dag_a = worker(WorkerInput(value_a="dag_a", value_b=worker_input.value_a))
+    sub_dag_b = worker(WorkerInput(value_a="dag_b", value_b=worker_input.value_b))
+
+    sub_dag_c = worker(WorkerInput(value_a=sub_dag_a.value, value_b=sub_dag_b.value))
+
+    return WorkerOutput(value=sub_dag_c.value)

--- a/examples/workflows/experimental/new_dag_decorator_inner_dag.py
+++ b/examples/workflows/experimental/new_dag_decorator_inner_dag.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -1,3 +1,4 @@
+from pydantic import BaseModel
 from typing_extensions import Annotated
 
 from hera.shared import global_config
@@ -10,14 +11,24 @@ global_config.experimental_features["script_pydantic_io"] = True
 w = Workflow(generate_name="my-workflow-")
 
 
+class SetupConfig(BaseModel):
+    a_param: str
+
+
 class SetupOutput(Output):
     environment_parameter: str
-    an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]
+    an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]  # use an annotated non-str
+    setup_config: Annotated[SetupConfig, Parameter(name="setup-config")]  # use a pydantic BaseModel
 
 
 @w.script()
 def setup() -> SetupOutput:
-    return SetupOutput(environment_parameter="linux", an_annotated_parameter=42, result="Setting things up")
+    return SetupOutput(
+        environment_parameter="linux",
+        an_annotated_parameter=42,
+        setup_config=SetupConfig(a_param="test"),
+        result="Setting things up",
+    )
 
 
 class ConcatInput(Input):

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -6,6 +6,7 @@ from hera.workflows import Input, Output, Parameter, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -1,0 +1,56 @@
+from typing_extensions import Annotated
+
+from hera.shared import global_config
+from hera.workflows import Input, Output, Parameter, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class SetupOutput(Output):
+    environment_parameter: str
+    an_annotated_parameter: Annotated[int, Parameter(name="dummy-param")]
+
+
+@w.script()
+def setup() -> SetupOutput:
+    return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+class ConcatInput(Input):
+    word_a: Annotated[str, Parameter(name="word_a", default="")]
+    word_b: str
+
+
+@w.script()
+def concat(concat_input: ConcatInput) -> Output:
+    return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+class WorkerInput(Input):
+    value_a: str = "my default"
+    value_b: str
+    an_int_value: int = 42
+
+
+class WorkerOutput(Output):
+    value: str
+
+
+@w.set_entrypoint
+@w.dag()
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    setup_task = setup()
+    task_a = concat(
+        ConcatInput(
+            word_a=worker_input.value_a,
+            word_b=setup_task.environment_parameter + str(setup_task.an_annotated_parameter),
+        )
+    )
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+    return WorkerOutput(value=final_task.result)

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -17,7 +17,7 @@ class SetupOutput(Output):
 
 @w.script()
 def setup() -> SetupOutput:
-    return SetupOutput(environment_parameter="linux", result="Setting things up")
+    return SetupOutput(environment_parameter="linux", an_annotated_parameter=42, result="Setting things up")
 
 
 class ConcatInput(Input):

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -31,20 +31,34 @@ def setup() -> SetupOutput:
     )
 
 
+class ConcatConfig(BaseModel):
+    reverse: bool
+
+
 class ConcatInput(Input):
     word_a: Annotated[str, Parameter(name="word_a", default="")]
     word_b: str
+    concat_config: ConcatConfig = ConcatConfig(reverse=False)
 
 
 @w.script()
 def concat(concat_input: ConcatInput) -> Output:
-    return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+    res = f"{concat_input.word_a} {concat_input.word_b}"
+    if concat_input.reverse:
+        res = res[::-1]
+    return Output(result=res)
+
+
+class WorkerConfig(BaseModel):
+    param_1: str
+    param_2: str
 
 
 class WorkerInput(Input):
     value_a: str = "my default"
     value_b: str
     an_int_value: int = 42
+    a_basemodel: WorkerConfig = WorkerConfig(param_1="Hello", param_2="world")
 
 
 class WorkerOutput(Output):

--- a/examples/workflows/experimental/new_decorators_basic_script.py
+++ b/examples/workflows/experimental/new_decorators_basic_script.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, WorkflowTemplate
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 w = WorkflowTemplate(name="my-template")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -442,6 +442,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "executing"
+version = "2.0.1"
+description = "Get the currently executing AST node of a frame, and other information"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
+    {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
+
+[[package]]
 name = "genson"
 version = "1.2.2"
 description = "GenSON is a powerful, user-friendly JSON Schema generator."
@@ -1300,6 +1314,23 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "varname"
+version = "0.13.1"
+description = "Dark magics about variable names in python."
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "varname-0.13.1-py3-none-any.whl", hash = "sha256:f70f58e2b85584daa4fe6d4f90c5fdd4bf314e5a60b0bd5865bc79da0f404729"},
+    {file = "varname-0.13.1.tar.gz", hash = "sha256:3d3ae868936c908d81e0bef19b29d2f21e9a60247097c9ed39678522cd678c0c"},
+]
+
+[package.dependencies]
+executing = ">=2.0,<3.0"
+
+[package.extras]
+all = ["asttokens (==2.*)", "pure_eval (==0.*)"]
+
+[[package]]
 name = "zipp"
 version = "3.18.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1321,4 +1352,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "a4734295afa5564adc1c8794d6380d922e0705397ccc0ade3aa6a44f303120fd"
+content-hash = "dba5d494f5ef1afe83f595a3c34aefc7a4fc510b5a5659f13a91cac1e14648ef"

--- a/poetry.lock
+++ b/poetry.lock
@@ -445,7 +445,7 @@ test = ["pytest (>=6)"]
 name = "executing"
 version = "2.0.1"
 description = "Get the currently executing AST node of a frame, and other information"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
@@ -1317,7 +1317,7 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "varname"
 version = "0.13.1"
 description = "Dark magics about variable names in python."
-optional = false
+optional = true
 python-versions = "<4.0,>=3.8"
 files = [
     {file = "varname-0.13.1-py3-none-any.whl", hash = "sha256:f70f58e2b85584daa4fe6d4f90c5fdd4bf314e5a60b0bd5865bc79da0f404729"},
@@ -1347,9 +1347,10 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 cli = ["cappa", "pyyaml"]
+experimental = ["varname"]
 yaml = ["pyyaml"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "dba5d494f5ef1afe83f595a3c34aefc7a4fc510b5a5659f13a91cac1e14648ef"
+content-hash = "cabe27fcec24c46ae592ec530acaa61ca5820d940f6a5a09189f93cca915828e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pyyaml = { version = ">=6.0", optional = true }
 requests = "*"
 pydantic = { extras = ["email"], version = ">=1.7,<3.0" }
 cappa = {version = ">=0.14.3,<0.20.0", optional = true}
+varname = "^0.13.1"
 
 [tool.poetry.extras]
 yaml = ["PyYAML"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,12 @@ pyyaml = { version = ">=6.0", optional = true }
 requests = "*"
 pydantic = { extras = ["email"], version = ">=1.7,<3.0" }
 cappa = {version = ">=0.14.3,<0.20.0", optional = true}
-varname = "^0.13.1"
+varname = {version = "^0.13.1", optional = true}
 
 [tool.poetry.extras]
 yaml = ["PyYAML"]
 cli = ["cappa", "PyYAML"]
+experimental = ["varname"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "<8.0.0"

--- a/src/hera/shared/_pydantic.py
+++ b/src/hera/shared/_pydantic.py
@@ -18,6 +18,7 @@ _PYDANTIC_VERSION: int = int(VERSION.split(".")[0])
 if _PYDANTIC_VERSION == 2:
     from pydantic.v1 import (  # type: ignore
         Field,
+        PrivateAttr,
         ValidationError,
         root_validator,
         validator,
@@ -25,6 +26,7 @@ if _PYDANTIC_VERSION == 2:
 else:
     from pydantic import (  # type: ignore[assignment,no-redef]
         Field,
+        PrivateAttr,
         ValidationError,
         root_validator,
         validator,
@@ -84,6 +86,7 @@ __all__ = [
     "BaseModel",
     "Field",
     "FieldInfo",
+    "PrivateAttr",
     "PydanticBaseModel",  # Export for serialization.py to cover user-defined models
     "ValidationError",
     "root_validator",

--- a/src/hera/workflows/__init__.py
+++ b/src/hera/workflows/__init__.py
@@ -151,6 +151,8 @@ __all__ = [
     "Resources",
     "RetryPolicy",
     "RetryStrategy",
+    "RunnerInput",
+    "RunnerOutput",
     "RunnerScriptConstructor",
     "S3Artifact",
     "ScaleIOVolume",

--- a/src/hera/workflows/__init__.py
+++ b/src/hera/workflows/__init__.py
@@ -151,8 +151,6 @@ __all__ = [
     "Resources",
     "RetryPolicy",
     "RetryStrategy",
-    "RunnerInput",
-    "RunnerOutput",
     "RunnerScriptConstructor",
     "S3Artifact",
     "ScaleIOVolume",

--- a/src/hera/workflows/_context.py
+++ b/src/hera/workflows/_context.py
@@ -14,6 +14,7 @@ from hera.workflows.protocol import Subbable, TTemplate
 TNode = TypeVar("TNode", bound="SubNodeMixin")
 
 _pieces = ContextVar("_pieces", default=None)
+_declaring = ContextVar("_declaring", default=False)
 
 
 class SubNodeMixin(BaseMixin):
@@ -64,6 +65,14 @@ class _HeraContext:
     def pieces(self, value) -> None:
         """Sets the given values as the pieces of the context."""
         _pieces.set(value)
+
+    @property
+    def declaring(self) -> bool:
+        return _declaring.get()
+
+    @declaring.setter
+    def declaring(self, value: bool) -> None:
+        _declaring.set(value)
 
     @property
     def active(self) -> bool:

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -686,13 +686,11 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                     subnode_name = kwargs.pop("name", subnode_name)
                     assert isinstance(subnode_name, str)
 
-                    return create_subnode(subnode_name, func, dag, args, kwargs)
+                    return create_subnode(subnode_name, func, dag, *args, **kwargs)
 
                 return func(*args, **kwargs)
 
             dag_call_wrapper.template_name = name  # type: ignore
-            dag_call_wrapper.template_type = "dag"  # type: ignore
-            dag_call_wrapper.context = dag  # type: ignore
 
             # Open workflow context to cross-check task template names
             with self, dag:

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -524,6 +524,9 @@ def create_subnode(
     return subnode
 
 
+_DECORATOR_SYNTAX_FLAG = "decorator_syntax"
+
+
 class TemplateDecoratorFuncsMixin(ContextMixin):
     from hera.workflows.dag import DAG
     from hera.workflows.script import Script
@@ -548,6 +551,15 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
             Function wrapper that holds a `Script` and allows the function to be called to create a Step or Task if
             in a Steps or DAG context.
         """
+        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
+            raise ValueError(
+                str(
+                    "Unable to use {} decorator since it is an experimental feature."
+                    " Please turn on experimental features by setting "
+                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
+                    " Note that experimental features are unstable and subject to breaking changes."
+                ).format("script", _DECORATOR_SYNTAX_FLAG)
+            )
         from hera.workflows.script import RunnerScriptConstructor, Script
 
         def script_decorator(func: Callable[FuncIns, FuncR]) -> Callable:
@@ -651,6 +663,16 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
 
     @_add_type_hints(DAG)  # type: ignore
     def dag(self, **dag_kwargs) -> Callable:
+        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
+            raise ValueError(
+                str(
+                    "Unable to use {} decorator since it is an experimental feature."
+                    " Please turn on experimental features by setting "
+                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
+                    " Note that experimental features are unstable and subject to breaking changes."
+                ).format("dag", _DECORATOR_SYNTAX_FLAG)
+            )
+
         from hera.workflows.dag import DAG
 
         def dag_decorator(func: Callable[FuncIns, FuncR]) -> Callable:

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -570,6 +570,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
 
                     subnode: Union[Step, Task]
 
+                    assert _context.pieces
                     _context.declaring = False
                     if isinstance(_context.pieces[-1], (Steps, Parallel)):
                         subnode = Step(
@@ -652,4 +653,5 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                             dag.outputs = dag_func_return._get_as_output()
 
             return dag_call_wrapper
+
         return dag_decorator

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -10,7 +10,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type, TypeVar, Union, cast
 
 from typing_extensions import ParamSpec
-from varname import ImproperUseError, varname
 
 from hera.shared import BaseMixin, global_config
 from hera.shared._pydantic import BaseModel, get_fields, root_validator
@@ -61,6 +60,16 @@ try:
     _yaml = yaml
 except ImportError:
     _yaml = None
+
+
+_varname_imported: bool = False
+try:
+    # user must install `hera[experimental]`
+    from varname import ImproperUseError, varname
+
+    _varname_imported = True
+except ImportError:
+    pass
 
 THookable = TypeVar("THookable", bound="HookMixin")
 """`THookable` is the type associated with mixins that provide the ability to apply hooks from the global config"""
@@ -560,6 +569,11 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                     " Note that experimental features are unstable and subject to breaking changes."
                 ).format("script", _DECORATOR_SYNTAX_FLAG)
             )
+        if not _varname_imported:
+            raise ImportError(
+                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
+            )
+
         from hera.workflows.script import RunnerScriptConstructor, Script
 
         def script_decorator(func: Callable[FuncIns, FuncR]) -> Callable:
@@ -671,6 +685,10 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                     '`hera.shared.global_config.experimental_features["{}"] = True`.'
                     " Note that experimental features are unstable and subject to breaking changes."
                 ).format("dag", _DECORATOR_SYNTAX_FLAG)
+            )
+        if not _varname_imported:
+            raise ImportError(
+                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
             )
 
         from hera.workflows.dag import DAG

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -664,14 +664,14 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
             To run the function in declaring mode, we first need to create an input object which will
             carry templated string arguments in its attributes, rather than the correct types (like ints,
             other BaseModels, etc). This will let the templated strings propagate to the task arguments. We
-            must skip Pydantic's validation of the input object, which is why InputMixin override __new__,
+            must skip Pydantic's validation of the input object, which is why InputMixin overrides __new__,
             to `construct` an instance; __init__ then returns early to skip validation.
 
             Then, passing in the object, we call the underlying function. This is where other templates
             are called, such as scripts, containers or other DAGs, and results in `Task` (or `Step`) objects being
             created. These tasks may have attribute access on them when passing values between tasks, as the
             code author sees Inputs/Outputs, while we are seeing Tasks in declaring mode. Therefore,
-            TemplateInvocatorSubNodeMixin override __getattribute__, which, when in declaring mode, will
+            TemplateInvocatorSubNodeMixin overrides __getattribute__, which, when in declaring mode, will
             retrieve a templated string for the given attribute, e.g. `my_task.an_output_param` will get
             the string "{{tasks.my_task.outputs.parameters.an_output_param}}". This also works for artifacts
             and the special `result` output.

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -711,7 +711,7 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
     with_sequence: Optional[Sequence] = None
 
     _build_obj: Optional[HeraBuildObj] = PrivateAttr(None)
-    
+
     def __init__(self, **kwargs) -> None:
         if _context.declaring:
             object.__setattr__(self, "_build_data", kwargs)

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -6,8 +6,9 @@ for more on DAGs (Directed Acyclic Graphs).
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Set, Union
 
+from hera.shared._pydantic import PrivateAttr
 from hera.workflows._meta_mixins import CallableTemplateMixin, ContextMixin
 from hera.workflows._mixins import IOMixin, TemplateMixin
 from hera.workflows.exceptions import InvalidType
@@ -42,6 +43,10 @@ class DAG(
     fail_fast: Optional[bool] = None
     target: Optional[str] = None
     tasks: List[Union[Task, DAGTask]] = []
+
+    # Boolean to set when we are running DAG/Steps declaration code, i.e. when we are running decorator manipulation code
+    _declaring: bool = PrivateAttr(False)
+    _current_task_depends: Set[str] = PrivateAttr(set())
 
     def _add_sub(self, node: Any):
         if not isinstance(node, Task):

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -44,8 +44,6 @@ class DAG(
     target: Optional[str] = None
     tasks: List[Union[Task, DAGTask]] = []
 
-    # Boolean to set when we are running DAG/Steps declaration code, i.e. when we are running decorator manipulation code
-    _declaring: bool = PrivateAttr(False)
     _current_task_depends: Set[str] = PrivateAttr(set())
 
     def _add_sub(self, node: Any):

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -134,7 +134,9 @@ class InputMixin(BaseModel):
             self_dict = self.model_dump()
 
         for field in get_fields(type(self)):
-            templated_value = self_dict[field]
+            # The value may be a static value (of any time) if it has a default value, so we need to serialize it
+            # If it is a templated string, it will be unaffected as `"{{mystr}}" == serialize("{{mystr}}")``
+            templated_value = serialize(self_dict[field])
 
             if get_origin(annotations[field]) is Annotated:
                 annotation = get_args(annotations[field])[1]

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -39,23 +39,20 @@ else:
 
 class InputMixin(BaseModel):
     def __new__(cls, **kwargs):
-        from hera.workflows.dag import DAG
-        from hera.workflows.steps import Steps
-
-        if _context.pieces and isinstance(_context.pieces[-1], (DAG, Steps)) and _context.pieces[-1]._declaring:
+        if _context.declaring:
             # Intercept the declaration to avoid validation on the templated strings
-            _context.pieces[-1]._declaring = False
+            # We must then turn off declaring mode to be able to "construct" an instance
+            # of the InputMixin subclass.
+            _context.declaring = False
             instance = cls.construct(**kwargs)
-            _context.pieces[-1]._declaring = True
+            _context.declaring = True
             return instance
         else:
             return super(InputMixin, cls).__new__(cls)
 
     def __init__(self, /, **kwargs):
-        from hera.workflows.dag import DAG
-        from hera.workflows.steps import Steps
-
-        if _context.pieces and isinstance(_context.pieces[-1], (DAG, Steps)) and _context.pieces[-1]._declaring:
+        if _context.declaring:
+            # object.__setattr__(self, "_build_data", kwargs)
             # Return in order to skip validation of `construct`ed instance
             return
 
@@ -154,23 +151,17 @@ class InputMixin(BaseModel):
 
 class OutputMixin(BaseModel):
     def __new__(cls, **kwargs):
-        from hera.workflows.dag import DAG
-        from hera.workflows.steps import Steps
-
-        if _context.pieces and isinstance(_context.pieces[-1], (DAG, Steps)) and _context.pieces[-1]._declaring:
+        if _context.declaring:
             # Intercept the declaration to avoid validation on the templated strings
-            _context.pieces[-1]._declaring = False
+            _context.declaring = False
             instance = cls.construct(**kwargs)
-            _context.pieces[-1]._declaring = True
+            _context.declaring = True
             return instance
         else:
             return super(OutputMixin, cls).__new__(cls)
 
     def __init__(self, /, **kwargs):
-        from hera.workflows.dag import DAG
-        from hera.workflows.steps import Steps
-
-        if _context.pieces and isinstance(_context.pieces[-1], (DAG, Steps)) and _context.pieces[-1]._declaring:
+        if _context.declaring:
             # Return in order to skip validation of `construct`ed instance
             return
 

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -202,7 +202,10 @@ class OutputMixin(BaseModel):
         return Parameter(name=field_name, default=default)  # type: ignore
 
     def _get_as_output(self) -> List[Union[Artifact, Parameter]]:
-        """Get the Output with values of ..."""
+        """Get the Output model as the output of a dag/steps template.
+
+        This lets dags and steps hoist task/step outputs into its own outputs.
+        """
         outputs: List[Union[Artifact, Parameter]] = []
         annotations = get_field_annotations(type(self))
 

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -55,7 +55,7 @@ class InputMixin(BaseModel):
             # Return in order to skip validation of `construct`ed instance
             return
 
-        return super().__init__(**kwargs)
+        super().__init__(**kwargs)
 
     @classmethod
     def _get_parameters(cls, object_override: Optional[Self] = None) -> List[Parameter]:
@@ -164,7 +164,7 @@ class OutputMixin(BaseModel):
             # Return in order to skip validation of `construct`ed instance
             return
 
-        return super().__init__(**kwargs)
+        super().__init__(**kwargs)
 
     @classmethod
     def _get_outputs(cls) -> List[Union[Artifact, Parameter]]:

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -52,7 +52,6 @@ class InputMixin(BaseModel):
 
     def __init__(self, /, **kwargs):
         if _context.declaring:
-            # object.__setattr__(self, "_build_data", kwargs)
             # Return in order to skip validation of `construct`ed instance
             return
 

--- a/src/hera/workflows/io/v1.py
+++ b/src/hera/workflows/io/v1.py
@@ -10,8 +10,8 @@ class Input(InputMixin, BaseModel):
     """Input model usable by the Hera Runner.
 
     Input is a Pydantic model which users can create a subclass of. When a subclass
-    of Input is used as a function parameter type, the Hera Runner will take the fields
-    of the user's subclass to create template input parameters and artifacts. See the example
+    of Input is used as a function parameter type, Hera will take the fields of the
+    user's subclass to create template input parameters and artifacts. See the example
     for the script_pydantic_io experimental feature.
     """
 
@@ -20,8 +20,8 @@ class Output(OutputMixin, BaseModel):
     """Output model usable by the Hera Runner.
 
     Output is a Pydantic model which users can create a subclass of. When a subclass
-    of Output is used as a function return type, the Hera Runner will take the fields
-    of the user's subclass to create template output parameters and artifacts. See the example
+    of Output is used as a function return type, Hera will take the fields of the
+    user's subclass to create template output parameters and artifacts. See the example
     for the script_pydantic_io experimental feature.
     """
 

--- a/src/hera/workflows/io/v1.py
+++ b/src/hera/workflows/io/v1.py
@@ -6,7 +6,7 @@ from hera.shared._pydantic import BaseModel
 from hera.workflows.io._io_mixins import InputMixin, OutputMixin
 
 
-class Input(BaseModel, InputMixin):
+class Input(InputMixin, BaseModel):
     """Input model usable by the Hera Runner.
 
     Input is a Pydantic model which users can create a subclass of. When a subclass
@@ -16,7 +16,7 @@ class Input(BaseModel, InputMixin):
     """
 
 
-class Output(BaseModel, OutputMixin):
+class Output(OutputMixin, BaseModel):
     """Output model usable by the Hera Runner.
 
     Output is a Pydantic model which users can create a subclass of. When a subclass

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -6,6 +6,7 @@ for more on Steps.
 
 from typing import Any, List, Optional, Union
 
+from hera.shared._pydantic import PrivateAttr
 from hera.workflows._meta_mixins import CallableTemplateMixin, ContextMixin
 from hera.workflows._mixins import (
     ArgumentsMixin,
@@ -120,6 +121,9 @@ class Steps(
     in the order they are initialised.
     * All Step objects initialised within a Parallel context will run in parallel.
     """
+
+    # Boolean to set when we are running DAG/Steps declaration code, i.e. when we are running decorator manipulation code
+    _declaring: bool = PrivateAttr(False)
 
     sub_steps: List[
         Union[

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -6,7 +6,6 @@ for more on Steps.
 
 from typing import Any, List, Optional, Union
 
-from hera.shared._pydantic import PrivateAttr
 from hera.workflows._meta_mixins import CallableTemplateMixin, ContextMixin
 from hera.workflows._mixins import (
     ArgumentsMixin,

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -122,9 +122,6 @@ class Steps(
     * All Step objects initialised within a Parallel context will run in parallel.
     """
 
-    # Boolean to set when we are running DAG/Steps declaration code, i.e. when we are running decorator manipulation code
-    _declaring: bool = PrivateAttr(False)
-
     sub_steps: List[
         Union[
             Step,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,13 @@
 import importlib
 import logging
+from typing import cast
+
+from hera.workflows import DAG, Workflow
+from hera.workflows.models import (
+    Artifact as ModelArtifact,
+    Parameter as ModelParameter,
+    Workflow as ModelWorkflow,
+)
 
 
 def test_set_entrypoint():
@@ -14,3 +22,167 @@ def test_multiple_set_entrypoint(caplog):
 
     assert "entrypoint is being reassigned" in caplog.text
     assert w.entrypoint == "hello-world-2"
+
+
+def test_dag_io_declaration():
+    w: Workflow = importlib.import_module("tests.workflow_decorators.dag_io_declaration").w
+
+    model_workflow = cast(ModelWorkflow, w.build())
+
+    assert len(model_workflow.spec.templates) == 1
+
+    template = model_workflow.spec.templates[0]
+
+    assert template.inputs
+    assert len(template.inputs.parameters) == 2
+    assert template.inputs.parameters == [
+        ModelParameter(name="basic_input_parameter"),
+        ModelParameter(name="my-input-param"),
+    ]
+    assert len(template.inputs.artifacts) == 1
+    assert template.inputs.artifacts == [
+        ModelArtifact(name="my-input-artifact", path="/tmp/hera-inputs/artifacts/my-input-artifact"),
+    ]
+
+    assert template.outputs
+    assert len(template.outputs.parameters) == 2
+    assert template.outputs.parameters == [
+        ModelParameter(name="basic_output_parameter"),
+        ModelParameter(name="my-output-param"),
+    ]
+    assert template.outputs.artifacts == [
+        ModelArtifact(name="my-output-artifact"),
+    ]
+
+
+def test_dag_task_arguments():
+    w: Workflow = importlib.import_module("tests.workflow_decorators.dag_io_hoisting").w
+
+    model_workflow = cast(ModelWorkflow, w.build())
+
+    assert model_workflow.spec.templates is not None
+    assert len(model_workflow.spec.templates) == 2
+
+    dag_template = next(filter(lambda t: t.name == "dummy-dag", model_workflow.spec.templates))
+
+    assert dag_template.dag is not None
+    assert len(dag_template.dag.tasks) == 1
+    task = dag_template.dag.tasks[0]
+    assert task.arguments and task.arguments.parameters and task.arguments.artifacts
+
+    assert task.arguments.parameters == [
+        ModelParameter(
+            name="basic_input_parameter",
+            value="{{inputs.parameters.basic_input_parameter}}",
+        ),
+        ModelParameter(name="my-input-param", value="{{inputs.parameters.my-input-param}}"),
+    ]
+    assert task.arguments.artifacts == [
+        ModelArtifact(name="my-input-artifact", from_="{{inputs.artifacts.my-input-artifact}}"),
+    ]
+
+
+def test_dag_tasks_with_masked_attributes_in_arguments():
+    w: Workflow = importlib.import_module("tests.workflow_decorators.dag_io_masked_parameters").w
+
+    model_workflow = cast(ModelWorkflow, w.build())
+
+    assert model_workflow.spec.templates is not None
+    assert len(model_workflow.spec.templates) == 2
+
+    dag_template = next(filter(lambda t: t.name == "dummy-dag", model_workflow.spec.templates))
+
+    assert dag_template.dag is not None
+    assert len(dag_template.dag.tasks) == 2
+    task_a = next(filter(lambda t: t.name == "task_a", dag_template.dag.tasks))
+    assert task_a.arguments and task_a.arguments.parameters
+
+    assert task_a.arguments.parameters == [
+        ModelParameter(
+            name="name",
+            value="{{inputs.parameters.name}}",
+        ),
+        ModelParameter(name="hooks", value="{{inputs.parameters.hooks}}"),
+        ModelParameter(name="target", value="{{inputs.parameters.target}}"),
+    ]
+
+    task_b = next(filter(lambda t: t.name == "task_b", dag_template.dag.tasks))
+    assert task_b.arguments and task_b.arguments.parameters
+
+    assert task_b.arguments.parameters == [
+        ModelParameter(name="name", value="{{tasks.task_a.outputs.parameters.name}}"),
+        ModelParameter(name="hooks", value="{{tasks.task_a.outputs.parameters.hooks}}"),
+        ModelParameter(name="target", value="{{inputs.parameters.target}}"),
+    ]
+
+    assert dag_template.outputs.parameters == [
+        ModelParameter(
+            name="name",
+            value_from={"parameter": "{{tasks.task_a.outputs.parameters.name}}"},
+        ),
+        ModelParameter(
+            name="hooks",
+            value_from={"parameter": "{{tasks.task_b.outputs.parameters.hooks}}"},
+        ),
+        ModelParameter(
+            name="target",
+            value_from={"parameter": "{{inputs.parameters.target}}"},
+        ),
+    ]
+
+
+def test_dag_task_io_hoisting():
+    w: Workflow = importlib.import_module("tests.workflow_decorators.dag_io_hoisting").w
+
+    model_workflow = cast(ModelWorkflow, w.build())
+
+    assert model_workflow.spec.templates is not None
+    assert len(model_workflow.spec.templates) == 2
+
+    dag_template = next(filter(lambda t: t.name == "dummy-dag", model_workflow.spec.templates))
+
+    assert dag_template.outputs and dag_template.outputs.parameters and dag_template.outputs.artifacts
+    assert dag_template.outputs.parameters == [
+        ModelParameter(
+            name="basic_output_parameter",
+            value_from={"parameter": "{{tasks.a_task.outputs.parameters.basic_output_parameter}}"},
+        ),
+        ModelParameter(
+            name="my-output-param", value_from={"parameter": "{{tasks.a_task.outputs.parameters.my-output-param}}"}
+        ),
+    ]
+    assert dag_template.outputs.artifacts == [
+        ModelArtifact(name="my-output-artifact", from_="{{tasks.a_task.outputs.artifacts.my-output-artifact}}"),
+    ]
+
+
+def test_dag_task_auto_depends():
+    """The workflow should contain the dag with correct tasks without having to call `build`."""
+    w: Workflow = importlib.import_module("tests.workflow_decorators.dag").w
+
+    assert len(w.templates) == 3
+
+    dag_template: DAG = next(iter([t for t in w.templates if t.name == "worker"]), None)
+
+    assert len(dag_template.tasks) == 4
+
+    setup_task = next(iter([t for t in dag_template.tasks if t.name == "setup_task"]), None)
+    assert setup_task.depends is None
+
+    task_a = next(iter([t for t in dag_template.tasks if t.name == "task_a"]), None)
+    assert task_a.depends == "setup_task"
+
+    task_b = next(iter([t for t in dag_template.tasks if t.name == "task_b"]), None)
+    assert task_b.depends == "setup_task"
+
+    final_task = next(iter([t for t in dag_template.tasks if t.name == "final_task"]), None)
+    assert final_task.depends == "task_a && task_b"
+
+
+def test_dag_is_runnable():
+    """The dag function should be runnable as Python code."""
+    from tests.workflow_decorators.dag import WorkerInput, WorkerOutput, worker
+
+    assert worker(WorkerInput(value_a="hello", value_b="world")) == WorkerOutput(
+        value="hello linux world Setting things up"
+    )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -179,6 +179,25 @@ def test_dag_task_auto_depends():
     assert final_task.depends == "task_a && task_b"
 
 
+def test_dag_with_inner_dag():
+    w: Workflow = importlib.import_module("tests.workflow_decorators.inner_dag").w
+
+    assert len(w.templates) == 4
+
+    outer_dag_template: DAG = next(iter([t for t in w.templates if t.name == "outer-dag"]), None)
+
+    assert len(outer_dag_template.tasks) == 3
+
+    dag_a = next(iter([t for t in outer_dag_template.tasks if t.name == "sub_dag_a"]), None)
+    assert dag_a
+
+    dag_b = next(iter([t for t in outer_dag_template.tasks if t.name == "sub_dag_b"]), None)
+    assert dag_b
+
+    dag_c = next(iter([t for t in outer_dag_template.tasks if t.name == "sub_dag_c"]), None)
+    assert dag_c
+
+
 def test_dag_is_runnable():
     """The dag function should be runnable as Python code."""
     from tests.workflow_decorators.dag import WorkerInput, WorkerOutput, worker

--- a/tests/workflow_decorators/dag.py
+++ b/tests/workflow_decorators/dag.py
@@ -1,0 +1,47 @@
+from hera.shared import global_config
+from hera.workflows import Input, Output, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class SetupOutput(Output):
+    environment_parameter: str
+
+
+@w.script()
+def setup() -> SetupOutput:
+    return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+class ConcatInput(Input):
+    word_a: str
+    word_b: str
+
+
+@w.script()
+def concat(concat_input: ConcatInput) -> Output:
+    return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+class WorkerInput(Input):
+    value_a: str
+    value_b: str
+
+
+class WorkerOutput(Output):
+    value: str
+
+
+@w.set_entrypoint
+@w.dag()
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    setup_task = setup()
+    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.environment_parameter))
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+    return WorkerOutput(value=final_task.result)

--- a/tests/workflow_decorators/dag.py
+++ b/tests/workflow_decorators/dag.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/tests/workflow_decorators/dag_io_declaration.py
+++ b/tests/workflow_decorators/dag_io_declaration.py
@@ -1,0 +1,28 @@
+from typing_extensions import Annotated
+
+from hera.shared import global_config
+from hera.workflows import Artifact, Input, Output, Parameter, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class WorkerInput(Input):
+    basic_input_parameter: str
+    annotated_parameter: Annotated[str, Parameter(name="my-input-param")]
+    an_artifact: Annotated[str, Artifact(name="my-input-artifact")]
+
+
+class WorkerOutput(Output):
+    basic_output_parameter: str
+    annotated_parameter: Annotated[str, Parameter(name="my-output-param")]
+    an_artifact: Annotated[str, Artifact(name="my-output-artifact")]
+
+
+@w.set_entrypoint
+@w.dag()
+def dummy_worker(_: WorkerInput) -> WorkerOutput:
+    pass

--- a/tests/workflow_decorators/dag_io_declaration.py
+++ b/tests/workflow_decorators/dag_io_declaration.py
@@ -5,6 +5,7 @@ from hera.workflows import Artifact, Input, Output, Parameter, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/tests/workflow_decorators/dag_io_hoisting.py
+++ b/tests/workflow_decorators/dag_io_hoisting.py
@@ -1,0 +1,45 @@
+from typing_extensions import Annotated
+
+from hera.shared import global_config
+from hera.workflows import Artifact, Input, Output, Parameter, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class WorkerInput(Input):
+    basic_input_parameter: str
+    annotated_parameter: Annotated[str, Parameter(name="my-input-param")]
+    an_artifact: Annotated[str, Artifact(name="my-input-artifact")]
+
+
+class WorkerOutput(Output):
+    basic_output_parameter: str
+    annotated_parameter: Annotated[str, Parameter(name="my-output-param")]
+    an_artifact: Annotated[str, Artifact(name="my-output-artifact")]
+
+
+@w.script()
+def dummy_task(_: WorkerInput) -> WorkerOutput:
+    pass
+
+
+@w.set_entrypoint
+@w.dag()
+def dummy_dag(dag_input: WorkerInput) -> WorkerOutput:
+    a_task = dummy_task(
+        WorkerInput(
+            basic_input_parameter=dag_input.basic_input_parameter,
+            annotated_parameter=dag_input.annotated_parameter,
+            an_artifact=dag_input.an_artifact,
+        )
+    )
+
+    return WorkerOutput(
+        basic_output_parameter=a_task.basic_output_parameter,
+        annotated_parameter=a_task.annotated_parameter,
+        an_artifact=a_task.an_artifact,
+    )

--- a/tests/workflow_decorators/dag_io_hoisting.py
+++ b/tests/workflow_decorators/dag_io_hoisting.py
@@ -5,6 +5,7 @@ from hera.workflows import Artifact, Input, Output, Parameter, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/tests/workflow_decorators/dag_io_masked_parameters.py
+++ b/tests/workflow_decorators/dag_io_masked_parameters.py
@@ -1,0 +1,50 @@
+from hera.shared import global_config
+from hera.workflows import Input, Output, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class WorkerInput(Input):
+    name: str  # Masking task attribute
+    hooks: bool  # Masking task attribute
+    target: str  # Some DAG attribute (not being masked)
+
+
+class WorkerOutput(Output):
+    name: str  # Masking task attribute
+    hooks: bool  # Masking task attribute
+    target: str  # Some DAG attribute (not being masked)
+
+
+@w.script()
+def dummy_task(_: WorkerInput) -> WorkerOutput:
+    pass
+
+
+@w.set_entrypoint
+@w.dag()
+def dummy_dag(dag_input: WorkerInput) -> WorkerOutput:
+    task_a = dummy_task(
+        WorkerInput(
+            name=dag_input.name,
+            hooks=dag_input.hooks,
+            target=dag_input.target,
+        )
+    )
+    task_b = dummy_task(
+        WorkerInput(
+            name=task_a.name,
+            hooks=task_a.hooks,
+            target=dag_input.target,
+        )
+    )
+
+    return WorkerOutput(
+        name=task_a.name,
+        hooks=task_b.hooks,
+        target=dag_input.target,
+    )

--- a/tests/workflow_decorators/dag_io_masked_parameters.py
+++ b/tests/workflow_decorators/dag_io_masked_parameters.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/tests/workflow_decorators/inner_dag.py
+++ b/tests/workflow_decorators/inner_dag.py
@@ -1,0 +1,57 @@
+from hera.shared import global_config
+from hera.workflows import Input, Output, Workflow
+
+global_config.experimental_features["script_annotations"] = True
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+w = Workflow(generate_name="my-workflow-")
+
+
+class SetupOutput(Output):
+    environment_parameter: str
+
+
+@w.script()
+def setup() -> SetupOutput:
+    return SetupOutput(environment_parameter="linux", result="Setting things up")
+
+
+class ConcatInput(Input):
+    word_a: str
+    word_b: str
+
+
+@w.script()
+def concat(concat_input: ConcatInput) -> Output:
+    return Output(result=f"{concat_input.word_a} {concat_input.word_b}")
+
+
+class WorkerInput(Input):
+    value_a: str
+    value_b: str
+
+
+class WorkerOutput(Output):
+    value: str
+
+
+@w.dag()
+def worker(worker_input: WorkerInput) -> WorkerOutput:
+    setup_task = setup()
+    task_a = concat(ConcatInput(word_a=worker_input.value_a, word_b=setup_task.environment_parameter))
+    task_b = concat(ConcatInput(word_a=worker_input.value_b, word_b=setup_task.result))
+    final_task = concat(ConcatInput(word_a=task_a.result, word_b=task_b.result))
+
+    return WorkerOutput(value=final_task.result)
+
+
+@w.set_entrypoint
+@w.dag()
+def outer_dag(worker_input: WorkerInput) -> WorkerOutput:
+    sub_dag_a = worker(WorkerInput(value_a="dag_a", value_b=worker_input.value_a))
+    sub_dag_b = worker(WorkerInput(value_a="dag_b", value_b=worker_input.value_b))
+
+    sub_dag_c = worker(WorkerInput(value_a=sub_dag_a.value, value_b=sub_dag_b.value))
+
+    return WorkerOutput(value=sub_dag_c.value)

--- a/tests/workflow_decorators/inner_dag.py
+++ b/tests/workflow_decorators/inner_dag.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, Workflow
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 w = Workflow(generate_name="my-workflow-")

--- a/tests/workflow_decorators/multiple_entrypoints.py
+++ b/tests/workflow_decorators/multiple_entrypoints.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, WorkflowTemplate
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 w = WorkflowTemplate(name="my-template")
 

--- a/tests/workflow_decorators/set_entrypoint.py
+++ b/tests/workflow_decorators/set_entrypoint.py
@@ -3,6 +3,7 @@ from hera.workflows import Input, Output, WorkflowTemplate
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 w = WorkflowTemplate(name="my-template")
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1043 
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Adds the new dag decorator from HEP0001.

* Within the decorator function call we perform a static inspection of
inputs and outputs, add a `DAG` object to the Workflow, and finally
do a "run" of the DAG function code using a templated input to collect the tasks
* Tasks that pass arguments simply take the templated input strings by using pydantic's `construct` method to skip validation, and then pass the strings around
* The dependencies between tasks are inferred automatically via __getattr__ calls
on the Task object
* Add varname as a dependency to be able to get the python variable name to use
as the task name (in the YAML)
* Make the _add_type_hints function work for *any* pydantic class