### PR TITLE
Support various output tuple annotation

### DIFF
--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -92,6 +92,8 @@ def origin_type_issubclass(cls: Any, type_: type) -> bool:
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
         return any(origin_type_issubclass(arg, type_) for arg in get_args(cls))
+    if not isinstance(origin_type, type):
+        return False
     return issubclass(origin_type, type_)
 
 

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -92,8 +92,6 @@ def origin_type_issubclass(cls: Any, type_: type) -> bool:
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
         return any(origin_type_issubclass(arg, type_) for arg in get_args(cls))
-    if not isinstance(origin_type, type):
-        return False
     return issubclass(origin_type, type_)
 
 

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -555,11 +555,15 @@ def _extract_return_annotation_output(source: Callable) -> List:
     if get_workflow_annotation(return_annotation):
         output.append(annotation_args)
     elif origin_type is tuple:
-        workflow_args = [get_args(annotated_type) for annotated_type in annotation_args if get_workflow_annotation(annotated_type)]
+        workflow_args = [
+            get_args(annotated_type) for annotated_type in annotation_args if get_workflow_annotation(annotated_type)
+        ]
         if len(workflow_args) == len(annotation_args):
             output.extend(workflow_args)
         elif workflow_args:
-            raise ValueError("All elements in the tuple should be annotated with Artifact/Parameter.")
+            raise ValueError(
+                f"Function '{source.__name__}' output has partially annotated return type. Hera allows tuple annotation to be fully annotated or not."
+            )
     elif (
         origin_type is None
         and isinstance(return_annotation, type)

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -555,10 +555,10 @@ def _extract_return_annotation_output(source: Callable) -> List:
     if get_workflow_annotation(return_annotation):
         output.append(annotation_args)
     elif origin_type is tuple:
-        if all(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
-            for annotated_type in annotation_args:
-                output.append(get_args(annotated_type))
-        elif any(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
+        workflow_args = [get_args(annotated_type) for annotated_type in annotation_args if get_workflow_annotation(annotated_type)]
+        if len(workflow_args) == len(annotation_args):
+            output.extend(workflow_args)
+        elif workflow_args:
             raise ValueError("All elements in the tuple should be annotated with Artifact/Parameter.")
     elif (
         origin_type is None

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -558,11 +558,12 @@ def _extract_return_annotation_output(source: Callable) -> List:
         workflow_args = [
             get_args(annotated_type) for annotated_type in annotation_args if get_workflow_annotation(annotated_type)
         ]
+        # If all tuple elements are annotated as Parameter/Artifact
         if len(workflow_args) == len(annotation_args):
             output.extend(workflow_args)
-        elif workflow_args:
+        elif workflow_args:  # Only some tuple elements are annotated as Parameter/Artifact
             raise ValueError(
-                f"Function '{source.__name__}' output has partially annotated return type. Hera allows tuple annotation to be fully annotated or not."
+                f"Function '{source.__name__}' output has partially annotated tuple return type. Tuple elements must be all Annotated as Parameter/Artifact, or contain no Parameter/Artifact annotations for a raw tuple return type."
             )
     elif (
         origin_type is None

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -555,8 +555,11 @@ def _extract_return_annotation_output(source: Callable) -> List:
     if get_workflow_annotation(return_annotation):
         output.append(annotation_args)
     elif origin_type is tuple:
-        for annotated_type in annotation_args:
-            output.append(get_args(annotated_type))
+        if all(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
+            for annotated_type in annotation_args:
+                output.append(get_args(annotated_type))
+        elif any(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
+            raise ValueError("All elements in the tuple should be annotated with Artifact/Parameter.")
     elif (
         origin_type is None
         and isinstance(return_annotation, type)

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -552,8 +552,8 @@ def _extract_return_annotation_output(source: Callable) -> List:
     return_annotation = inspect.signature(source).return_annotation
     origin_type = get_origin(return_annotation)
     annotation_args = get_args(return_annotation)
-    if param_or_artifact := get_workflow_annotation(return_annotation):
-        output.append(param_or_artifact)
+    if get_workflow_annotation(return_annotation):
+        output.append(annotation_args)
     elif origin_type is tuple:
         if all(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
             for annotated_type in annotation_args:

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -558,12 +558,15 @@ def _extract_return_annotation_output(source: Callable) -> List:
         workflow_args = [
             get_args(annotated_type) for annotated_type in annotation_args if get_workflow_annotation(annotated_type)
         ]
+
         # If all tuple elements are annotated as Parameter/Artifact
         if len(workflow_args) == len(annotation_args):
             output.extend(workflow_args)
-        elif workflow_args:  # Only some tuple elements are annotated as Parameter/Artifact
+        # Only some tuple elements are annotated as Parameter/Artifact
+        elif workflow_args:
             raise ValueError(
-                f"Function '{source.__name__}' output has partially annotated tuple return type. Tuple elements must be all Annotated as Parameter/Artifact, or contain no Parameter/Artifact annotations for a raw tuple return type."
+                f"Function '{source.__name__}' output has partially annotated tuple return type. "
+                "Tuple elements must be all Annotated as Parameter/Artifact, or contain no Parameter/Artifact annotations for a raw tuple return type."
             )
     elif (
         origin_type is None

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -552,8 +552,8 @@ def _extract_return_annotation_output(source: Callable) -> List:
     return_annotation = inspect.signature(source).return_annotation
     origin_type = get_origin(return_annotation)
     annotation_args = get_args(return_annotation)
-    if get_workflow_annotation(return_annotation):
-        output.append(annotation_args)
+    if param_or_artifact := get_workflow_annotation(return_annotation):
+        output.append(param_or_artifact)
     elif origin_type is tuple:
         if all(get_workflow_annotation(annotated_type) for annotated_type in annotation_args):
             for annotated_type in annotation_args:

--- a/tests/script_runner/parameter_with_complex_types.py
+++ b/tests/script_runner/parameter_with_complex_types.py
@@ -1,8 +1,8 @@
 import sys
-from typing import Optional, Union
+from typing import Annotated, Optional, Tuple, Union
 
 from hera.shared import global_config
-from hera.workflows import script
+from hera.workflows import Parameter, script
 
 global_config.experimental_features["script_annotations"] = True
 
@@ -36,3 +36,13 @@ def optional_int_parameter(my_int: Optional[int] = None) -> Optional[int]:
 @script(constructor="runner")
 def union_parameter(my_param: Union[str, int] = None) -> Union[str, int]:
     return my_param
+
+
+@script(constructor="runner")
+def fn_with_output_tuple(my_string: str) -> Tuple[str, str]:
+    return my_string, my_string
+
+
+@script(constructor="runner")
+def fn_with_output_tuple_partially_annotated(my_string: str) -> Tuple[str, Annotated[str, Parameter(name="sample")]]:
+    return my_string, my_string

--- a/tests/script_runner/parameter_with_complex_types.py
+++ b/tests/script_runner/parameter_with_complex_types.py
@@ -1,5 +1,10 @@
 import sys
-from typing import Annotated, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from hera.shared import global_config
 from hera.workflows import Parameter, script

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1125,5 +1125,11 @@ def test_script_partially_annotated_tuple_should_raise_an_error(monkeypatch: pyt
     kwargs_list = [{"name": "my_string", "value": "123"}]
 
     # WHEN/THEN
-    with pytest.raises(ValueError, match="All elements in the tuple should be annotated with Artifact/Parameter."):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Function 'fn_with_output_tuple_partially_annotated' output has partially annotated return type. "
+            "Hera allows tuple annotation to be fully annotated or not."
+        ),
+    ):
         _runner(entrypoint, kwargs_list)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1128,8 +1128,8 @@ def test_script_partially_annotated_tuple_should_raise_an_error(monkeypatch: pyt
     with pytest.raises(
         ValueError,
         match=(
-            "Function 'fn_with_output_tuple_partially_annotated' output has partially annotated return type. "
-            "Hera allows tuple annotation to be fully annotated or not."
+            "Function 'fn_with_output_tuple_partially_annotated' output has partially annotated tuple return type. "
+            "Tuple elements must be all Annotated as Parameter/Artifact, or contain no Parameter/Artifact annotations for a raw tuple return type."
         ),
     ):
         _runner(entrypoint, kwargs_list)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1095,6 +1095,11 @@ def test_script_optional_parameter(
             [{"name": "my_param", "value": 123}],
             "123",
         ],
+        [
+            "tests.script_runner.parameter_with_complex_types:fn_with_output_tuple",
+            [{"name": "my_string", "value": "123"}],
+            '["123", "123"]',
+        ],
     ],
 )
 def test_script_with_complex_types(
@@ -1111,3 +1116,14 @@ def test_script_with_complex_types(
 
     # THEN
     assert serialize(output) == expected_output
+
+
+def test_script_partially_annotated_tuple_should_raise_an_error(monkeypatch: pytest.MonkeyPatch):
+    # GIVEN
+    monkeypatch.setenv("hera__script_annotations", "")
+    entrypoint = "tests.script_runner.parameter_with_complex_types:fn_with_output_tuple_partially_annotated"
+    kwargs_list = [{"name": "my_string", "value": "123"}]
+
+    # WHEN/THEN
+    with pytest.raises(ValueError, match="All elements in the tuple should be annotated with Artifact/Parameter."):
+        _runner(entrypoint, kwargs_list)


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1167 
- [x] Tests added
- [x] Documentation/examples added; bug fix
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, hera doesn't support un-annotated tuple output type, and there's no guard for partially annotated type.

So updating hera like as following.
- Support un-annotated tuple output.
- Raise the error when the output tuple is partially annotated.