### PR TITLE
Propagate WorkflowsService instance from WorkflowTemplate to the created Workflow

### DIFF
--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -153,6 +153,7 @@ class WorkflowTemplate(Workflow):
     def _get_as_workflow(self, generate_name: Optional[str]) -> Workflow:
         workflow = cast(Workflow, Workflow.from_dict(self.to_dict()))
         workflow.kind = "Workflow"
+        workflow.workflows_service = self.workflows_service  # bind this workflow to the same service
 
         if generate_name is not None:
             workflow.generate_name = generate_name


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, when creating a workflow from a workflow template, it implicitly relies on the global config for the WorkflowsService, as it is not copying the service from the template. Thus, the simple example in the doc would fail, useless the Argo host is defined in the global config.

This PR binds the WorkflowsService instance of the WorkflowTemplate to the created Workflow to propagate non-global configuration, and changes 2 tests to make sure the config is actually propagated.

Thanks!
