### PR TITLE
Add superseding flag logic

### DIFF
--- a/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
@@ -13,8 +13,6 @@
     from hera.shared import global_config
     from hera.workflows import Artifact, Input, Output, Workflow
 
-    global_config.experimental_features["script_annotations"] = True
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -11,8 +11,6 @@
     from hera.shared import global_config
     from hera.workflows import Input, Output, Workflow
 
-    global_config.experimental_features["script_annotations"] = True
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -14,8 +14,6 @@
     from hera.shared import global_config
     from hera.workflows import Input, Output, Parameter, Workflow
 
-    global_config.experimental_features["script_annotations"] = True
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/docs/examples/workflows/experimental/new_decorators_basic_script.md
+++ b/docs/examples/workflows/experimental/new_decorators_basic_script.md
@@ -11,8 +11,6 @@
     from hera.shared import global_config
     from hera.workflows import Input, Output, WorkflowTemplate
 
-    global_config.experimental_features["script_annotations"] = True
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.experimental_features["decorator_syntax"] = True
 
     w = WorkflowTemplate(name="my-template")

--- a/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
+++ b/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
@@ -13,8 +13,6 @@
     from hera.shared import global_config
     from hera.workflows import Input, Output, Parameter, Workflow, parallel
 
-    global_config.experimental_features["script_annotations"] = True
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/docs/examples/workflows/experimental/script_runner_io.md
+++ b/docs/examples/workflows/experimental/script_runner_io.md
@@ -23,7 +23,6 @@
     except ImportError:
         from typing_extensions import Annotated  # type: ignore
 
-    global_config.experimental_features["script_annotations"] = True
     global_config.experimental_features["script_pydantic_io"] = True
 
 

--- a/examples/workflows/experimental/new_dag_decorator_artifacts.py
+++ b/examples/workflows/experimental/new_dag_decorator_artifacts.py
@@ -3,8 +3,6 @@ from typing_extensions import Annotated
 from hera.shared import global_config
 from hera.workflows import Artifact, Input, Output, Workflow
 
-global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/examples/workflows/experimental/new_dag_decorator_inner_dag.py
+++ b/examples/workflows/experimental/new_dag_decorator_inner_dag.py
@@ -1,8 +1,6 @@
 from hera.shared import global_config
 from hera.workflows import Input, Output, Workflow
 
-global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/examples/workflows/experimental/new_dag_decorator_params.py
+++ b/examples/workflows/experimental/new_dag_decorator_params.py
@@ -4,8 +4,6 @@ from typing_extensions import Annotated
 from hera.shared import global_config
 from hera.workflows import Input, Output, Parameter, Workflow
 
-global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/examples/workflows/experimental/new_decorators_basic_script.py
+++ b/examples/workflows/experimental/new_decorators_basic_script.py
@@ -1,8 +1,6 @@
 from hera.shared import global_config
 from hera.workflows import Input, Output, WorkflowTemplate
 
-global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.experimental_features["decorator_syntax"] = True
 
 w = WorkflowTemplate(name="my-template")

--- a/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.py
+++ b/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.py
@@ -3,8 +3,6 @@ from typing_extensions import Annotated
 from hera.shared import global_config
 from hera.workflows import Input, Output, Parameter, Workflow, parallel
 
-global_config.experimental_features["script_annotations"] = True
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.experimental_features["decorator_syntax"] = True
 
 

--- a/examples/workflows/experimental/script_runner_io.py
+++ b/examples/workflows/experimental/script_runner_io.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 
-global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True
 
 

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -165,3 +165,23 @@ class BaseMixin(BaseModel):
 
 GlobalConfig = global_config = _GlobalConfig()
 register_pre_build_hook = global_config.register_pre_build_hook
+
+_SCRIPT_ANNOTATIONS_FLAG = "script_annotations"
+_SCRIPT_PYDANTIC_IO_FLAG = "script_pydantic_io"
+_DECORATOR_SYNTAX_FLAG = "decorator_syntax"
+
+# A dictionary where each key is a flag that has a list of flags which supersede it, hence
+# the given flag key can also be switched on by any of the flags in the list. Using simple flat lists
+# for now, otherwise with many superseding flags we may want to have a recursive structure.
+_SUPERSEDING_FLAGS: Dict[str, List] = {
+    _SCRIPT_ANNOTATIONS_FLAG: [_SCRIPT_PYDANTIC_IO_FLAG, _DECORATOR_SYNTAX_FLAG],
+    _SCRIPT_PYDANTIC_IO_FLAG: [_DECORATOR_SYNTAX_FLAG],
+    _DECORATOR_SYNTAX_FLAG: [],
+}
+
+
+def _flag_enabled(flag: str) -> bool:
+    """Return true if the flag is set, or any of its superseding flags."""
+    return global_config.experimental_features[flag] or any(
+        global_config.experimental_features[f] for f in _SUPERSEDING_FLAGS[flag]
+    )

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -541,6 +541,22 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
     from hera.workflows.script import Script
     from hera.workflows.steps import Steps
 
+    @staticmethod
+    def _check_if_enabled(decorator_name: str):
+        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
+            raise ValueError(
+                str(
+                    "Unable to use {} decorator since it is an experimental feature."
+                    " Please turn on experimental features by setting "
+                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
+                    " Note that experimental features are unstable and subject to breaking changes."
+                ).format(decorator_name, _DECORATOR_SYNTAX_FLAG)
+            )
+        if not _varname_imported:
+            raise ImportError(
+                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
+            )
+
     @_add_type_hints(Script)  # type: ignore
     def script(self, **script_kwargs) -> Callable:
         """A decorator that wraps a function into a Script object.
@@ -561,19 +577,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
             Function wrapper that holds a `Script` and allows the function to be called to create a Step or Task if
             in a Steps or DAG context.
         """
-        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
-            raise ValueError(
-                str(
-                    "Unable to use {} decorator since it is an experimental feature."
-                    " Please turn on experimental features by setting "
-                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
-                    " Note that experimental features are unstable and subject to breaking changes."
-                ).format("script", _DECORATOR_SYNTAX_FLAG)
-            )
-        if not _varname_imported:
-            raise ImportError(
-                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
-            )
+        self._check_if_enabled("script")
 
         from hera.workflows.script import RunnerScriptConstructor, Script
 
@@ -772,19 +776,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
 
     @_add_type_hints(DAG)  # type: ignore
     def dag(self, **dag_kwargs) -> Callable:
-        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
-            raise ValueError(
-                str(
-                    "Unable to use {} decorator since it is an experimental feature."
-                    " Please turn on experimental features by setting "
-                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
-                    " Note that experimental features are unstable and subject to breaking changes."
-                ).format("dag", _DECORATOR_SYNTAX_FLAG)
-            )
-        if not _varname_imported:
-            raise ImportError(
-                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
-            )
+        self._check_if_enabled("dag")
 
         from hera.workflows.dag import DAG
 
@@ -792,19 +784,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
 
     @_add_type_hints(Steps)  # type: ignore
     def steps(self, **steps_kwargs) -> Callable:
-        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
-            raise ValueError(
-                str(
-                    "Unable to use {} decorator since it is an experimental feature."
-                    " Please turn on experimental features by setting "
-                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
-                    " Note that experimental features are unstable and subject to breaking changes."
-                ).format("steps", _DECORATOR_SYNTAX_FLAG)
-            )
-        if not _varname_imported:
-            raise ImportError(
-                "`varname` is not installed. Install `hera[experimental]` to bring in the extra dependency"
-            )
+        self._check_if_enabled("steps")
 
         from hera.workflows.steps import Steps
 

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
 from typing_extensions import ParamSpec
 
 from hera.shared import BaseMixin, global_config
+from hera.shared._global_config import _DECORATOR_SYNTAX_FLAG, _flag_enabled
 from hera.shared._pydantic import BaseModel, get_fields, root_validator
 from hera.workflows._context import _context
 from hera.workflows.exceptions import InvalidTemplateCall
@@ -533,9 +534,6 @@ def create_subnode(
     return subnode
 
 
-_DECORATOR_SYNTAX_FLAG = "decorator_syntax"
-
-
 class TemplateDecoratorFuncsMixin(ContextMixin):
     from hera.workflows.dag import DAG
     from hera.workflows.script import Script
@@ -543,7 +541,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
 
     @staticmethod
     def _check_if_enabled(decorator_name: str):
-        if not global_config.experimental_features[_DECORATOR_SYNTAX_FLAG]:
+        if not _flag_enabled(_DECORATOR_SYNTAX_FLAG):
             raise ValueError(
                 str(
                     "Unable to use {} decorator since it is an experimental feature."

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -712,12 +712,6 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
 
     _build_obj: Optional[HeraBuildObj] = PrivateAttr(None)
 
-    def __init__(self, **kwargs) -> None:
-        if _context.declaring:
-            object.__setattr__(self, "_build_data", kwargs)
-        else:
-            super().__init__(**kwargs)
-
     def __getattribute__(self, name: str) -> Any:
         if _context.declaring:
             # Use object's __getattribute__ to avoid infinite recursion


### PR DESCRIPTION
This PR adds a superseding relationship between flags, specified by the `_SUPERSEDING_FLAGS` dictionary in `_global_config.py`

Also refactored and removed unused code