### PR TITLE
Add ability to subclass from both Input and Output allowing for passthrough IO

### DIFF
--- a/docs/examples/workflows/experimental/new_decorators_passthrough_io.md
+++ b/docs/examples/workflows/experimental/new_decorators_passthrough_io.md
@@ -1,0 +1,124 @@
+# New Decorators Passthrough Io
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from typing_extensions import Annotated
+
+    from hera.shared import global_config
+    from hera.workflows import Artifact, ArtifactLoader, Input, Output, WorkflowTemplate
+
+    global_config.experimental_features["decorator_syntax"] = True
+
+    w = WorkflowTemplate(name="my-template")
+
+
+    class PassthroughIO(Input, Output):
+        my_str: str
+        my_int: int
+        my_artifact: Annotated[str, Artifact(name="my-artifact", loader=ArtifactLoader.json)]
+
+
+    @w.script()
+    def give_output() -> PassthroughIO:
+        return PassthroughIO(my_str="test", my_int=42)
+
+
+    @w.script()
+    def take_input(inputs: PassthroughIO) -> Output:
+        return Output(result=f"Got a string: {inputs.my_str}, got an int: {inputs.my_int}")
+
+
+    @w.dag()
+    def my_dag():
+        output_task = give_output()
+        take_input(output_task)
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      name: my-template
+    spec:
+      templates:
+      - name: give-output
+        outputs:
+          artifacts:
+          - name: my-artifact
+            path: /tmp/hera-outputs/artifacts/my-artifact
+          parameters:
+          - name: my_str
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/my_str
+          - name: my_int
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/my_int
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_decorators_passthrough_io:give_output
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - inputs:
+          artifacts:
+          - name: my-artifact
+            path: /tmp/hera-inputs/artifacts/my-artifact
+          parameters:
+          - name: my_str
+          - name: my_int
+        name: take-input
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.new_decorators_passthrough_io:take_input
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - dag:
+          tasks:
+          - name: output_task
+            template: give-output
+          - arguments:
+              artifacts:
+              - from: '{{tasks.output_task.outputs.artifacts.my-artifact}}'
+                name: my-artifact
+              parameters:
+              - name: my_str
+                value: '{{tasks.output_task.outputs.parameters.my_str}}'
+              - name: my_int
+                value: '{{tasks.output_task.outputs.parameters.my_int}}'
+            depends: output_task
+            name: take-input
+            template: take-input
+        name: my-dag
+    ```
+

--- a/examples/workflows/experimental/new-decorators-passthrough-io.yaml
+++ b/examples/workflows/experimental/new-decorators-passthrough-io.yaml
@@ -1,0 +1,77 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: my-template
+spec:
+  templates:
+  - name: give-output
+    outputs:
+      artifacts:
+      - name: my-artifact
+        path: /tmp/hera-outputs/artifacts/my-artifact
+      parameters:
+      - name: my_str
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/my_str
+      - name: my_int
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/my_int
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_decorators_passthrough_io:give_output
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - inputs:
+      artifacts:
+      - name: my-artifact
+        path: /tmp/hera-inputs/artifacts/my-artifact
+      parameters:
+      - name: my_str
+      - name: my_int
+    name: take-input
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.new_decorators_passthrough_io:take_input
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - dag:
+      tasks:
+      - name: output_task
+        template: give-output
+      - arguments:
+          artifacts:
+          - from: '{{tasks.output_task.outputs.artifacts.my-artifact}}'
+            name: my-artifact
+          parameters:
+          - name: my_str
+            value: '{{tasks.output_task.outputs.parameters.my_str}}'
+          - name: my_int
+            value: '{{tasks.output_task.outputs.parameters.my_int}}'
+        depends: output_task
+        name: take-input
+        template: take-input
+    name: my-dag

--- a/examples/workflows/experimental/new_decorators_passthrough_io.py
+++ b/examples/workflows/experimental/new_decorators_passthrough_io.py
@@ -1,0 +1,30 @@
+from typing_extensions import Annotated
+
+from hera.shared import global_config
+from hera.workflows import Artifact, ArtifactLoader, Input, Output, WorkflowTemplate
+
+global_config.experimental_features["decorator_syntax"] = True
+
+w = WorkflowTemplate(name="my-template")
+
+
+class PassthroughIO(Input, Output):
+    my_str: str
+    my_int: int
+    my_artifact: Annotated[str, Artifact(name="my-artifact", loader=ArtifactLoader.json)]
+
+
+@w.script()
+def give_output() -> PassthroughIO:
+    return PassthroughIO(my_str="test", my_int=42)
+
+
+@w.script()
+def take_input(inputs: PassthroughIO) -> Output:
+    return Output(result=f"Got a string: {inputs.my_str}, got an int: {inputs.my_int}")
+
+
+@w.dag()
+def my_dag():
+    output_task = give_output()
+    take_input(output_task)

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -156,7 +156,7 @@ class InputMixin(BaseModel):
                 # to create a "passthrough" IO object
                 continue
             # The dict value may be of any type if it was a default value, so we need to serialize it.
-            # If it is a templated string, it will be unaffected as `"{{mystr}}" == serialize("{{mystr}}")``
+            # If it is a templated string, it will be unaffected as `"{{mystr}}" == serialize("{{mystr}}")`
             templated_value = serialize(self_dict[field])
 
             if get_origin(annotations[field]) is Annotated:


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #922 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
This PR makes it possible to subclass `Input` and `Output` for the new decorators in HEP0001, and then pass an output from a script template call directly into the next step or task. i.e. instead of

```py
@w.dag()
def my_dag():
    output_task = give_output()
    take_input(
        PassthroughIO(
            my_str=output_task.my_str,
            my_int=output_task.my_int,
            my_artifact=output_task.my_artifact,
        )
    )
```
you can do
```py
@w.dag()
def my_dag():
    output_task = give_output()
    take_input(output_task)
```

Note this functionality is limited to script-decorated functions only for now, as other template types would need an even more involved approach where this code had already become complex enough, as we are reconstructing an `Output` from a step or task object.