### PR TITLE
Fix unclosed file warning

### DIFF
--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -110,7 +110,8 @@ def get_annotated_artifact_value(artifact_annotation: Artifact) -> Union[Path, A
 
     if artifact_annotation.loader == ArtifactLoader.json.value:
         path = Path(artifact_annotation.path)
-        return json.load(path.open())
+        with path.open() as f:
+            return json.load(f)
 
     if artifact_annotation.loader == ArtifactLoader.file.value:
         path = Path(artifact_annotation.path)


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, `get_annotated_artifact_value` is opening a file but not closing it, resulting in a ResourceWarning in the `__del__` method.

This PR just adds a `with` block to ensure safe cleanup.

