### PR TITLE
fix: update dask use case example

### DIFF
--- a/docs/examples/workflows/use-cases/dask.md
+++ b/docs/examples/workflows/use-cases/dask.md
@@ -27,16 +27,11 @@ This example showcases how to run Dask within a Hera submitted Argo workflow.
 
         import dask.array as da
         from dask.distributed import Client
-        from dask_kubernetes.classic import KubeCluster, make_pod_spec
+        from dask_kubernetes.operator import KubeCluster
 
         cluster = KubeCluster(
-            pod_template=make_pod_spec(
-                image="ghcr.io/dask/dask:latest",
-                memory_limit="4G",
-                memory_request="2G",
-                cpu_limit=1,
-                cpu_request=1,
-            ),
+            image="ghcr.io/dask/dask:latest",
+            resources={"requests": {"memory": "2G", "cpu": "1"}, "limits": {"memory": "4G", "cpu": "1"}},
             namespace=namespace,
             n_workers=n_workers,
         )
@@ -92,8 +87,8 @@ This example showcases how to run Dask within a Hera submitted Argo workflow.
             subprocess.run(['pip', 'install', 'dask-kubernetes', 'dask[distributed]'], stdout=subprocess.PIPE, universal_newlines=True)
             import dask.array as da
             from dask.distributed import Client
-            from dask_kubernetes.classic import KubeCluster, make_pod_spec
-            cluster = KubeCluster(pod_template=make_pod_spec(image='ghcr.io/dask/dask:latest', memory_limit='4G', memory_request='2G', cpu_limit=1, cpu_request=1), namespace=namespace, n_workers=n_workers)
+            from dask_kubernetes.operator import KubeCluster
+            cluster = KubeCluster(image='ghcr.io/dask/dask:latest', resources={"requests": {"memory": "2G", "cpu": "1"}, "limits": {"memory": "4G", "cpu": "1"}}, namespace=namespace, n_workers=n_workers)
             client = Client(cluster)
             array = da.ones((1000, 1000, 1000))
             print('Array mean = {array_mean}, expected = 1.0'.format(array_mean=array.mean().compute()))

--- a/examples/workflows/use_cases/dask.py
+++ b/examples/workflows/use_cases/dask.py
@@ -19,16 +19,11 @@ def dask_computation(namespace: str = "default", n_workers: int = 1) -> None:
 
     import dask.array as da
     from dask.distributed import Client
-    from dask_kubernetes.classic import KubeCluster, make_pod_spec
+    from dask_kubernetes.operator import KubeCluster
 
     cluster = KubeCluster(
-        pod_template=make_pod_spec(
-            image="ghcr.io/dask/dask:latest",
-            memory_limit="4G",
-            memory_request="2G",
-            cpu_limit=1,
-            cpu_request=1,
-        ),
+        image="ghcr.io/dask/dask:latest",
+        resources={"requests": {"memory": "2G", "cpu": "1"}, "limits": {"memory": "4G", "cpu": "1"}},
         namespace=namespace,
         n_workers=n_workers,
     )

--- a/examples/workflows/use_cases/dask.yaml
+++ b/examples/workflows/use_cases/dask.yaml
@@ -34,8 +34,8 @@ spec:
         subprocess.run(['pip', 'install', 'dask-kubernetes', 'dask[distributed]'], stdout=subprocess.PIPE, universal_newlines=True)
         import dask.array as da
         from dask.distributed import Client
-        from dask_kubernetes.classic import KubeCluster, make_pod_spec
-        cluster = KubeCluster(pod_template=make_pod_spec(image='ghcr.io/dask/dask:latest', memory_limit='4G', memory_request='2G', cpu_limit=1, cpu_request=1), namespace=namespace, n_workers=n_workers)
+        from dask_kubernetes.operator import KubeCluster
+        cluster = KubeCluster(image='ghcr.io/dask/dask:latest', resources={"requests": {"memory": "2G", "cpu": "1"}, "limits": {"memory": "4G", "cpu": "1"}}, namespace=namespace, n_workers=n_workers)
         client = Client(cluster)
         array = da.ones((1000, 1000, 1000))
         print('Array mean = {array_mean}, expected = 1.0'.format(array_mean=array.mean().compute()))


### PR DESCRIPTION
dask_kubernetes.classic is deprecated, so migrated this example by following https://kubernetes.dask.org/en/latest/kubecluster_migrating.html

