### PR TITLE
Disable template name conflict detection

### DIFF
--- a/examples/workflows/steps/recursive-steps.yaml
+++ b/examples/workflows/steps/recursive-steps.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: my-workflow
+spec:
+  entrypoint: steps
+  templates:
+  - name: sub-steps
+    steps:
+    - - name: random-roll
+        template: random-roll
+    - - arguments:
+          parameters:
+          - name: input-num
+            value: '{{steps.random-roll.outputs.result}}'
+        name: recurse
+        template: sub-steps
+        when: '{{steps.random-roll.outputs.result}} != 0'
+  - name: random-roll
+    script:
+      command:
+      - python
+      image: python:3.8
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import random
+        return random.randint(0, 2)
+  - name: steps
+    steps:
+    - - name: sub-steps
+        template: sub-steps

--- a/examples/workflows/steps/recursive_steps.py
+++ b/examples/workflows/steps/recursive_steps.py
@@ -1,0 +1,22 @@
+from hera.workflows import Step, Steps, WorkflowTemplate, script
+
+
+@script(constructor="inline")
+def random_roll():
+    import random
+
+    return random.randint(0, 2)
+
+
+with WorkflowTemplate(name="my-workflow", entrypoint="steps") as w:
+    with Steps(name="sub-steps") as sub_steps:
+        random_number = random_roll()
+        Step(
+            name="recurse",
+            arguments={"input-num": random_number.result},
+            template=sub_steps,
+            when=f"{random_number.result} != 0",
+        )
+
+    with Steps(name="steps"):
+        sub_steps()

--- a/src/hera/workflows/_context.py
+++ b/src/hera/workflows/_context.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from typing import List, Optional, TypeVar, Union
 
 from hera.shared import BaseMixin
-from hera.workflows.exceptions import InvalidType, TemplateNameConflict
+from hera.workflows.exceptions import InvalidType
 from hera.workflows.protocol import Subbable, TTemplate
 
 TNode = TypeVar("TNode", bound="SubNodeMixin")
@@ -102,8 +102,6 @@ class _HeraContext:
             found = False
             for t in pieces[0].templates:
                 if t.name == node.template.name:
-                    if t != node.template:
-                        raise TemplateNameConflict(f"Found multiple templates with the same name: {t.name}")
                     found = True
                     break
             if not found:

--- a/src/hera/workflows/exceptions.py
+++ b/src/hera/workflows/exceptions.py
@@ -26,7 +26,7 @@ class InvalidDispatchType(WorkflowsException):
 
 
 class TemplateNameConflict(WorkflowsException):
-    """Exception raised when multiple Templates are found with the same name.."""
+    """Currently unused."""
 
     ...
 


### PR DESCRIPTION
**Pull Request Checklist**
- [X] Fixes #1151
- [X] Tests added
- [X] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, template name conflict detection is causing a stack overflow when run on a recursive template.

This PR removes template name conflict detection, which was added in #1054.
