### PR TITLE
Use sys.version_info to guard imports

### DIFF
--- a/docs/examples/workflows/experimental/script_annotations_artifact_custom_volume.md
+++ b/docs/examples/workflows/experimental/script_annotations_artifact_custom_volume.md
@@ -8,14 +8,12 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows.artifact import ArtifactLoader
-    from hera.workflows.volume import Volume
+    import sys
 
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
-
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import (
@@ -28,6 +26,8 @@ This example will reuse the outputs volume across script steps.
         models as m,
         script,
     )
+    from hera.workflows.artifact import ArtifactLoader
+    from hera.workflows.volume import Volume
 
     global_config.experimental_features["script_annotations"] = True
 

--- a/docs/examples/workflows/experimental/script_annotations_artifact_loaders.md
+++ b/docs/examples/workflows/experimental/script_annotations_artifact_loaders.md
@@ -9,13 +9,14 @@
 
     ```python linenums="1"
     import json
+    import sys
     from pathlib import Path
     from typing import Dict
 
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script

--- a/docs/examples/workflows/experimental/script_annotations_artifact_outputs_defaults.md
+++ b/docs/examples/workflows/experimental/script_annotations_artifact_outputs_defaults.md
@@ -8,14 +8,12 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
-    from hera.workflows.artifact import ArtifactLoader
-    from hera.workflows.volume import Volume
+    import sys
 
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
-
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import (
@@ -25,6 +23,8 @@ This example will reuse the outputs volume across script steps.
         Workflow,
         script,
     )
+    from hera.workflows.artifact import ArtifactLoader
+    from hera.workflows.volume import Volume
 
     global_config.experimental_features["script_annotations"] = True
 

--- a/docs/examples/workflows/experimental/script_annotations_artifact_passing.md
+++ b/docs/examples/workflows/experimental/script_annotations_artifact_passing.md
@@ -8,13 +8,13 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
-
-
+    import sys
     from pathlib import Path
+
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import (

--- a/docs/examples/workflows/experimental/script_annotations_inputs.md
+++ b/docs/examples/workflows/experimental/script_annotations_inputs.md
@@ -8,12 +8,13 @@
 === "Hera"
 
     ```python linenums="1"
+    import sys
     from typing import Dict
 
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script

--- a/docs/examples/workflows/experimental/script_annotations_outputs.md
+++ b/docs/examples/workflows/experimental/script_annotations_outputs.md
@@ -8,13 +8,14 @@
 === "Hera"
 
     ```python linenums="1"
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
-
+    import sys
     from pathlib import Path
     from typing import Tuple
+
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from hera.shared import global_config
     from hera.workflows import Artifact, Parameter, RunnerScriptConstructor, Steps, Workflow, script

--- a/docs/examples/workflows/experimental/script_runner_io.md
+++ b/docs/examples/workflows/experimental/script_runner_io.md
@@ -8,6 +8,13 @@
 === "Hera"
 
     ```python linenums="1"
+    import sys
+
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
+
     try:
         from pydantic.v1 import BaseModel
     except ImportError:
@@ -17,11 +24,6 @@
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
     from hera.workflows.archive import NoneArchiveStrategy
     from hera.workflows.io import Input, Output
-
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
 
     global_config.experimental_features["script_pydantic_io"] = True
 

--- a/docs/examples/workflows/scripts/callable_script.md
+++ b/docs/examples/workflows/scripts/callable_script.md
@@ -8,18 +8,18 @@
 === "Hera"
 
     ```python linenums="1"
+    import sys
     from typing import List, Union
 
-    from hera.shared.serialization import serialize
-
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
     from pydantic import BaseModel
 
     from hera.shared import global_config
+    from hera.shared.serialization import serialize
     from hera.workflows import Parameter, Script, Steps, Workflow, script
 
     # Note, setting constructor to runner is only possible if the source code is available

--- a/docs/examples/workflows/scripts/callable_script_v1.md
+++ b/docs/examples/workflows/scripts/callable_script_v1.md
@@ -8,21 +8,21 @@
 === "Hera"
 
     ```python linenums="1"
+    import sys
     from typing import List, Union
 
-    from hera.shared.serialization import serialize
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
 
-    try:
-        from typing import Annotated  # type: ignore
-    except ImportError:
-        from typing_extensions import Annotated  # type: ignore
     try:
         from pydantic.v1 import BaseModel
     except (ImportError, ModuleNotFoundError):
         from pydantic import BaseModel
 
-
     from hera.shared import global_config
+    from hera.shared.serialization import serialize
     from hera.workflows import Parameter, RunnerScriptConstructor, Script, Steps, Workflow, script
 
     # Note, setting constructor to runner is only possible if the source code is available

--- a/examples/workflows/experimental/script_annotations_artifact_custom_volume.py
+++ b/examples/workflows/experimental/script_annotations_artifact_custom_volume.py
@@ -1,13 +1,11 @@
 """This example will reuse the outputs volume across script steps."""
 
-from hera.workflows.artifact import ArtifactLoader
-from hera.workflows.volume import Volume
+import sys
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import (
@@ -20,6 +18,8 @@ from hera.workflows import (
     models as m,
     script,
 )
+from hera.workflows.artifact import ArtifactLoader
+from hera.workflows.volume import Volume
 
 global_config.experimental_features["script_annotations"] = True
 

--- a/examples/workflows/experimental/script_annotations_artifact_loaders.py
+++ b/examples/workflows/experimental/script_annotations_artifact_loaders.py
@@ -1,11 +1,12 @@
 import json
+import sys
 from pathlib import Path
 from typing import Dict
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script

--- a/examples/workflows/experimental/script_annotations_artifact_outputs_defaults.py
+++ b/examples/workflows/experimental/script_annotations_artifact_outputs_defaults.py
@@ -1,13 +1,11 @@
 """This example will reuse the outputs volume across script steps."""
 
-from hera.workflows.artifact import ArtifactLoader
-from hera.workflows.volume import Volume
+import sys
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import (
@@ -17,6 +15,8 @@ from hera.workflows import (
     Workflow,
     script,
 )
+from hera.workflows.artifact import ArtifactLoader
+from hera.workflows.volume import Volume
 
 global_config.experimental_features["script_annotations"] = True
 

--- a/examples/workflows/experimental/script_annotations_artifact_passing.py
+++ b/examples/workflows/experimental/script_annotations_artifact_passing.py
@@ -1,12 +1,12 @@
 """This example will reuse the outputs volume across script steps."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
-
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import (

--- a/examples/workflows/experimental/script_annotations_inputs.py
+++ b/examples/workflows/experimental/script_annotations_inputs.py
@@ -1,9 +1,10 @@
+import sys
 from typing import Dict
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script

--- a/examples/workflows/experimental/script_annotations_outputs.py
+++ b/examples/workflows/experimental/script_annotations_outputs.py
@@ -1,10 +1,11 @@
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+import sys
 from pathlib import Path
 from typing import Tuple
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Artifact, Parameter, RunnerScriptConstructor, Steps, Workflow, script

--- a/examples/workflows/experimental/script_runner_io.py
+++ b/examples/workflows/experimental/script_runner_io.py
@@ -1,3 +1,10 @@
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 try:
     from pydantic.v1 import BaseModel
 except ImportError:
@@ -7,11 +14,6 @@ from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
 from hera.workflows.archive import NoneArchiveStrategy
 from hera.workflows.io import Input, Output
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_pydantic_io"] = True
 

--- a/examples/workflows/scripts/callable_script.py
+++ b/examples/workflows/scripts/callable_script.py
@@ -1,15 +1,15 @@
+import sys
 from typing import List, Union
 
-from hera.shared.serialization import serialize
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from pydantic import BaseModel
 
 from hera.shared import global_config
+from hera.shared.serialization import serialize
 from hera.workflows import Parameter, Script, Steps, Workflow, script
 
 # Note, setting constructor to runner is only possible if the source code is available

--- a/examples/workflows/scripts/callable_script_v1.py
+++ b/examples/workflows/scripts/callable_script_v1.py
@@ -1,18 +1,18 @@
+import sys
 from typing import List, Union
 
-from hera.shared.serialization import serialize
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 try:
     from pydantic.v1 import BaseModel
 except (ImportError, ModuleNotFoundError):
     from pydantic import BaseModel
 
-
 from hera.shared import global_config
+from hera.shared.serialization import serialize
 from hera.workflows import Parameter, RunnerScriptConstructor, Script, Steps, Workflow, script
 
 # Note, setting constructor to runner is only possible if the source code is available

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -4,10 +4,27 @@ from __future__ import annotations
 
 import functools
 import inspect
+import sys
 from collections import ChainMap
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type, TypeVar, Union, cast
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware.
+    from typing_extensions import Annotated, get_args, get_origin
+
+if sys.version_info >= (3, 10):
+    from inspect import get_annotations
+    from types import NoneType
+else:
+    from hera.shared._inspect import get_annotations
+
+    NoneType = type(None)
+
 
 from typing_extensions import ParamSpec
 
@@ -38,21 +55,6 @@ except ImportError:
         Input as InputV2,
         Output as OutputV2,
     )
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
-
-try:
-    from inspect import get_annotations  # type: ignore
-except ImportError:
-    from hera.shared._inspect import get_annotations  # type: ignore
-
-try:
-    from types import NoneType  # type: ignore
-except ImportError:
-    NoneType = type(None)  # type: ignore
-
 
 if TYPE_CHECKING:
     from hera.workflows._mixins import TemplateMixin

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import (
     Any,
     Callable,
@@ -14,6 +15,13 @@ from typing import (
     Union,
     cast,
 )
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware.
+    from typing_extensions import Annotated, get_args, get_origin
 
 from hera.shared import BaseMixin, global_config
 from hera.shared._pydantic import PrivateAttr, get_field_annotations, get_fields, root_validator, validator
@@ -69,12 +77,6 @@ from hera.workflows.protocol import Templatable
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import Volume, _BaseVolume
-
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
-
 
 T = TypeVar("T")
 OneOrMany = Union[T, SequenceType[T]]

--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -3,8 +3,16 @@
 import inspect
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware.
+    from typing_extensions import Annotated, get_args, get_origin
 
 from hera.shared._pydantic import BaseModel, get_field_annotations, get_fields
 from hera.shared.serialization import serialize
@@ -25,11 +33,6 @@ except ImportError:
         Input as InputV2,
         Output as OutputV2,
     )
-
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
 
 
 def _get_outputs_path(destination: Union[Parameter, Artifact]) -> Path:

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -6,8 +6,16 @@ import importlib
 import inspect
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union, cast
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware.
+    from typing_extensions import Annotated, get_args, get_origin
 
 from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.shared.serialization import serialize
@@ -22,11 +30,6 @@ from hera.workflows.io.v1 import (
     Output as OutputV1,
 )
 from hera.workflows.script import _extract_return_annotation_output
-
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
 
 if _PYDANTIC_VERSION == 2:
     from pydantic.type_adapter import TypeAdapter  # type: ignore

--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -4,20 +4,23 @@ See https://argoproj.github.io/argo-workflows/cron-workflows
 for more on CronWorkflows.
 """
 
+import sys
 from pathlib import Path
 from typing import Dict, Optional, Type, Union, cast
 
-from hera.workflows._meta_mixins import ModelMapperMixin, _set_model_attr
-
-try:
-    from typing import Annotated, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args, get_origin  # type: ignore
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware.
+    from typing_extensions import Annotated, get_args, get_origin
 
 from hera.exceptions import NotFound
 from hera.shared._pydantic import BaseModel
 from hera.workflows._meta_mixins import (
+    ModelMapperMixin,
     _get_model_attr,
+    _set_model_attr,
 )
 from hera.workflows.models import (
     CreateCronWorkflowRequest,

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -1,6 +1,26 @@
+import sys
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
+if sys.version_info >= (3, 10):
+    from typing import get_args, get_origin
+else:
+    # Python 3.8 has get_origin() and get_args() but those implementations aren't
+    # Annotated-aware. Python 3.9's versions don't support ParamSpecArgs and
+    # ParamSpecKwargs.
+    from typing_extensions import get_args, get_origin
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 from hera.shared._pydantic import _PYDANTIC_VERSION, get_field_annotations, get_fields
 from hera.shared.serialization import MISSING, serialize
@@ -24,11 +44,6 @@ else:
     V2BaseModel = V1BaseModel  # type: ignore
     PydanticUndefined = None  # type: ignore[assignment]
 
-
-try:
-    from typing import Annotated, Self, get_args, get_origin  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, Self, get_args, get_origin  # type: ignore
 
 if TYPE_CHECKING:
     # We add BaseModel as a parent class of the mixins only when type checking which allows it

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -6,6 +6,7 @@ for more on scripts.
 
 import copy
 import inspect
+import sys
 import textwrap
 import warnings
 from abc import abstractmethod
@@ -23,6 +24,12 @@ from typing import (
     Union,
     cast,
 )
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 
 from typing_extensions import ParamSpec, get_args, get_origin
 
@@ -77,11 +84,6 @@ from hera.workflows.parameter import MISSING, Parameter
 from hera.workflows.steps import Step
 from hera.workflows.task import Task
 from hera.workflows.volume import _BaseVolume
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 class ScriptConstructor(BaseMixin):

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -5,23 +5,24 @@ for more on Workflows.
 """
 
 import logging
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated, get_args
+else:
+    # Python 3.8 has get_args() but the implementation isn't Annotated-aware.
+    from typing_extensions import Annotated, get_args
+
+
 from typing_extensions import ParamSpec
-
-from hera.workflows._meta_mixins import HookMixin, ModelMapperMixin, TemplateDecoratorFuncsMixin
-from hera.workflows.template_set import TemplateSet
-
-try:
-    from typing import Annotated, get_args  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated, get_args  # type: ignore
 
 from hera import _yaml
 from hera.shared import global_config
 from hera.shared._pydantic import BaseModel, validator
+from hera.workflows._meta_mixins import HookMixin, ModelMapperMixin, TemplateDecoratorFuncsMixin
 from hera.workflows._mixins import (
     ArgumentsMixin,
     ArgumentsT,
@@ -66,6 +67,7 @@ from hera.workflows.models import (
 from hera.workflows.parameter import Parameter
 from hera.workflows.protocol import Templatable, TTemplate, TWorkflow, VolumeClaimable
 from hera.workflows.service import WorkflowsService
+from hera.workflows.template_set import TemplateSet
 from hera.workflows.workflow_status import WorkflowStatus
 
 ImagePullSecretsT = Optional[Union[LocalObjectReference, List[LocalObjectReference], str, List[str]]]

--- a/src/hera/workflows/workflow_template.py
+++ b/src/hera/workflows/workflow_template.py
@@ -4,13 +4,14 @@ See https://argoproj.github.io/argo-workflows/workflow-templates/
 for more on WorkflowTemplates.
 """
 
+import sys
 from pathlib import Path
 from typing import Dict, Optional, Type, Union, cast
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.exceptions import NotFound
 from hera.shared._pydantic import BaseModel, validator

--- a/tests/script_annotations/duplicate_input_names.py
+++ b/tests/script_annotations/duplicate_input_names.py
@@ -1,10 +1,12 @@
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 from hera.shared import global_config
 from hera.workflows import Parameter, Workflow, script
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_annotations/outputs.py
+++ b/tests/script_annotations/outputs.py
@@ -1,12 +1,13 @@
 """Test the correctness of the Output annotations. The test inspects the inputs and outputs of the workflow."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+import sys
 from pathlib import Path
 from typing import Tuple
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Artifact, Parameter, RunnerScriptConstructor, Workflow, script

--- a/tests/script_annotations/pydantic_duplicate_input_artifact_names.py
+++ b/tests/script_annotations/pydantic_duplicate_input_artifact_names.py
@@ -1,11 +1,13 @@
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Workflow, script
 from hera.workflows.io.v1 import Input
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_annotations/pydantic_io_invalid_multiple_inputs.py
+++ b/tests/script_annotations/pydantic_io_invalid_multiple_inputs.py
@@ -1,11 +1,13 @@
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 from hera.shared import global_config
 from hera.workflows import Parameter, Workflow, script
 from hera.workflows.io.v1 import Input
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_annotations/pydantic_io_invalid_outputs.py
+++ b/tests/script_annotations/pydantic_io_invalid_outputs.py
@@ -1,14 +1,15 @@
+import sys
 from pathlib import Path
 from typing import Tuple
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Parameter, Workflow, script
 from hera.workflows.io.v1 import Output
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_annotations/pydantic_io_v1.py
+++ b/tests/script_annotations/pydantic_io_v1.py
@@ -1,13 +1,14 @@
+import sys
 from pathlib import Path
 from typing import List
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Workflow, script
 from hera.workflows.io.v1 import Input, Output
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 class ParamOnlyInput(Input):

--- a/tests/script_annotations/pydantic_io_v1_strs.py
+++ b/tests/script_annotations/pydantic_io_v1_strs.py
@@ -1,4 +1,10 @@
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.workflows import Parameter, Workflow, script
 
@@ -12,11 +18,6 @@ except ImportError:
         Input,
         Output,
     )
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 class ParamOnlyInput(Input):

--- a/tests/script_annotations/pydantic_io_v2.py
+++ b/tests/script_annotations/pydantic_io_v2.py
@@ -1,5 +1,11 @@
+import sys
 from pathlib import Path
 from typing import List
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Workflow, script
 
@@ -13,11 +19,6 @@ except ImportError:
         Input,
         Output,
     )
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 class ParamOnlyInput(Input):

--- a/tests/script_annotations/pydantic_io_v2_strs.py
+++ b/tests/script_annotations/pydantic_io_v2_strs.py
@@ -1,4 +1,10 @@
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.workflows import Parameter, Workflow, script
 
@@ -12,11 +18,6 @@ except ImportError:
         Input,
         Output,
     )
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 class ParamOnlyInput(Input):

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_artifactory_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_azure_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_gcs_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_git_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_hdfs_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_http_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_mode_recurse_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_oss_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_raw_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_s3_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_subpath_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_configmap_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_configmap_new.py
@@ -1,16 +1,18 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 from hera.workflows import (
     Parameter,
     Workflow,
     models as m,
     script,
 )
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 @script()

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_alias.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_alias.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_combined_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_description_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_description_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_parameters_enum_new.py
@@ -1,9 +1,11 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script

--- a/tests/script_runner/annotated_outputs.py
+++ b/tests/script_runner/annotated_outputs.py
@@ -1,12 +1,13 @@
 """Test the correctness of the Output annotations. The test uses the runner to check the outputs and if they save correctly to files."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from tests.helper import ARTIFACT_PATH
 

--- a/tests/script_runner/artifact_loaders.py
+++ b/tests/script_runner/artifact_loaders.py
@@ -1,9 +1,10 @@
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from pydantic import BaseModel
 from tests.helper import ARTIFACT_PATH

--- a/tests/script_runner/artifact_with_invalid_loader.py
+++ b/tests/script_runner/artifact_with_invalid_loader.py
@@ -1,10 +1,11 @@
 """This file causes a pydantic validation error when imported, so must be tested separately."""
 
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from tests.helper import ARTIFACT_PATH
 

--- a/tests/script_runner/pydantic_io_v1.py
+++ b/tests/script_runner/pydantic_io_v1.py
@@ -1,5 +1,11 @@
+import sys
 from pathlib import Path
 from typing import List
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from tests.helper import ARTIFACT_PATH
 
@@ -11,11 +17,6 @@ try:
     from pydantic.v1 import BaseModel
 except ImportError:
     from pydantic import BaseModel
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_runner/pydantic_io_v2.py
+++ b/tests/script_runner/pydantic_io_v2.py
@@ -1,5 +1,11 @@
+import sys
 from pathlib import Path
 from typing import List
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from pydantic import BaseModel
 from tests.helper import ARTIFACT_PATH
@@ -11,11 +17,6 @@ try:
     from hera.workflows.io.v2 import Input, Output
 except ImportError:
     from hera.workflows.io.v1 import Input, Output
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 global_config.experimental_features["script_annotations"] = True
 global_config.experimental_features["script_pydantic_io"] = True

--- a/tests/script_runner/unknown_annotation_types.py
+++ b/tests/script_runner/unknown_annotation_types.py
@@ -1,8 +1,9 @@
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
+import sys
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import script

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -1,20 +1,21 @@
 """Test script annotations are built correctly within workflows."""
 
 import importlib
+import sys
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 import pytest
-
-from .test_examples import _compare_workflows
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.workflows import Workflow, script
 from hera.workflows.parameter import Parameter
 from hera.workflows.steps import Steps
+
+from .test_examples import _compare_workflows
 
 
 @pytest.mark.parametrize("module_name", ["combined", "description", "enum"])

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -1,13 +1,13 @@
+import sys
+from pathlib import Path
 from typing import Optional, Union
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
 import pytest
-
-try:
-    from typing import Annotated  # type: ignore
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
-
-from pathlib import Path
 
 from hera.workflows import Workflow, script
 from hera.workflows.artifact import Artifact


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, conditional imports that depend on Python version are using `try/except ImportError` to import from `typing_extensions` on older Python versions. This is not natively supported by typecheckers, forcing use of error suppression, and losing potential validation of downstream code. (Additionally, pyright is erroneously flagging a lot of code that uses `Annotated` with "Call expression not allowed in type expression, making it harder to spot real issues in VSCode.)

This PR refactors these conditional imports to use the recommended `if sys.version_info >= (3, minor):` pattern instead.

See also: [mypy issue comment](https://github.com/python/mypy/issues/1393#issuecomment-1694796858), [pyright issue comment](https://github.com/microsoft/pyright/discussions/4160#discussioncomment-4082791)
