### PR TITLE
Add docstrings for ArtifactLoader values

### DIFF
--- a/src/hera/workflows/artifact.py
+++ b/src/hera/workflows/artifact.py
@@ -39,7 +39,10 @@ class ArtifactLoader(Enum):
     """Enum for artifact loader options."""
 
     json = "json"
+    """Deserialize the JSON-string Artifact file to a Python object (the target variable can be any JSON-compatible type)."""
+
     file = "file"
+    """Read the contents of the Artifact file directly as a string (the target variable must be a `str` type)."""
 
 
 class Artifact(BaseModel):


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes doc string for ArtifactLoaders
- [ ] ~Tests added~
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
When trying to use `ArtifactLoaders` I found it hard to remember what `json` and `file` actually do, and what type the variable type should be. This PR adds docstrings which help when you're writing the annotation.

![Intellisense docs hint](https://github.com/user-attachments/assets/280666e0-1528-444c-84c6-efd1ff9a109e)
