### PR TITLE
Update check-codegen to fail CI if examples not regenerated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ codegen: models services examples init-files
 check-codegen: ## Check if the code is up to date
 check-codegen:
 	@$(MAKE) codegen
-	@git diff --exit-code || echo "Code is not up-to-date. Please run 'make codegen'"
+	@git diff --exit-code || (echo "Code is not up-to-date. Please run 'make codegen'" && exit 1)
 
 .PHONY: format
 format: ## Format and sort imports for source, tests, examples, etc.

--- a/docs/examples/workflows/misc/suspend_input_duration.md
+++ b/docs/examples/workflows/misc/suspend_input_duration.md
@@ -9,7 +9,7 @@
 
     ```python linenums="1"
     from hera.workflows import Step, Steps, Suspend, Workflow
-    from hera.workflows.models import Inputs, Parameter, SuspendTemplate, Template
+    from hera.workflows.models import Parameter
 
     with Workflow(
         generate_name="suspend-input-duration-",
@@ -20,19 +20,19 @@
             intermediate_parameters=[Parameter(name="duration")],
         )
 
-        configurable_suspend_template = Template(
+        configurable_suspend_template = Suspend(
             name="input-duration-suspend",
-            suspend=SuspendTemplate(duration="{{inputs.parameters.duration}}"),
-            inputs=Inputs(parameters=[Parameter(name="duration", default="10")]),
+            inputs=[Parameter(name="duration", default="10")],
+            duration="{{inputs.parameters.duration}}",
         )
 
         with Steps(name="suspend"):
-            intermediate_params(name="get-value-step")
+            get_value_step = intermediate_params(name="get-value-step")
 
             Step(
                 name="custom-delay-step",
                 template=configurable_suspend_template,
-                arguments={"duration": "{{steps.get-value-step.outputs.parameters.duration}}"},
+                arguments={"duration": get_value_step.get_parameter("duration")},
             )
     ```
 


### PR DESCRIPTION
Add non-zero exit for`check-codegen` so we stop missing non-regenerated examples in CI e.g. for https://github.com/argoproj-labs/hera/pull/1108 - https://github.com/argoproj-labs/hera/actions/runs/9566065952/job/26370421288 - had the Code is not up-to-date. Please run 'make codegen' message but no failure