### PR TITLE
Fix new container decorator example

### DIFF
--- a/docs/examples/workflows/experimental/new_container_decorator.md
+++ b/docs/examples/workflows/experimental/new_container_decorator.md
@@ -36,7 +36,11 @@
 
 
     @w.set_entrypoint
-    @w.container(command=["sh", "-c"], args=["echo Hello {{inputs.parameters.user}} | tee /tmp/hello_world.txt"])
+    @w.container(
+        image="busybox",
+        command=["sh", "-c"],
+        args=["echo Hello {{inputs.parameters.user}} | tee /tmp/hello_world.txt"],
+    )
     def basic_hello_world(my_input: MyInput) -> MyOutput: ...
     ```
 
@@ -56,7 +60,7 @@
           command:
           - sh
           - -c
-          image: python:3.8
+          image: busybox
         inputs:
           parameters:
           - default: Hera

--- a/docs/examples/workflows/misc/init_containers_with_env.md
+++ b/docs/examples/workflows/misc/init_containers_with_env.md
@@ -48,18 +48,21 @@ This example showcases how to run a init_containers with env
           - cowsay
           - foo
           image: docker/whalesay
-        name: cowsay
         initContainers:
-        - name: init
-          image: busybox
-          command: [ "sh", "-c", "echo Hello from the init container ($FOO, $SECRET)" ]
+        - command:
+          - sh
+          - -c
+          - echo Hello from the init container ($FOO, $SECRET)
           env:
           - name: FOO
-            value: "bar"
+            value: bar
           - name: SECRET
             valueFrom:
               secretKeyRef:
-                name: my-secret
                 key: password
+                name: my-secret
+          image: busybox
+          name: init
+        name: cowsay
     ```
 

--- a/examples/workflows/experimental/new-container-decorator.yaml
+++ b/examples/workflows/experimental/new-container-decorator.yaml
@@ -11,7 +11,7 @@ spec:
       command:
       - sh
       - -c
-      image: python:3.8
+      image: busybox
     inputs:
       parameters:
       - default: Hera

--- a/examples/workflows/experimental/new_container_decorator.py
+++ b/examples/workflows/experimental/new_container_decorator.py
@@ -26,5 +26,9 @@ class MyOutput(Output):
 
 
 @w.set_entrypoint
-@w.container(command=["sh", "-c"], args=["echo Hello {{inputs.parameters.user}} | tee /tmp/hello_world.txt"])
+@w.container(
+    image="busybox",
+    command=["sh", "-c"],
+    args=["echo Hello {{inputs.parameters.user}} | tee /tmp/hello_world.txt"],
+)
 def basic_hello_world(my_input: MyInput) -> MyOutput: ...

--- a/examples/workflows/misc/init-containers-with-env.yaml
+++ b/examples/workflows/misc/init-containers-with-env.yaml
@@ -10,16 +10,19 @@ spec:
       - cowsay
       - foo
       image: docker/whalesay
-    name: cowsay
     initContainers:
-    - name: init
-      image: busybox
-      command: [ "sh", "-c", "echo Hello from the init container ($FOO, $SECRET)" ]
+    - command:
+      - sh
+      - -c
+      - echo Hello from the init container ($FOO, $SECRET)
       env:
       - name: FOO
-        value: "bar"
+        value: bar
       - name: SECRET
         valueFrom:
           secretKeyRef:
-            name: my-secret
             key: password
+            name: my-secret
+      image: busybox
+      name: init
+    name: cowsay

--- a/examples/workflows/upstream/work-avoidance.upstream.yaml
+++ b/examples/workflows/upstream/work-avoidance.upstream.yaml
@@ -65,7 +65,7 @@ spec:
       script:
         image: busybox
         command:
-          - bash
+          - sh
           - -eux
         source: |
           marker=/work/markers/$(date +%Y-%m-%d)-echo-{{inputs.parameters.num}}


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes erroneous example
- [ ] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
New container decorator example was using a `python` image as the `image` wasn't set in the decorator kwargs (and instead used the default `global_config.image` in the `ContainerMixin` validator). Also ran `make regenerate-test-data` to fix examples.