### PR TITLE
Add optional Session to Service to be able to reuse connections

### DIFF
--- a/scripts/service.py
+++ b/scripts/service.py
@@ -468,7 +468,7 @@ class {models_type}Service:
         
     def __exit__(self, *_):
         \"\"\"Close the service.\"\"\"
-        self.session.close()
+        self.close()
 """
 
 

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -176,7 +176,8 @@ class ServiceEndpoint:
         return f"""
     {signature}
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.{self.method}(
+        resp = self.request(
+            method="{self.method}",
             url={req_url},
             params={params},
             headers={headers},
@@ -422,6 +423,7 @@ class {models_type}Service:
         token: Optional[str] = None,
         client_certs: Optional[Tuple[str, str]] = None,
         namespace: Optional[str] = None,
+        use_session: Optional[bool] = None,
     ) -> None:
         \"\"\"{models_type} service constructor.\"\"\"
         self.host = cast(str, host or global_config.host)
@@ -448,7 +450,20 @@ class {models_type}Service:
         else:
             self.token = None
 
+        use_session = use_session if use_session is not None else global_config.use_session
+        if use_session:
+            self.session: Optional[requests.Session] = requests.Session()
+        else: 
+            self.session = None
+
         self.namespace = namespace or global_config.namespace
+        
+    def request(self, method, **kwargs):
+        \"\"\"Make a request using the session if enabled.\"\"\"
+        if self.session is None:
+            return requests.request(method, **kwargs)
+        else:
+            return self.session.request(method, **kwargs)
 """
 
 

--- a/src/hera/events/service.py
+++ b/src/hera/events/service.py
@@ -47,6 +47,7 @@ class EventsService:
         token: Optional[str] = None,
         client_certs: Optional[Tuple[str, str]] = None,
         namespace: Optional[str] = None,
+        use_session: Optional[bool] = None,
     ) -> None:
         """Events service constructor."""
         self.host = cast(str, host or global_config.host)
@@ -73,7 +74,20 @@ class EventsService:
         else:
             self.token = None
 
+        use_session = use_session if use_session is not None else global_config.use_session
+        if use_session:
+            self.session: Optional[requests.Session] = requests.Session()
+        else:
+            self.session = None
+
         self.namespace = namespace or global_config.namespace
+
+    def request(self, method, **kwargs):
+        """Make a request using the session if enabled."""
+        if self.session is None:
+            return requests.request(method, **kwargs)
+        else:
+            return self.session.request(method, **kwargs)
 
     def list_event_sources(
         self,
@@ -90,7 +104,8 @@ class EventsService:
     ) -> EventSourceList:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/event-sources/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -119,7 +134,8 @@ class EventsService:
     def create_event_source(self, req: CreateEventSourceRequest, namespace: Optional[str] = None) -> EventSource:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.post(
+        resp = self.request(
+            method="post",
             url=urljoin(self.host, "api/v1/event-sources/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -140,7 +156,8 @@ class EventsService:
     def get_event_source(self, name: str, namespace: Optional[str] = None) -> EventSource:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/event-sources/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -161,7 +178,8 @@ class EventsService:
     ) -> EventSource:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.put(
+        resp = self.request(
+            method="put",
             url=urljoin(self.host, "api/v1/event-sources/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -192,7 +210,8 @@ class EventsService:
     ) -> EventSourceDeletedResponse:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.delete(
+        resp = self.request(
+            method="delete",
             url=urljoin(self.host, "api/v1/event-sources/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -218,7 +237,8 @@ class EventsService:
     def receive_event(self, discriminator: str, req: Item, namespace: Optional[str] = None) -> EventResponse:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.post(
+        resp = self.request(
+            method="post",
             url=urljoin(self.host, "api/v1/events/{namespace}/{discriminator}").format(
                 discriminator=discriminator, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -239,7 +259,8 @@ class EventsService:
     def get_info(self) -> InfoResponse:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/info"),
             params=None,
             headers={"Authorization": self.token},
@@ -268,7 +289,8 @@ class EventsService:
     ) -> SensorList:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/sensors/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -297,7 +319,8 @@ class EventsService:
     def create_sensor(self, req: CreateSensorRequest, namespace: Optional[str] = None) -> Sensor:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.post(
+        resp = self.request(
+            method="post",
             url=urljoin(self.host, "api/v1/sensors/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -318,7 +341,8 @@ class EventsService:
     def get_sensor(self, name: str, namespace: Optional[str] = None, resource_version: Optional[str] = None) -> Sensor:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/sensors/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -337,7 +361,8 @@ class EventsService:
     def update_sensor(self, name: str, req: UpdateSensorRequest, namespace: Optional[str] = None) -> Sensor:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.put(
+        resp = self.request(
+            method="put",
             url=urljoin(self.host, "api/v1/sensors/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -368,7 +393,8 @@ class EventsService:
     ) -> DeleteSensorResponse:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.delete(
+        resp = self.request(
+            method="delete",
             url=urljoin(self.host, "api/v1/sensors/{namespace}/{name}").format(
                 name=name, namespace=namespace if namespace is not None else self.namespace
             ),
@@ -406,7 +432,8 @@ class EventsService:
     ) -> EventSourceWatchEvent:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/stream/event-sources/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -452,7 +479,8 @@ class EventsService:
     ) -> EventsourceLogEntry:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/stream/event-sources/{namespace}/logs").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -498,7 +526,8 @@ class EventsService:
     ) -> Event:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/stream/events/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -539,7 +568,8 @@ class EventsService:
     ) -> SensorWatchEvent:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/stream/sensors/{namespace}").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -584,7 +614,8 @@ class EventsService:
     ) -> SensorLogEntry:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/stream/sensors/{namespace}/logs").format(
                 namespace=namespace if namespace is not None else self.namespace
             ),
@@ -617,7 +648,8 @@ class EventsService:
     def get_user_info(self) -> GetUserInfoResponse:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/userinfo"),
             params=None,
             headers={"Authorization": self.token},
@@ -634,7 +666,8 @@ class EventsService:
     def get_version(self) -> Version:
         """API documentation."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "api/v1/version"),
             params=None,
             headers={"Authorization": self.token},
@@ -659,7 +692,8 @@ class EventsService:
     ) -> str:
         """Get an artifact."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(
                 self.host,
                 "artifact-files/{namespace}/{idDiscriminator}/{id}/{nodeId}/{artifactDiscriminator}/{artifactName}",
@@ -686,7 +720,8 @@ class EventsService:
     def get_output_artifact_by_uid(self, uid: str, node_id: str, artifact_name: str) -> str:
         """Get an output artifact by UID."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "artifacts-by-uid/{uid}/{nodeId}/{artifactName}").format(
                 uid=uid, nodeId=node_id, artifactName=artifact_name
             ),
@@ -705,7 +740,8 @@ class EventsService:
     def get_output_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an output artifact."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
                 name=name,
                 nodeId=node_id,
@@ -727,7 +763,8 @@ class EventsService:
     def get_input_artifact_by_uid(self, uid: str, node_id: str, artifact_name: str) -> str:
         """Get an input artifact by UID."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "input-artifacts-by-uid/{uid}/{nodeId}/{artifactName}").format(
                 uid=uid, nodeId=node_id, artifactName=artifact_name
             ),
@@ -746,7 +783,8 @@ class EventsService:
     def get_input_artifact(self, name: str, node_id: str, artifact_name: str, namespace: Optional[str] = None) -> str:
         """Get an input artifact."""
         assert valid_host_scheme(self.host), "The host scheme is required for service usage"
-        resp = requests.get(
+        resp = self.request(
+            method="get",
             url=urljoin(self.host, "input-artifacts/{namespace}/{name}/{nodeId}/{artifactName}").format(
                 name=name,
                 nodeId=node_id,

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -62,6 +62,9 @@ class _GlobalConfig:
     verify_ssl: bool = True
     """whether to perform SSL verification on the path towards communicating with the Argo server"""
 
+    use_session: bool = False
+    """whether to use a session for communicating with the Argo server and reuse connections"""
+
     api_version: str = "argoproj.io/v1alpha1"
     """the Argo API verison to use on models"""
 

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -62,9 +62,6 @@ class _GlobalConfig:
     verify_ssl: bool = True
     """whether to perform SSL verification on the path towards communicating with the Argo server"""
 
-    use_session: bool = False
-    """whether to use a session for communicating with the Argo server and reuse connections"""
-
     api_version: str = "argoproj.io/v1alpha1"
     """the Argo API verison to use on models"""
 

--- a/src/hera/workflows/service.py
+++ b/src/hera/workflows/service.py
@@ -115,7 +115,7 @@ class WorkflowsService:
 
     def __exit__(self, *_):
         """Close the service."""
-        self.session.close()
+        self.close()
 
     def list_archived_workflows(
         self,


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

The WorkflowService uses direct calls to requests library, which under the hood creates a Session, makes the request, then closes the session.

This means that the TCP connection is opened and closed for each call instead of being reused - which causes unnecessary overhead if the service is making multiple calls.

This PR adds the possibility to use a Session object in the Service, by default not enabled to keep the current behavior as-is.

From a performance point of view, if Argo is running locally the advantage will be virtually non-existent ; however, we can simulate the outcome with a remote Argo server  using [toxiproxy](https://github.com/Shopify/toxiproxy/):


```bash
toxiproxy-cli create --listen localhost:2747 --upstream localhost:2746 argo 
toxiproxy-cli toxic add -t latency -a latency=20 -a jitter=5 argo  
```

Using ipython and the magic command %timeit:
```
from hera.workflows import WorkflowsService

# default current behavior: no session
ws = WorkflowsService("https://localhost:2747", verify_ssl=False)

%timeit -n10 -r10 ws.list_workflows("argo")
133 ms ± 2.17 ms per loop (mean ± std. dev. of 10 runs, 10 loops each)

ws = WorkflowsService("https://localhost:2747", verify_ssl=False, use_session=True)
%timeit -n10 -r10 ws.list_workflows("argo")
77.4 ms ± 2.01 ms per loop (mean ± std. dev. of 10 runs, 10 loops each)
```

In toxiproxy logs (and the kubectl port-forward logs) , we can see that the tcp open is done now only once.


Thanks!

