### PR TITLE
Enable Pydantic I/O types in workflow context

### DIFF
--- a/docs/examples/workflows/experimental/pydantic_io_in_dag_context.md
+++ b/docs/examples/workflows/experimental/pydantic_io_in_dag_context.md
@@ -1,0 +1,154 @@
+# Pydantic Io In Dag Context
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    import sys
+    from typing import List
+
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
+
+
+    from hera.shared import global_config
+    from hera.workflows import DAG, Parameter, WorkflowTemplate, script
+    from hera.workflows.io.v1 import Input, Output
+
+    global_config.experimental_features["script_pydantic_io"] = True
+
+
+    class CutInput(Input):
+        cut_after: Annotated[int, Parameter(name="cut-after")]
+        strings: List[str]
+
+
+    class CutOutput(Output):
+        first_strings: Annotated[List[str], Parameter(name="first-strings")]
+        remainder: List[str]
+
+
+    class JoinInput(Input):
+        strings: List[str]
+        joiner: str
+
+
+    class JoinOutput(Output):
+        joined_string: Annotated[str, Parameter(name="joined-string")]
+
+
+    @script(constructor="runner")
+    def cut(input: CutInput) -> CutOutput:
+        return CutOutput(
+            first_strings=input.strings[: input.cut_after],
+            remainder=input.strings[input.cut_after :],
+            exit_code=1 if len(input.strings) <= input.cut_after else 0,
+        )
+
+
+    @script(constructor="runner")
+    def join(input: JoinInput) -> JoinOutput:
+        return JoinOutput(joined_string=input.joiner.join(input.strings))
+
+
+    with WorkflowTemplate(generate_name="pydantic-io-in-steps-context-v1-", entrypoint="d") as w:
+        with DAG(name="d"):
+            cut_result = cut(CutInput(strings=["hello", "world", "it's", "hera"], cut_after=1))
+            join(JoinInput(strings=cut_result.first_strings, joiner=" "))
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      generateName: pydantic-io-in-steps-context-v1-
+    spec:
+      entrypoint: d
+      templates:
+      - dag:
+          tasks:
+          - arguments:
+              parameters:
+              - name: cut-after
+                value: '1'
+              - name: strings
+                value: '["hello", "world", "it''s", "hera"]'
+            name: cut
+            template: cut
+          - arguments:
+              parameters:
+              - name: strings
+                value: '{{tasks.cut.outputs.parameters.first-strings}}'
+              - name: joiner
+                value: ' '
+            depends: cut
+            name: join
+            template: join
+        name: d
+      - inputs:
+          parameters:
+          - name: cut-after
+          - name: strings
+        name: cut
+        outputs:
+          parameters:
+          - name: first-strings
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/first-strings
+          - name: remainder
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/remainder
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.pydantic_io_in_dag_context:cut
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - inputs:
+          parameters:
+          - name: strings
+          - name: joiner
+        name: join
+        outputs:
+          parameters:
+          - name: joined-string
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/joined-string
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.pydantic_io_in_dag_context:join
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+    ```
+

--- a/docs/examples/workflows/experimental/pydantic_io_in_dag_context.md
+++ b/docs/examples/workflows/experimental/pydantic_io_in_dag_context.md
@@ -21,7 +21,7 @@
     from hera.workflows import DAG, Parameter, WorkflowTemplate, script
     from hera.workflows.io.v1 import Input, Output
 
-    global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
 
     class CutInput(Input):

--- a/docs/examples/workflows/experimental/pydantic_io_in_steps_context.md
+++ b/docs/examples/workflows/experimental/pydantic_io_in_steps_context.md
@@ -1,0 +1,152 @@
+# Pydantic Io In Steps Context
+
+
+
+
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    import sys
+    from typing import List
+
+    if sys.version_info >= (3, 9):
+        from typing import Annotated
+    else:
+        from typing_extensions import Annotated
+
+
+    from hera.shared import global_config
+    from hera.workflows import Parameter, Steps, WorkflowTemplate, script
+    from hera.workflows.io.v1 import Input, Output
+
+    global_config.experimental_features["script_pydantic_io"] = True
+
+
+    class CutInput(Input):
+        cut_after: Annotated[int, Parameter(name="cut-after")]
+        strings: List[str]
+
+
+    class CutOutput(Output):
+        first_strings: Annotated[List[str], Parameter(name="first-strings")]
+        remainder: List[str]
+
+
+    class JoinInput(Input):
+        strings: List[str]
+        joiner: str
+
+
+    class JoinOutput(Output):
+        joined_string: Annotated[str, Parameter(name="joined-string")]
+
+
+    @script(constructor="runner")
+    def cut(input: CutInput) -> CutOutput:
+        return CutOutput(
+            first_strings=input.strings[: input.cut_after],
+            remainder=input.strings[input.cut_after :],
+            exit_code=1 if len(input.strings) <= input.cut_after else 0,
+        )
+
+
+    @script(constructor="runner")
+    def join(input: JoinInput) -> JoinOutput:
+        return JoinOutput(joined_string=input.joiner.join(input.strings))
+
+
+    with WorkflowTemplate(generate_name="pydantic-io-in-steps-context-v1-", entrypoint="d") as w:
+        with Steps(name="d"):
+            cut_result = cut(CutInput(strings=["hello", "world", "it's", "hera"], cut_after=1))
+            join(JoinInput(strings=cut_result.first_strings, joiner=" "))
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      generateName: pydantic-io-in-steps-context-v1-
+    spec:
+      entrypoint: d
+      templates:
+      - name: d
+        steps:
+        - - arguments:
+              parameters:
+              - name: cut-after
+                value: '1'
+              - name: strings
+                value: '["hello", "world", "it''s", "hera"]'
+            name: cut
+            template: cut
+        - - arguments:
+              parameters:
+              - name: strings
+                value: '{{steps.cut.outputs.parameters.first-strings}}'
+              - name: joiner
+                value: ' '
+            name: join
+            template: join
+      - inputs:
+          parameters:
+          - name: cut-after
+          - name: strings
+        name: cut
+        outputs:
+          parameters:
+          - name: first-strings
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/first-strings
+          - name: remainder
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/remainder
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.pydantic_io_in_steps_context:cut
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+      - inputs:
+          parameters:
+          - name: strings
+          - name: joiner
+        name: join
+        outputs:
+          parameters:
+          - name: joined-string
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/joined-string
+        script:
+          args:
+          - -m
+          - hera.workflows.runner
+          - -e
+          - examples.workflows.experimental.pydantic_io_in_steps_context:join
+          command:
+          - python
+          env:
+          - name: hera__script_annotations
+            value: ''
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
+          - name: hera__script_pydantic_io
+            value: ''
+          image: python:3.8
+          source: '{{inputs.parameters}}'
+    ```
+

--- a/docs/examples/workflows/experimental/pydantic_io_in_steps_context.md
+++ b/docs/examples/workflows/experimental/pydantic_io_in_steps_context.md
@@ -21,7 +21,7 @@
     from hera.workflows import Parameter, Steps, WorkflowTemplate, script
     from hera.workflows.io.v1 import Input, Output
 
-    global_config.experimental_features["script_pydantic_io"] = True
+    global_config.experimental_features["decorator_syntax"] = True
 
 
     class CutInput(Input):

--- a/examples/workflows/experimental/incremental-workflow-migration.yaml
+++ b/examples/workflows/experimental/incremental-workflow-migration.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: my-template
+spec:
+  templates:
+  - name: steps
+    steps:
+    - - name: double
+        template: double
+    - - arguments:
+          parameters:
+          - name: value
+            value: '{{steps.double.outputs.parameters.value}}'
+        name: print-value
+        template: print-value
+  - inputs:
+      parameters:
+      - name: value
+    name: double
+    outputs:
+      parameters:
+      - name: value
+    script:
+      command:
+      - python
+      image: python:3.9
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import json
+        try: value = json.loads(r'''{{inputs.parameters.value}}''')
+        except: value = r'''{{inputs.parameters.value}}'''
+
+        return MyOutput(value=input.value * 2)
+  - inputs:
+      parameters:
+      - name: value
+    name: print-value
+    script:
+      command:
+      - python
+      image: python:3.9
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import json
+        try: value = json.loads(r'''{{inputs.parameters.value}}''')
+        except: value = r'''{{inputs.parameters.value}}'''
+
+        print('Value was', value)

--- a/examples/workflows/experimental/incremental_workflow_migration.py
+++ b/examples/workflows/experimental/incremental_workflow_migration.py
@@ -1,0 +1,33 @@
+from hera.shared import global_config
+from hera.workflows import Input, Output, Steps, Workflow, script
+
+global_config.experimental_features["context_manager_pydantic_io"] = True
+
+
+class MyInput(Input):
+    value: int
+
+
+class MyOutput(Output):
+    value: int
+
+
+# Function migrated to Pydantic I/O
+@script()
+def double(input: MyInput) -> MyOutput:
+    return MyOutput(value=input.value * 2)
+
+
+# Not yet migrated to Pydantic I/O
+@script()
+def print_value(value: int) -> None:
+    print("Value was", value)
+
+
+# Not yet migrated to decorator syntax
+with Workflow(name="my-template") as w:
+    with Steps(name="steps"):
+        # Can now pass Pydantic types to/from functions
+        first_step = double(Input(value=5))
+        # Results can be passed into non-migrated functions
+        print_value(arguments={"value": first_step.value})

--- a/examples/workflows/experimental/pydantic-io-in-dag-context.yaml
+++ b/examples/workflows/experimental/pydantic-io-in-dag-context.yaml
@@ -53,7 +53,7 @@ spec:
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
         value: ''
-      image: python:3.8
+      image: python:3.9
       source: '{{inputs.parameters}}'
   - inputs:
       parameters:
@@ -80,5 +80,5 @@ spec:
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
         value: ''
-      image: python:3.8
+      image: python:3.9
       source: '{{inputs.parameters}}'

--- a/examples/workflows/experimental/pydantic-io-in-dag-context.yaml
+++ b/examples/workflows/experimental/pydantic-io-in-dag-context.yaml
@@ -1,0 +1,84 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  generateName: pydantic-io-in-steps-context-v1-
+spec:
+  entrypoint: d
+  templates:
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: cut-after
+            value: '1'
+          - name: strings
+            value: '["hello", "world", "it''s", "hera"]'
+        name: cut
+        template: cut
+      - arguments:
+          parameters:
+          - name: strings
+            value: '{{tasks.cut.outputs.parameters.first-strings}}'
+          - name: joiner
+            value: ' '
+        depends: cut
+        name: join
+        template: join
+    name: d
+  - inputs:
+      parameters:
+      - name: cut-after
+      - name: strings
+    name: cut
+    outputs:
+      parameters:
+      - name: first-strings
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/first-strings
+      - name: remainder
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/remainder
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.pydantic_io_in_dag_context:cut
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - inputs:
+      parameters:
+      - name: strings
+      - name: joiner
+    name: join
+    outputs:
+      parameters:
+      - name: joined-string
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/joined-string
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.pydantic_io_in_dag_context:join
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'

--- a/examples/workflows/experimental/pydantic-io-in-steps-context.yaml
+++ b/examples/workflows/experimental/pydantic-io-in-steps-context.yaml
@@ -1,0 +1,82 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  generateName: pydantic-io-in-steps-context-v1-
+spec:
+  entrypoint: d
+  templates:
+  - name: d
+    steps:
+    - - arguments:
+          parameters:
+          - name: cut-after
+            value: '1'
+          - name: strings
+            value: '["hello", "world", "it''s", "hera"]'
+        name: cut
+        template: cut
+    - - arguments:
+          parameters:
+          - name: strings
+            value: '{{steps.cut.outputs.parameters.first-strings}}'
+          - name: joiner
+            value: ' '
+        name: join
+        template: join
+  - inputs:
+      parameters:
+      - name: cut-after
+      - name: strings
+    name: cut
+    outputs:
+      parameters:
+      - name: first-strings
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/first-strings
+      - name: remainder
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/remainder
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.pydantic_io_in_steps_context:cut
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'
+  - inputs:
+      parameters:
+      - name: strings
+      - name: joiner
+    name: join
+    outputs:
+      parameters:
+      - name: joined-string
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/joined-string
+    script:
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - examples.workflows.experimental.pydantic_io_in_steps_context:join
+      command:
+      - python
+      env:
+      - name: hera__script_annotations
+        value: ''
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
+      - name: hera__script_pydantic_io
+        value: ''
+      image: python:3.8
+      source: '{{inputs.parameters}}'

--- a/examples/workflows/experimental/pydantic-io-in-steps-context.yaml
+++ b/examples/workflows/experimental/pydantic-io-in-steps-context.yaml
@@ -51,7 +51,7 @@ spec:
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
         value: ''
-      image: python:3.8
+      image: python:3.9
       source: '{{inputs.parameters}}'
   - inputs:
       parameters:
@@ -78,5 +78,5 @@ spec:
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
         value: ''
-      image: python:3.8
+      image: python:3.9
       source: '{{inputs.parameters}}'

--- a/examples/workflows/experimental/pydantic_io_in_dag_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_dag_context.py
@@ -11,7 +11,7 @@ from hera.shared import global_config
 from hera.workflows import DAG, Parameter, WorkflowTemplate, script
 from hera.workflows.io.v1 import Input, Output
 
-global_config.experimental_features["decorator_syntax"] = True
+global_config.experimental_features["context_manager_pydantic_io"] = True
 
 
 class CutInput(Input):

--- a/examples/workflows/experimental/pydantic_io_in_dag_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_dag_context.py
@@ -1,0 +1,53 @@
+import sys
+from typing import List
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
+
+from hera.shared import global_config
+from hera.workflows import DAG, Parameter, WorkflowTemplate, script
+from hera.workflows.io.v1 import Input, Output
+
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+class CutInput(Input):
+    cut_after: Annotated[int, Parameter(name="cut-after")]
+    strings: List[str]
+
+
+class CutOutput(Output):
+    first_strings: Annotated[List[str], Parameter(name="first-strings")]
+    remainder: List[str]
+
+
+class JoinInput(Input):
+    strings: List[str]
+    joiner: str
+
+
+class JoinOutput(Output):
+    joined_string: Annotated[str, Parameter(name="joined-string")]
+
+
+@script(constructor="runner")
+def cut(input: CutInput) -> CutOutput:
+    return CutOutput(
+        first_strings=input.strings[: input.cut_after],
+        remainder=input.strings[input.cut_after :],
+        exit_code=1 if len(input.strings) <= input.cut_after else 0,
+    )
+
+
+@script(constructor="runner")
+def join(input: JoinInput) -> JoinOutput:
+    return JoinOutput(joined_string=input.joiner.join(input.strings))
+
+
+with WorkflowTemplate(generate_name="pydantic-io-in-steps-context-v1-", entrypoint="d") as w:
+    with DAG(name="d"):
+        cut_result = cut(CutInput(strings=["hello", "world", "it's", "hera"], cut_after=1))
+        join(JoinInput(strings=cut_result.first_strings, joiner=" "))

--- a/examples/workflows/experimental/pydantic_io_in_dag_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_dag_context.py
@@ -11,7 +11,7 @@ from hera.shared import global_config
 from hera.workflows import DAG, Parameter, WorkflowTemplate, script
 from hera.workflows.io.v1 import Input, Output
 
-global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 class CutInput(Input):

--- a/examples/workflows/experimental/pydantic_io_in_steps_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_steps_context.py
@@ -11,7 +11,7 @@ from hera.shared import global_config
 from hera.workflows import Parameter, Steps, WorkflowTemplate, script
 from hera.workflows.io.v1 import Input, Output
 
-global_config.experimental_features["script_pydantic_io"] = True
+global_config.experimental_features["decorator_syntax"] = True
 
 
 class CutInput(Input):

--- a/examples/workflows/experimental/pydantic_io_in_steps_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_steps_context.py
@@ -1,0 +1,53 @@
+import sys
+from typing import List
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+
+
+from hera.shared import global_config
+from hera.workflows import Parameter, Steps, WorkflowTemplate, script
+from hera.workflows.io.v1 import Input, Output
+
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+class CutInput(Input):
+    cut_after: Annotated[int, Parameter(name="cut-after")]
+    strings: List[str]
+
+
+class CutOutput(Output):
+    first_strings: Annotated[List[str], Parameter(name="first-strings")]
+    remainder: List[str]
+
+
+class JoinInput(Input):
+    strings: List[str]
+    joiner: str
+
+
+class JoinOutput(Output):
+    joined_string: Annotated[str, Parameter(name="joined-string")]
+
+
+@script(constructor="runner")
+def cut(input: CutInput) -> CutOutput:
+    return CutOutput(
+        first_strings=input.strings[: input.cut_after],
+        remainder=input.strings[input.cut_after :],
+        exit_code=1 if len(input.strings) <= input.cut_after else 0,
+    )
+
+
+@script(constructor="runner")
+def join(input: JoinInput) -> JoinOutput:
+    return JoinOutput(joined_string=input.joiner.join(input.strings))
+
+
+with WorkflowTemplate(generate_name="pydantic-io-in-steps-context-v1-", entrypoint="d") as w:
+    with Steps(name="d"):
+        cut_result = cut(CutInput(strings=["hello", "world", "it's", "hera"], cut_after=1))
+        join(JoinInput(strings=cut_result.first_strings, joiner=" "))

--- a/examples/workflows/experimental/pydantic_io_in_steps_context.py
+++ b/examples/workflows/experimental/pydantic_io_in_steps_context.py
@@ -11,7 +11,7 @@ from hera.shared import global_config
 from hera.workflows import Parameter, Steps, WorkflowTemplate, script
 from hera.workflows.io.v1 import Input, Output
 
-global_config.experimental_features["decorator_syntax"] = True
+global_config.experimental_features["context_manager_pydantic_io"] = True
 
 
 class CutInput(Input):

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -15,9 +15,9 @@ TBase = TypeVar("TBase", bound="BaseMixin")
 TypeTBase = Type[TBase]
 
 Hook = Callable[[TBase], TBase]
-"""`Hook` is a callable that takes a Hera objects and returns the same, optionally mutated, object. 
+"""`Hook` is a callable that takes a Hera objects and returns the same, optionally mutated, object.
 
-This can be a Workflow, a Script, a Container, etc - any Hera object. 
+This can be a Workflow, a Script, a Container, etc - any Hera object.
 """
 
 _HookMap = Dict[TypeTBase, List[Hook]]
@@ -202,14 +202,15 @@ register_pre_build_hook = global_config.register_pre_build_hook
 _SCRIPT_ANNOTATIONS_FLAG = "script_annotations"
 _SCRIPT_PYDANTIC_IO_FLAG = "script_pydantic_io"
 _DECORATOR_SYNTAX_FLAG = "decorator_syntax"
+_CONTEXT_MANAGER_PYDANTIC_IO_FLAG = "context_manager_pydantic_io"
 _SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG = "suppress_parameter_default_error"
 
 # A dictionary where each key is a flag that has a list of flags which supersede it, hence
 # the given flag key can also be switched on by any of the flags in the list. Using simple flat lists
 # for now, otherwise with many superseding flags we may want to have a recursive structure.
 _SUPERSEDING_FLAGS: Dict[str, List] = {
-    _SCRIPT_ANNOTATIONS_FLAG: [_SCRIPT_PYDANTIC_IO_FLAG, _DECORATOR_SYNTAX_FLAG],
-    _SCRIPT_PYDANTIC_IO_FLAG: [_DECORATOR_SYNTAX_FLAG],
+    _SCRIPT_ANNOTATIONS_FLAG: [_SCRIPT_PYDANTIC_IO_FLAG, _DECORATOR_SYNTAX_FLAG, _CONTEXT_MANAGER_PYDANTIC_IO_FLAG],
+    _SCRIPT_PYDANTIC_IO_FLAG: [_DECORATOR_SYNTAX_FLAG, _CONTEXT_MANAGER_PYDANTIC_IO_FLAG],
     _DECORATOR_SYNTAX_FLAG: [],
 }
 

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -377,7 +377,6 @@ class CallableTemplateMixin(BaseMixin):
                 current_task_depends = _context.pieces[-1]._current_task_depends
                 if current_task_depends and "depends" not in kwargs:
                     kwargs["depends"] = " && ".join(sorted(current_task_depends))
-                current_task_depends.clear()
 
                 return Task(template=self, **kwargs)
 
@@ -582,7 +581,6 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                 depends=" && ".join(sorted(_context.pieces[-1]._current_task_depends)) or None,
                 **kwargs,
             )
-            _context.pieces[-1]._current_task_depends.clear()
 
         subnode._build_obj = HeraBuildObj(subnode._subtype, output_class)
         return subnode

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -564,7 +564,8 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
             # Set template to None as it cannot be set alongside template_ref
             template = None  # type: ignore
 
-        if isinstance(_context.pieces[-1], (Steps, Parallel)):
+        current_context = _context.pieces[-1]
+        if isinstance(current_context, (Steps, Parallel)):
             subnode = Step(
                 name=subnode_name,
                 template=template,
@@ -572,13 +573,14 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
                 arguments=subnode_args,
                 **kwargs,
             )
-        elif isinstance(_context.pieces[-1], DAG):
+        elif isinstance(current_context, DAG):
+            if current_context._current_task_depends and "depends" not in kwargs:
+                kwargs["depends"] = " && ".join(sorted(current_context._current_task_depends))
             subnode = Task(
                 name=subnode_name,
                 template=template,
                 template_ref=template_ref,
                 arguments=subnode_args,
-                depends=" && ".join(sorted(_context.pieces[-1]._current_task_depends)) or None,
                 **kwargs,
             )
 

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -373,6 +373,12 @@ class CallableTemplateMixin(BaseMixin):
                 return Step(template=self, **kwargs)
 
             if isinstance(_context.pieces[-1], DAG):
+                # Add dependencies based on context if not explicitly provided
+                current_task_depends = _context.pieces[-1]._current_task_depends
+                if current_task_depends and "depends" not in kwargs:
+                    kwargs["depends"] = " && ".join(sorted(current_task_depends))
+                current_task_depends.clear()
+
                 return Task(template=self, **kwargs)
 
         raise InvalidTemplateCall(

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -548,8 +548,7 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
         assert _context.pieces
 
         template_ref = None
-        _context.declaring = False
-        if _context.pieces[0] != self and isinstance(self, WorkflowTemplate):
+        if _context.pieces[0] is not self and isinstance(self, WorkflowTemplate):
             # Using None for cluster_scope means it won't appear in the YAML spec (saving some bytes),
             # as cluster_scope=False is the default value
             template_ref = TemplateRef(
@@ -580,7 +579,6 @@ class TemplateDecoratorFuncsMixin(ContextMixin):
             _context.pieces[-1]._current_task_depends.clear()
 
         subnode._build_obj = HeraBuildObj(subnode._subtype, output_class)
-        _context.declaring = True
         return subnode
 
     @_add_type_hints(Script)  # type: ignore

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -721,12 +721,12 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
         except AttributeError:
             build_obj = None
 
-        if build_obj and _context.declaring:
+        if build_obj and _context.active:
             fields = get_fields(build_obj.output_class)
             annotations = get_field_annotations(build_obj.output_class)
             if name in fields:
                 # If the attribute name is in the build_obj's output class fields, then
-                # as we are in a declaring context, the access is for a Task/Step output
+                # as we are in an active context, the access is for a Task/Step output
                 subnode_name = object.__getattribute__(self, "name")
                 subnode_type = object.__getattribute__(self, "_subtype")
 

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -715,11 +715,13 @@ class TemplateInvocatorSubNodeMixin(BaseMixin):
     _build_obj: Optional[HeraBuildObj] = PrivateAttr(None)
 
     def __getattribute__(self, name: str) -> Any:
-        if _context.declaring:
+        try:
             # Use object's __getattribute__ to avoid infinite recursion
             build_obj = object.__getattribute__(self, "_build_obj")
-            assert build_obj  # Assertions to fix type checking
+        except AttributeError:
+            build_obj = None
 
+        if build_obj and _context.declaring:
             fields = get_fields(build_obj.output_class)
             annotations = get_field_annotations(build_obj.output_class)
             if name in fields:

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -54,6 +54,7 @@ class DAG(
             raise NodeNameConflict(f"Found multiple Task nodes with name: {node.name}")
         self._node_names.add(node.name)
         self.tasks.append(node)
+        self._current_task_depends.clear()
 
     def _build_template(self) -> _ModelTemplate:
         """Builds the auto-generated `Template` representation of the `DAG`."""

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -47,6 +47,11 @@ class DAG(
     _node_names = PrivateAttr(default_factory=set)
     _current_task_depends: Set[str] = PrivateAttr(set())
 
+    def _create_leaf_node(self, **kwargs) -> Task:
+        if self._current_task_depends and "depends" not in kwargs:
+            kwargs["depends"] = " && ".join(sorted(self._current_task_depends))
+        return Task(**kwargs)
+
     def _add_sub(self, node: Any):
         if not isinstance(node, Task):
             raise InvalidType(type(node))

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -41,7 +41,7 @@ from typing_extensions import ParamSpec, get_args, get_origin
 from hera.expr import g
 from hera.shared import BaseMixin, global_config
 from hera.shared._global_config import (
-    _DECORATOR_SYNTAX_FLAG,
+    _CONTEXT_MANAGER_PYDANTIC_IO_FLAG,
     _SCRIPT_ANNOTATIONS_FLAG,
     _SCRIPT_PYDANTIC_IO_FLAG,
     _SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG,
@@ -775,10 +775,10 @@ def script(**script_kwargs) -> Callable:
             """Invokes a `Script` object's `__call__` method using the given SubNode (Step or Task) args/kwargs."""
             if _context.active:
                 if len(args) == 1 and isinstance(args[0], (InputV1, InputV2)):
-                    if not _flag_enabled(_DECORATOR_SYNTAX_FLAG):
+                    if not _flag_enabled(_CONTEXT_MANAGER_PYDANTIC_IO_FLAG):
                         raise SyntaxError(
                             "Cannot pass a Pydantic type inside a context. "
-                            + _enable_experimental_feature_msg(_DECORATOR_SYNTAX_FLAG)
+                            + _enable_experimental_feature_msg(_CONTEXT_MANAGER_PYDANTIC_IO_FLAG)
                         )
                     arguments = args[0]._get_as_arguments()
                     arguments_list = [

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -380,7 +380,7 @@ def _get_parameters_from_callable(source: Callable) -> List[Parameter]:
     return parameters
 
 
-def please_enable_experimental_feature(flag: str) -> str:
+def _enable_experimental_feature_msg(flag: str) -> str:
     return (
         "Please turn on experimental features by setting "
         f'`hera.shared.global_config.experimental_features["{flag}"] = True`.'
@@ -392,7 +392,7 @@ def _assert_pydantic_io_enabled(annotation: str) -> None:
     if not _flag_enabled(_SCRIPT_PYDANTIC_IO_FLAG):
         raise ValueError(
             f"Unable to instantiate {annotation} since it is an experimental feature. "
-            + please_enable_experimental_feature(_SCRIPT_PYDANTIC_IO_FLAG)
+            + _enable_experimental_feature_msg(_SCRIPT_PYDANTIC_IO_FLAG)
         )
 
 
@@ -778,7 +778,7 @@ def script(**script_kwargs) -> Callable:
                     if not _flag_enabled(_DECORATOR_SYNTAX_FLAG):
                         raise SyntaxError(
                             "Cannot pass a Pydantic type inside a context. "
-                            + please_enable_experimental_feature(_DECORATOR_SYNTAX_FLAG)
+                            + _enable_experimental_feature_msg(_DECORATOR_SYNTAX_FLAG)
                         )
                     arguments = args[0]._get_as_arguments()
                     arguments_list = [

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -110,6 +110,9 @@ class Parallel(
 
     _node_names = PrivateAttr(default_factory=set)
 
+    def _create_leaf_node(self, **kwargs) -> Step:
+        return Step(**kwargs)
+
     def _add_sub(self, node: Any):
         if not isinstance(node, Step):
             raise InvalidType(type(node))
@@ -179,6 +182,9 @@ class Steps(
                 raise InvalidType(type(workflow_step))
 
         return steps or None
+
+    def _create_leaf_node(self, **kwargs) -> Step:
+        return Step(**kwargs)
 
     def _add_sub(self, node: Any):
         if not isinstance(node, (Step, Parallel)):

--- a/tests/test_pydantic_io_syntax.py
+++ b/tests/test_pydantic_io_syntax.py
@@ -1,0 +1,62 @@
+import pytest
+
+from hera.shared._global_config import _SCRIPT_PYDANTIC_IO_FLAG
+from hera.workflows import Input, Output, Steps, Workflow, script
+
+
+class IntInput(Input):
+    field: int
+
+
+class IntOutput(Output):
+    field: int
+
+
+@pytest.fixture(autouse=True)
+def enable_pydantic_io(global_config_fixture):
+    global_config_fixture.experimental_features[_SCRIPT_PYDANTIC_IO_FLAG] = True
+
+
+def test_output_field_contains_argo_template(global_config_fixture):
+    @script()
+    def triple(input: IntInput) -> IntOutput:
+        return IntOutput(field=input.field * 3)
+
+    with Workflow(name="foo"):
+        with Steps(name="bar"):
+            result = triple(IntInput(field=5)).field
+
+    assert result == "{{steps.triple.outputs.parameters.field}}"
+
+
+def test_script_can_return_none():
+    @script()
+    def print_field(input: IntInput) -> None:
+        print(input.field)
+
+    with Workflow(name="foo"):
+        with Steps(name="bar"):
+            result = print_field(IntInput(field=5))
+
+    assert result is None
+
+
+def test_invalid_pydantic_io_outside_of_context():
+    @script()
+    def triple(input: IntInput) -> IntOutput:
+        return IntOutput(field=input.field * 3)
+
+    with Workflow(name="foo"):
+        with pytest.raises(SyntaxError, match="Cannot use Pydantic I/O outside of a .* context"):
+            triple(IntInput(field=5))
+
+
+def test_invalid_non_pydantic_return_type():
+    @script()
+    def triple(input: IntInput) -> int:
+        return input.field * 3
+
+    with Workflow(name="foo"):
+        with Steps(name="bar"):
+            with pytest.raises(SyntaxError, match="Cannot use Pydantic input type without a Pydantic output type"):
+                triple(IntInput(field=5))

--- a/tests/test_pydantic_io_workflow_syntax.py
+++ b/tests/test_pydantic_io_workflow_syntax.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hera.shared._global_config import _SCRIPT_PYDANTIC_IO_FLAG
+from hera.shared._global_config import _DECORATOR_SYNTAX_FLAG
 from hera.workflows import Input, Output, Steps, Workflow, script
 
 
@@ -14,7 +14,7 @@ class IntOutput(Output):
 
 @pytest.fixture(autouse=True)
 def enable_pydantic_io(global_config_fixture):
-    global_config_fixture.experimental_features[_SCRIPT_PYDANTIC_IO_FLAG] = True
+    global_config_fixture.experimental_features[_DECORATOR_SYNTAX_FLAG] = True
 
 
 def test_output_field_contains_argo_template(global_config_fixture):

--- a/tests/test_pydantic_io_workflow_syntax.py
+++ b/tests/test_pydantic_io_workflow_syntax.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hera.shared._global_config import _DECORATOR_SYNTAX_FLAG
+from hera.shared._global_config import _CONTEXT_MANAGER_PYDANTIC_IO_FLAG
 from hera.workflows import Input, Output, Steps, Workflow, script
 
 
@@ -14,7 +14,7 @@ class IntOutput(Output):
 
 @pytest.fixture(autouse=True)
 def enable_pydantic_io(global_config_fixture):
-    global_config_fixture.experimental_features[_DECORATOR_SYNTAX_FLAG] = True
+    global_config_fixture.experimental_features[_CONTEXT_MANAGER_PYDANTIC_IO_FLAG] = True
 
 
 def test_output_field_contains_argo_template(global_config_fixture):


### PR DESCRIPTION
**Pull Request Checklist**
- [X] Fixes #1192
- [X] Tests added
- [X] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, `@script`-decorated functions that use Pydantic I/O types must still use pre-Pydantic syntax when creating workflows. This makes it harder to migrate to the new dag and steps decorators, as more code must be migrated in a single step before the YAML can be regenerated and tested.

This PR allows Pydantic input types to be passed in when in an active context, and will then configure the returned subnode to mimic the Pydantic output type. Tasks using fields from the returned object will automatically have a dependency added, if no dependency is explicitly specified.
