### PR TITLE
Fix path to misc examples

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,7 @@ nav:
       - Experimental Features:
         - ... | flat | examples/workflows/experimental/*.md
       - Miscellaneous Examples:
-        - ... | flat | examples/workflows/*.md
+        - ... | flat | examples/workflows/misc/*.md
     - Use-Cases and Integrations:
       - About: examples/about-use-cases.md
       - ... | flat | examples/workflows/use-cases/*.md


### PR DESCRIPTION
The examples folder was rearranged (all remaining examples moved to `misc`) but we didn't update `mkdocs.yml`. 1 liner to fix