### PR TITLE
Add category for type:informational labels to release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,9 @@ template: $CHANGES
 name-template: v$RESOLVED_VERSION
 tag-template: $RESOLVED_VERSION
 categories:
+  - title: ℹ️ Information
+    labels:
+      - type:informational
   - title: ⭐️ Enhancements
     labels:
       - type:enhancement


### PR DESCRIPTION
Added a category for informational label, meaning we can set PR titles such as in https://github.com/argoproj-labs/hera/pull/1060 which will be visible as the first thing in the release notes.