### PR TITLE
Update template refs example to use different types of templates

### DIFF
--- a/examples/workflows/experimental/new-decorators-auto-template-refs.yaml
+++ b/examples/workflows/experimental/new-decorators-auto-template-refs.yaml
@@ -7,6 +7,11 @@ spec:
   templates:
   - dag:
       tasks:
+      - name: run-setup-dag
+        templateRef:
+          clusterScope: true
+          name: my-cluster-workflow-template
+          template: run-setup-dag
       - name: setup_task
         templateRef:
           clusterScope: true


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1099 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

It is already possible to use function stubs for scripts/dags/steps due to the way Dags and steps were implemented. This PR updates the example to use stubbed scripts and dags.