### PR TITLE
Fix codecov token for github actions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
 
@@ -89,6 +91,8 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
 


### PR DESCRIPTION
Followed https://docs.codecov.com/docs/adding-the-codecov-token#github-actions

Seems the action stopped getting the secret automatically, which is already in our repository secrets as `CODECOV_TOKEN`.