### PR TITLE
Disable warnings from model_dump

### DIFF
--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -138,7 +138,7 @@ class InputMixin(BaseModel):
         if isinstance(self, V1BaseModel):
             self_dict = self.dict()
         elif _PYDANTIC_VERSION == 2 and isinstance(self, V2BaseModel):
-            self_dict = self.model_dump()
+            self_dict = self.model_dump(warnings="none")
 
         for field, _, annotation in _construct_io_from_fields(type(self)):
             # The value may be a static value (of any time) if it has a default value, so we need to serialize it
@@ -217,7 +217,7 @@ class OutputMixin(BaseModel):
         if isinstance(self, V1BaseModel):
             self_dict = self.dict()
         elif _PYDANTIC_VERSION == 2 and isinstance(self, V2BaseModel):
-            self_dict = self.model_dump()
+            self_dict = self.model_dump(warnings="none")
 
         for field, _, annotation in _construct_io_from_fields(type(self)):
             if field in {"exit_code", "result"}:


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [X] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, using Pydantic V2 with the Input/Output mixin types and a non-`str` field prints a `UserWarning` when the class is declared, of the form "UserWarning: Pydantic serializer warning: Expected `int` but got `str` with value `'{{...}}'` - serialized value may not be as expected". This is caused by using `model_dump` on an object constructed with all string values, i.e. one which does not pass the type-checking performed by the method, as part of class creation.

This PR just adds `warnings="none"` to the two uses of `model_dump`, to disable these warnings.
