### PR TITLE
Remove use of skip_defaults

### DIFF
--- a/scripts/service.py
+++ b/scripts/service.py
@@ -155,15 +155,7 @@ class ServiceEndpoint:
         else:
             bp = body_params[0]
             assert bp.name == "req", bp.name
-            body = (
-                "req.json("
-                "exclude_none=True, "
-                "by_alias=True, "
-                "skip_defaults=True, "
-                "exclude_unset=True, "
-                "exclude_defaults=True"
-                ")"
-            )
+            body = "req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True)"
 
         # return value
         if self.response.ref == "str":

--- a/src/hera/events/service.py
+++ b/src/hera/events/service.py
@@ -146,9 +146,7 @@ class EventsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -190,9 +188,7 @@ class EventsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -249,9 +245,7 @@ class EventsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -331,9 +325,7 @@ class EventsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -373,9 +365,7 @@ class EventsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )

--- a/src/hera/workflows/service.py
+++ b/src/hera/workflows/service.py
@@ -263,9 +263,7 @@ class WorkflowsService:
             url=urljoin(self.host, "api/v1/archived-workflows/{uid}/resubmit").format(uid=uid),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -283,9 +281,7 @@ class WorkflowsService:
             url=urljoin(self.host, "api/v1/archived-workflows/{uid}/retry").format(uid=uid),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -342,9 +338,7 @@ class WorkflowsService:
             url=urljoin(self.host, "api/v1/cluster-workflow-templates"),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -362,9 +356,7 @@ class WorkflowsService:
             url=urljoin(self.host, "api/v1/cluster-workflow-templates/lint"),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -404,9 +396,7 @@ class WorkflowsService:
             url=urljoin(self.host, "api/v1/cluster-workflow-templates/{name}").format(name=name),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -502,9 +492,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -524,9 +512,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -570,9 +556,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -631,9 +615,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -655,9 +637,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -777,9 +757,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -801,9 +779,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -847,9 +823,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -950,9 +924,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -972,9 +944,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -994,9 +964,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1132,9 +1100,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1154,9 +1120,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1176,9 +1140,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1198,9 +1160,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1220,9 +1180,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1242,9 +1200,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )
@@ -1266,9 +1222,7 @@ class WorkflowsService:
             ),
             params=None,
             headers={"Authorization": self.token, "Content-Type": "application/json"},
-            data=req.json(
-                exclude_none=True, by_alias=True, skip_defaults=True, exclude_unset=True, exclude_defaults=True
-            ),
+            data=req.json(exclude_none=True, by_alias=True, exclude_unset=True, exclude_defaults=True),
             verify=self.verify_ssl,
             cert=self.client_certs,
         )


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, we are setting both `skip_defaults` and `exclude_unset` when we call Pydantic's `json` method. The former was made a (deprecated) alias for the latter in https://github.com/pydantic/pydantic/pull/915, released [as part of v1.0](https://github.com/pydantic/pydantic/blob/main/HISTORY.md#v10-2019-10-23); we have a minimum requirement of v1.7.

This PR removes the redundant `skip_defaults` parameter.
