### PR TITLE
Fix TypeError in script.py for functions returning non-types

### DIFF
--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -407,7 +407,7 @@ def _get_outputs_from_return_annotation(
 
             if param_or_artifact := get_workflow_annotation(annotation):
                 append_annotation(param_or_artifact)
-    elif return_annotation and issubclass(return_annotation, (OutputV1, OutputV2)):
+    elif isinstance(return_annotation, type) and issubclass(return_annotation, (OutputV1, OutputV2)):
         if not _flag_enabled(_SCRIPT_PYDANTIC_IO_FLAG):
             raise ValueError(
                 (


### PR DESCRIPTION

**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [X] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, `_get_outputs_from_return_annotation` is always passing the return type annotation (if one exists) to `issubclass`, to check if it is a Pydantic type. Some valid type annotations like `typing.Dict` are not valid types at runtime, i.e. cannot be used with `subclass`, resulting in a runtime `TypeError`.

This PR changes the precondition for entering this code from truthiness to `isinstance(..., type)`, matching the code a few lines above.
