### PR TITLE
Add docs signposts to install `experimental` extra for decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ w.create()
 
 ### Optional dependencies
 
-#### yaml
+#### `yaml`
 
 - Install via `hera[yaml]`
 - [PyYAML](https://pypi.org/project/PyYAML/) is required for the `yaml` output format, which is accessible via
   `hera.workflows.Workflow.to_yaml(*args, **kwargs)`. This enables GitOps practices and easier debugging.
 
-#### cli
+#### `cli`
 
 - Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa)
   required for the CLI
@@ -154,6 +154,9 @@ w.create()
   easier debugging, and a more seamless experience with Argo Workflows.
 - **_The CLI is an experimental feature and subject to change!_** At the moment it only supports generating YAML files
   from workflows via `hera generate yaml`. See `hera generate yaml --help` for more information.
+
+#### `experimental`
+ - Install via `hera[experimental]`. The `[experimental]` option adds dependencies required for experimental features that have not yet graduated into stable features.
 
 ## Presentations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,13 +140,13 @@ w.create()
 
 ### Optional dependencies
 
-#### yaml
+#### `yaml`
 
 - Install via `hera[yaml]`
 - [PyYAML](https://pypi.org/project/PyYAML/) is required for the `yaml` output format, which is accessible via
   `hera.workflows.Workflow.to_yaml(*args, **kwargs)`. This enables GitOps practices and easier debugging.
 
-#### cli
+#### `cli`
 
 - Install via `hera[cli]`. The `[cli]` option installs the extra dependency [Cappa](https://github.com/DanCardin/cappa)
   required for the CLI
@@ -154,6 +154,9 @@ w.create()
   easier debugging, and a more seamless experience with Argo Workflows.
 - **_The CLI is an experimental feature and subject to change!_** At the moment it only supports generating YAML files
   from workflows via `hera generate yaml`. See `hera generate yaml --help` for more information.
+
+#### `experimental`
+ - Install via `hera[experimental]`. The `[experimental]` option adds dependencies required for experimental features that have not yet graduated into stable features.
 
 ## Presentations
 

--- a/docs/user-guides/decorators.md
+++ b/docs/user-guides/decorators.md
@@ -18,6 +18,12 @@ If you want to declare inputs and outputs in your templates, you must use the sp
 classes from `hera.workflows` so that Hera can deduce the inputs and outputs of your templates from the fields declared
 in the classes.
 
+You must also install the optional extras under `experimental` to enable the full feature set for decorators
+
+```bash
+pip install hera[experimental]
+```
+
 ## `dag` and `steps`
 
 The `dag` and `steps` decorator bring brand-new functionality to Hera, as they allow you to run and test your dag and

--- a/docs/walk-through/advanced-hera-features.md
+++ b/docs/walk-through/advanced-hera-features.md
@@ -139,7 +139,13 @@ Read the full guide on script pydantic IO in [the script user guide](../user-gui
 
 Decorators for dags, steps and containers are provided alongside a new script decorator, letting your declare Workflows via Python functions alone.
 
-To enable the decorators, you must set the `experimental_feature` flag `decorator_syntax`
+To enable the decorators, you must install the optional extras under `experimental`
+
+```bash
+pip install hera[experimental]
+```
+
+You can then set the `experimental_feature` flag `decorator_syntax` in your code
 
 ```py
 global_config.experimental_features["decorator_syntax"] = True


### PR DESCRIPTION
Adds installation instructions to README, advanced-hera-features and the decorators user guide.