### PR TITLE
Add site_url in mkdocs.yml for broken stylesheet links in 404 page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 ---
 site_name: Hera
 site_author: Flaviu Vadan, Sambhav Kothari, Elliot Gunton
+site_url: https://hera-workflows.readthedocs.io/en/latest/
 copyright: Copyright &copy; 2023 Flaviu Vadan, Sambhav Kothari, Elliot Gunton
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 site_name: Hera
 site_author: Flaviu Vadan, Sambhav Kothari, Elliot Gunton
-site_url: https://hera-workflows.readthedocs.io/en/latest/
+site_url: https://hera.readthedocs.io/en/latest/
 copyright: Copyright &copy; 2023 Flaviu Vadan, Sambhav Kothari, Elliot Gunton
 
 nav:


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1142 
- ~~Tests added~~ no test needed
- ~~Documentation/examples added~~ no additional documentation needed
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, 404 page is not rendered properly because stylesheet links are broken in there.
(details are described in the linked issue)
This PR adds `site_url` attribute in `mkdocs.yml` for the workaround of #1142 .

if css hash has changed, it can be broken again in 404 page of outdated docs.
but with this workaround, at least latest docs will be rendered properly.
