### PR TITLE
Update docs to aid discoverability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ or
 ["ideal-for-contribution"](https://github.com/argoproj-labs/hera/issues?q=is%3Aopen+is%3Aissue+label%3Anote%3Aideal-for-contribution).
 
 We also encourage contributions in the form of:
+
 * Adding your organization as a [user of Hera](https://github.com/argoproj-labs/hera/blob/main/USERS.md)!
 * Answering questions on [GitHub Discussions](https://github.com/argoproj-labs/hera/discussions) and
   [Slack](https://cloud-native.slack.com/archives/C03NRMD9KPY)
@@ -30,7 +31,9 @@ meetings first, and then we can help you propose the feature using
 
 ### Setting up
 
-If you plan to submit contributions to Hera you can install Hera in a virtual environment managed by `poetry`:
+If you plan to submit contributions to Hera you can install Hera in a virtual environment managed by `poetry` (which
+must first be installed with `pipx` or the Poetry installer - see the
+[Poetry Installation guide](https://python-poetry.org/docs/#installation)):
 
 ```shell
 poetry install

--- a/docs/user-guides/script-basics.md
+++ b/docs/user-guides/script-basics.md
@@ -12,12 +12,6 @@ treated as the intended sub-object, which would be a `template` when under a `Wo
 `Steps`. The function will still behave as normal outside of any Hera contexts, meaning you can write unit tests on the
 given function.
 
-> **For advanced users**: the exact mechanism of the `script` decorator is to prepare a `Script` object within the
-> decorator, so that when your function is invoked under a Hera context, the call is redirected to the `Script.__call__`
-> function. This takes the kwargs of a `Step` or `Task` depending on whether the context manager is a `Steps` or a
-> `DAG`. Under a Workflow itself, your function is not expected to take arguments, so the call will add the function as
-> a template.
-
 When decorating a function, you should pass `Script` parameters to the `script` decorator. This includes values such as
 the `image` to use, and `resources` to request.
 
@@ -42,6 +36,12 @@ with Workflow(generate_name="dag-diamond-", entrypoint="diamond") as w:
         D = echo(name="D", arguments={"message": "D"})
         A >> [B, C] >> D
 ```
+
+> **For advanced users**: the exact mechanism of the `script` decorator is to prepare a `Script` object within the
+> decorator, so that when your function is invoked under a Hera context, the call is redirected to the `Script.__call__`
+> function. This takes the kwargs of a `Step` or `Task` depending on whether the context manager is a `Steps` or a
+> `DAG`. Under a Workflow itself, your function is not expected to take arguments, so the call will add the function as
+> a template.
 
 Alternatively, you can specify your DAG using `Task` directly:
 
@@ -117,7 +117,7 @@ spec:
 ```
 
 This method of running the function is handled by the `InlineScriptConstructor`, called such because it constructs the
-`Script` template to run the function "inline" in the YAML.
+`Script` template with the function appearing "inline" in the YAML in the `source` value.
 
 #### Importing modules
 

--- a/docs/walk-through/hello-world.md
+++ b/docs/walk-through/hello-world.md
@@ -38,6 +38,11 @@ so that we can decorate it. We use Hera's `script` decorator to turn the `echo` 
 `Script` class. As we're defining the Workflow in Python, Hera is able to infer multiple field values that the developer
 would otherwise have to define when using YAML.
 
+> **Note:** Using Hera's defaults for the script decorator is only suitable for very small/basic functions as it will
+> not allow you to use functions or modules defined outside of the function. For the best experience you will need to
+> build your own image and set up your config to use the `RunnerScriptConstructor`.
+> [See the Script Basics guide for details](../user-guides/script-basics.md).
+
 ### The `script` Decorator
 
 The `script` decorator can take kwargs that a `Script` can take. Importantly, you can specify the `image` of Python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,9 +23,6 @@ nav:
       - walk-through/advanced-template-features.md
       - walk-through/advanced-hera-features.md
       - walk-through/pydantic-support.md
-  - Contributing:
-    - Contributing Guide: CONTRIBUTING.md
-    - History of Hera: contributing/history.md
   - User Guides:
     - Core Concepts: user-guides/core-concepts.md
     - Scripts:
@@ -56,6 +53,9 @@ nav:
     - Upstream Examples:
       - About: examples/about-upstream.md
       - ... | flat | examples/workflows/upstream/*.md
+  - Contributing:
+    - Contributing Guide: CONTRIBUTING.md
+    - History of Hera: contributing/history.md
   - API Reference:
     - Shared: api/shared.md
     - Workflows:


### PR DESCRIPTION
* Move Contributing nav bar tab further to the right so "User Guides" and "Examples" are more prominent
* Also fix formatting in Contributing, and expand Poetry installation to link to installation of Poetry itself via pipx
* Add notice about script decorator to hello-world walkthrough page
* Move "advanced users" decorator explanation further down in script basics guide

Following [feedback in the Slack](https://cloud-native.slack.com/archives/C03NRMD9KPY/p1717177106037659), added another notice to read Script Basics from the hello world walkthrough page, and rearranged the nav bar to make "User Guides" and "Examples" more prominent. (Docs readers are more likely to need the walkthrough/guides more frequently than the contributing page.)