### PR TITLE
Remove types aliases to Input/Output

### DIFF
--- a/docs/user-guides/script-runner-io.md
+++ b/docs/user-guides/script-runner-io.md
@@ -1,9 +1,5 @@
 # Script Runner IO
 
-> ⚠️ The `RunnerInput` and `RunnerOutput` classes have been renamed to align on the [decorators](decorators.md) feature
-> and are deprecated since `v5.16.0`, please use `Input` and `Output` for equivalent functionality. The "Runner*" type
-> aliases will be removed in `v5.17.0`.
-
 Hera provides the `Input` and `Output` Pydantic classes which can be used to more succinctly write your
 script function inputs and outputs, and requires use of the Hera Runner. Use of these classes also requires the
 `"script_pydantic_io"` experimental feature flag to be enabled:

--- a/src/hera/workflows/__init__.py
+++ b/src/hera/workflows/__init__.py
@@ -36,7 +36,7 @@ from hera.workflows.exceptions import (
     TemplateNameConflict,
 )
 from hera.workflows.http_template import HTTP
-from hera.workflows.io import Input, Output, RunnerInput, RunnerOutput
+from hera.workflows.io import Input, Output
 from hera.workflows.metrics import Counter, Gauge, Histogram, Label, Metric, Metrics
 from hera.workflows.operator import Operator
 from hera.workflows.parameter import Parameter
@@ -159,8 +159,6 @@ __all__ = [
     "Resources",
     "RetryPolicy",
     "RetryStrategy",
-    "RunnerInput",
-    "RunnerOutput",
     "RunnerScriptConstructor",
     "S3Artifact",
     "ScaleIOVolume",

--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -152,7 +152,7 @@ def map_runner_input(
         kwargs: Dict[str, str],
     ) -> Any:
         annotation = runner_input_annotations.get(field)
-        assert annotation is not None, "RunnerInput fields must be type-annotated"
+        assert annotation is not None, "Input fields must be type-annotated"  # Note: not necessarily with `Annotated`
         ann_type = unwrap_annotation(annotation)
 
         if param_or_artifact := get_workflow_annotation(annotation):

--- a/src/hera/workflows/io/__init__.py
+++ b/src/hera/workflows/io/__init__.py
@@ -1,23 +1,15 @@
 """Hera IO models."""
 
-from typing import Type
-
 from pydantic import VERSION
 
 if VERSION.split(".")[0] == "2":
     from hera.workflows.io.v2 import Input, Output
 
-    RunnerInput: Type = Input
-    RunnerOutput: Type = Output
 else:
     from hera.workflows.io.v1 import Input, Output  # type: ignore
 
-    RunnerInput: Type = Input  # type: ignore
-    RunnerOutput: Type = Output  # type: ignore
 
 __all__ = [
     "Input",
     "Output",
-    "RunnerInput",
-    "RunnerOutput",
 ]


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] ~Fixes #<!--issue number goes here-->~
- [ ] ~Tests added~
- [x] Documentation~/examples~ Updated
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
We renamed `RunnerInput` and `RunnerOutput` to `Input`/`Output` to streamline terminology for the new decorators. As the `script_pydantic_io` is an experimental feature, and the only change is to rename references to the types, we are making a breaking change to remove the type aliases. Users can do `import hera.workflows.io.Input as RunnerInput` if they want to avoid code changes elsewhere in their codebase.
