### PR TITLE
Remove references to needing to enable second flag

### DIFF
--- a/docs/user-guides/script-runner-io.md
+++ b/docs/user-guides/script-runner-io.md
@@ -25,8 +25,8 @@ allowing you to migrate at your own pace.
 ## Script inputs using `Input`
 
 For your script inputs, you can create a derived class of `Input`, and declare all your input parameters (and
-artifacts) as fields of the class. If you want to use `Annotated` to declare `Artifacts` add metadata to your
-`Parameters`, you will also need to enable the `"script_annotations"` experimental feature flag.
+artifacts) as fields of the class. You can use `Annotated` to declare `Artifacts` add metadata to your
+`Parameters`.
 
 ```py
 from typing import Annotated

--- a/docs/walk-through/advanced-hera-features.md
+++ b/docs/walk-through/advanced-hera-features.md
@@ -123,9 +123,9 @@ Read the full guide on script annotations in [the script user guide](../user-gui
 
 Hera provides Pydantic models for you to create subclasses from, which allow you to more easily declare script template
 inputs. Any fields that you declare in your subclass of `Input` will become input parameters or artifacts, while
-`Output` fields will become output parameters artifacts. The fields that you declare can be `Annotated` as a
-`Parameter` or `Artifact`, as any fields with a basic type will become `Parameters` - you will also need the
-`script_annotations` experimental feature enabled.
+`Output` fields will become output parameters artifacts. The fields that you declare can be `Annotated` as a `Parameter`
+or `Artifact`, as any fields with a basic type will become `Parameters`. Turning on the `script_pydantic_io` flag will
+automatically enable the `script_annotations` experimental feature.
 
 To enable Hera input/output models, you must set the `experimental_feature` flag `script_pydantic_io`
 


### PR DESCRIPTION
* Setting script_pydantic_io flag also sets the `script_annotations` flag

Follow up from #1078, docs still mentioned users have to set the superseded flag