### PR TITLE
Refactor init_containers building logic in TemplateMixin

### DIFF
--- a/docs/examples/workflows/misc/init_containers_with_env.md
+++ b/docs/examples/workflows/misc/init_containers_with_env.md
@@ -1,0 +1,65 @@
+# Init Containers With Env
+
+
+
+This example showcases how to run a init_containers with env
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import Container, Env, SecretEnv, UserContainer, Workflow
+
+    with Workflow(generate_name="container-", entrypoint="cowsay") as w:
+        Container(
+            name="cowsay",
+            image="docker/whalesay",
+            command=["cowsay", "foo"],
+            init_containers=[
+                UserContainer(
+                    name="init",
+                    image="busybox",
+                    command=[
+                        "sh",
+                        "-c",
+                        "echo Hello from the init container ($FOO, $SECRET)",
+                    ],
+                    env=[
+                        Env(name="FOO", value="bar"),
+                        SecretEnv(name="SECRET", secret_key="password", secret_name="my-secret"),
+                    ],
+                )
+            ],
+        )
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: container-
+    spec:
+      entrypoint: cowsay
+      templates:
+      - container:
+          command:
+          - cowsay
+          - foo
+          image: docker/whalesay
+        name: cowsay
+        initContainers:
+        - name: init
+          image: busybox
+          command: [ "sh", "-c", "echo Hello from the init container ($FOO, $SECRET)" ]
+          env:
+          - name: FOO
+            value: "bar"
+          - name: SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: password
+    ```
+

--- a/examples/workflows/misc/init-containers-with-env.yaml
+++ b/examples/workflows/misc/init-containers-with-env.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: container-
+spec:
+  entrypoint: cowsay
+  templates:
+  - container:
+      command:
+      - cowsay
+      - foo
+      image: docker/whalesay
+    name: cowsay
+    initContainers:
+    - name: init
+      image: busybox
+      command: [ "sh", "-c", "echo Hello from the init container ($FOO, $SECRET)" ]
+      env:
+      - name: FOO
+        value: "bar"
+      - name: SECRET
+        valueFrom:
+          secretKeyRef:
+            name: my-secret
+            key: password

--- a/examples/workflows/misc/init_containers_with_env.py
+++ b/examples/workflows/misc/init_containers_with_env.py
@@ -1,0 +1,25 @@
+"""This example showcases how to run a init_containers with env"""
+
+from hera.workflows import Container, Env, SecretEnv, UserContainer, Workflow
+
+with Workflow(generate_name="container-", entrypoint="cowsay") as w:
+    Container(
+        name="cowsay",
+        image="docker/whalesay",
+        command=["cowsay", "foo"],
+        init_containers=[
+            UserContainer(
+                name="init",
+                image="busybox",
+                command=[
+                    "sh",
+                    "-c",
+                    "echo Hello from the init container ($FOO, $SECRET)",
+                ],
+                env=[
+                    Env(name="FOO", value="bar"),
+                    SecretEnv(name="SECRET", secret_key="password", secret_name="my-secret"),
+                ],
+            )
+        ],
+    )

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -433,6 +433,13 @@ class TemplateMixin(SubNodeMixin, HookMixin, MetricsMixin):
             return v
         return IntOrString(__root__=v)
 
+    def _build_init_containers(self) -> Optional[List[ModelUserContainer]]:
+        """Builds the `init_containers` field and optionally returns a list of `UserContainer`."""
+        if self.init_containers is None:
+            return None
+
+        return [i.build() if isinstance(i, UserContainer) else i for i in self.init_containers]
+
     def _build_sidecars(self) -> Optional[List[ModelUserContainer]]:
         """Builds the `sidecars` field and optionally returns a list of `UserContainer`."""
         if self.sidecars is None:

--- a/src/hera/workflows/container.py
+++ b/src/hera/workflows/container.py
@@ -84,7 +84,7 @@ class Container(
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -177,7 +177,7 @@ class ContainerSet(
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -73,7 +73,7 @@ class DAG(
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),

--- a/src/hera/workflows/data.py
+++ b/src/hera/workflows/data.py
@@ -46,7 +46,7 @@ class Data(TemplateMixin, IOMixin, CallableTemplateMixin):
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             outputs=self._build_outputs(),
             memoize=self.memoize,

--- a/src/hera/workflows/http_template.py
+++ b/src/hera/workflows/http_template.py
@@ -48,7 +48,7 @@ class HTTP(TemplateMixin, IOMixin, CallableTemplateMixin):
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
             http=self._build_http_template(),
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             memoize=self.memoize,
             metadata=self._build_metadata(),
             inputs=self._build_inputs(),

--- a/src/hera/workflows/resource.py
+++ b/src/hera/workflows/resource.py
@@ -61,7 +61,7 @@ class Resource(CallableTemplateMixin, TemplateMixin, SubNodeMixin, IOMixin):
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -186,7 +186,7 @@ class Script(
                 executor=self.executor,
                 fail_fast=self.fail_fast,
                 host_aliases=self.host_aliases,
-                init_containers=self.init_containers,
+                init_containers=self._build_init_containers(),
                 inputs=self._build_inputs(),
                 memoize=self.memoize,
                 metadata=self._build_metadata(),

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -210,7 +210,7 @@ class Steps(
             fail_fast=self.fail_fast,
             http=None,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),

--- a/src/hera/workflows/suspend.py
+++ b/src/hera/workflows/suspend.py
@@ -86,7 +86,7 @@ class Suspend(
             executor=self.executor,
             fail_fast=self.fail_fast,
             host_aliases=self.host_aliases,
-            init_containers=self.init_containers,
+            init_containers=self._build_init_containers(),
             inputs=self._build_inputs(),
             memoize=self.memoize,
             metadata=self._build_metadata(),


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1155 
- [ ] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**PR Description**

When using Hera to generate an Argo Workflow, I encountered an issue with the env structure in initContainers. Specifically, the env variable references for secrets are not being properly constructed. Instead of the correct structure with valueFrom, the generated YAML output directly assigns secret_name and secret_key, which is not valid in Argo Workflows.

This issue occurs because Hera doesn't handle this internally within its template constructors. Instead, it uses the `initContainers` as they are provided [here](https://github.com/argoproj-labs/hera/blob/main/src/hera/workflows/container.py#L87). To address this, I created the `_build_init_containers` method in the `TemplateMixin` class.

```python
    def _build_init_containers(self) -> Optional[List[ModelUserContainer]]:
        """Builds the `init_containers` field and optionally returns a list of `UserContainer`."""
        if self.init_containers is None:
            return None

        return [i.build() if isinstance(i, UserContainer) else i for i in self.init_containers]
```
This method ensures that the `init_containers` field is correctly constructed, and if any of the containers are instances of `UserContainer`, they are properly built before being returned.
