### PR TITLE
Fix deserialization for str unions

### DIFF
--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -92,13 +92,22 @@ def get_unsubscripted_type(t: Any) -> Any:
     return t
 
 
-def origin_type_issubclass(cls: Any, type_: type) -> bool:
-    """Return True if cls can be considered as a subclass of type_."""
-    unwrapped_type = unwrap_annotation(cls)
+def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]]) -> bool:
+    """Return True if annotation is a subtype of type_."""
+    unwrapped_type = unwrap_annotation(annotation)
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
-        return any(origin_type_issubclass(arg, type_) for arg in get_args(cls))
+        return all(origin_type_issubtype(arg, type_) for arg in get_args(annotation))
     return issubclass(origin_type, type_)
+
+
+def origin_type_issupertype(annotation: Any, type_: type) -> bool:
+    """Return True if annotation is a supertype of type_."""
+    unwrapped_type = unwrap_annotation(annotation)
+    origin_type = get_unsubscripted_type(unwrapped_type)
+    if origin_type is Union or origin_type is UnionType:
+        return any(origin_type_issupertype(arg, type_) for arg in get_args(annotation))
+    return issubclass(type_, origin_type)
 
 
 def is_subscripted(t: Any) -> bool:

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -93,7 +93,11 @@ def get_unsubscripted_type(t: Any) -> Any:
 
 
 def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]]) -> bool:
-    """Return True if annotation is a subtype of type_."""
+    """Return True if annotation is a subtype of type_.
+
+    type_ may be a tuple of types, in which case return True if annotation is a subtype
+    of the union of the types in the tuple.
+    """
     unwrapped_type = unwrap_annotation(annotation)
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -101,7 +101,7 @@ def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]])
     unwrapped_type = unwrap_annotation(annotation)
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
-        return all(origin_type_issubtype(arg, type_) for arg in get_args(annotation))
+        return all(origin_type_issubtype(arg, type_) for arg in get_args(unwrapped_type))
     return isinstance(origin_type, type) and issubclass(origin_type, type_)
 
 
@@ -110,7 +110,7 @@ def origin_type_issupertype(annotation: Any, type_: type) -> bool:
     unwrapped_type = unwrap_annotation(annotation)
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
-        return any(origin_type_issupertype(arg, type_) for arg in get_args(annotation))
+        return any(origin_type_issupertype(arg, type_) for arg in get_args(unwrapped_type))
     return isinstance(origin_type, type) and issubclass(type_, origin_type)
 
 

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -102,7 +102,7 @@ def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]])
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
         return all(origin_type_issubtype(arg, type_) for arg in get_args(annotation))
-    return issubclass(origin_type, type_)
+    return isinstance(origin_type, type) and issubclass(origin_type, type_)
 
 
 def origin_type_issupertype(annotation: Any, type_: type) -> bool:
@@ -111,7 +111,7 @@ def origin_type_issupertype(annotation: Any, type_: type) -> bool:
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
         return any(origin_type_issupertype(arg, type_) for arg in get_args(annotation))
-    return issubclass(type_, origin_type)
+    return isinstance(origin_type, type) and issubclass(type_, origin_type)
 
 
 def is_subscripted(t: Any) -> bool:

--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -3,15 +3,21 @@
 import inspect
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+
+if sys.version_info >= (3, 10):
+    from types import NoneType
+else:
+    NoneType = type(None)
 
 from hera.shared._pydantic import BaseModel, get_field_annotations, get_fields
 from hera.shared._type_util import (
     get_unsubscripted_type,
     get_workflow_annotation,
     is_subscripted,
-    origin_type_issubclass,
+    origin_type_issubtype,
     unwrap_annotation,
 )
 from hera.shared.serialization import serialize
@@ -138,7 +144,7 @@ def map_runner_input(
     input_model_obj = {}
 
     def load_parameter_value(value: str, value_type: type) -> Any:
-        if origin_type_issubclass(value_type, str):
+        if origin_type_issubtype(value_type, (str, NoneType)):
             return value
 
         try:

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -6,13 +6,19 @@ import importlib
 import inspect
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, cast
+
+if sys.version_info >= (3, 10):
+    from types import NoneType
+else:
+    NoneType = type(None)
 
 from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.shared._type_util import (
     get_workflow_annotation,
-    origin_type_issubclass,
+    origin_type_issubtype,
     unwrap_annotation,
 )
 from hera.shared.serialization import serialize
@@ -125,7 +131,7 @@ def _get_unannotated_type(key: str, f: Callable) -> Optional[type]:
 def _is_str_kwarg_of(key: str, f: Callable) -> bool:
     """Check if param `key` of function `f` has a type annotation that can be interpreted as a subclass of str."""
     if func_param_annotation := _get_function_param_annotation(key, f):
-        return origin_type_issubclass(func_param_annotation, str)
+        return origin_type_issubtype(func_param_annotation, (str, NoneType))
     return False
 
 

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -47,7 +47,7 @@ from hera.shared._global_config import (
     _flag_enabled,
 )
 from hera.shared._pydantic import _PYDANTIC_VERSION, root_validator, validator
-from hera.shared._type_util import get_workflow_annotation, is_subscripted, origin_type_issubclass
+from hera.shared._type_util import get_workflow_annotation, is_subscripted, origin_type_issupertype
 from hera.shared.serialization import serialize
 from hera.workflows._context import _context
 from hera.workflows._meta_mixins import CallableTemplateMixin
@@ -540,7 +540,9 @@ def _get_inputs_from_callable(source: Callable) -> Tuple[List[Parameter], List[A
             else:
                 default = MISSING
 
-            if origin_type_issubclass(func_param.annotation, NoneType) and (default is MISSING or default is not None):
+            if origin_type_issupertype(func_param.annotation, NoneType) and (
+                default is MISSING or default is not None
+            ):
                 raise ValueError(f"Optional parameter '{func_param.name}' must have a default value of None.")
 
             parameters.append(Parameter(name=func_param.name, default=default))

--- a/tests/script_runner/parameter_inputs.py
+++ b/tests/script_runner/parameter_inputs.py
@@ -77,7 +77,7 @@ def no_type_parameter(my_anything) -> Any:
 
 
 @script()
-def str_or_int_parameter(my_str_or_int: Union[str, int]) -> str:
+def str_or_int_parameter(my_str_or_int: Union[int, str]) -> str:
     return f"type given: {type(my_str_or_int).__name__}"
 
 

--- a/tests/script_runner/parameter_inputs.py
+++ b/tests/script_runner/parameter_inputs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List
+from typing import Any, List, Union
 
 try:
     from typing import Annotated
@@ -74,6 +74,11 @@ def annotated_parameter_no_name(
 def no_type_parameter(my_anything) -> Any:
     """`my_anything` will be whatever the json loader gives back."""
     return my_anything
+
+
+@script()
+def str_or_int_parameter(my_str_or_int: Union[str, int]) -> str:
+    return f"type given: {type(my_str_or_int).__name__}"
 
 
 @script()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -66,6 +66,18 @@ from hera.workflows.io.v1 import Output
             id="no-type-dict",
         ),
         pytest.param(
+            "tests.script_runner.parameter_inputs:str_or_int_parameter",
+            [{"name": "my_str_or_int", "value": "hi there"}],
+            "type given: str",
+            id="str-or-int-given-str",
+        ),
+        pytest.param(
+            "tests.script_runner.parameter_inputs:str_or_int_parameter",
+            [{"name": "my_str_or_int", "value": "3"}],
+            "type given: int",
+            id="str-or-int-given-int",
+        ),
+        pytest.param(
             "tests.script_runner.parameter_inputs:str_parameter_expects_jsonstr_dict",
             [{"name": "my_json_str", "value": json.dumps({"my": "dict"})}],
             {"my": "dict"},

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -65,17 +65,23 @@ from hera.workflows.io.v1 import Output
             {},
             id="no-type-dict",
         ),
-        pytest.param(
-            "tests.script_runner.parameter_inputs:str_or_int_parameter",
-            [{"name": "my_str_or_int", "value": "hi there"}],
-            "type given: str",
-            id="str-or-int-given-str",
-        ),
-        pytest.param(
-            "tests.script_runner.parameter_inputs:str_or_int_parameter",
-            [{"name": "my_str_or_int", "value": "3"}],
-            "type given: int",
-            id="str-or-int-given-int",
+        *(
+            [
+                pytest.param(
+                    "tests.script_runner.parameter_inputs:str_or_int_parameter",
+                    [{"name": "my_str_or_int", "value": "hi there"}],
+                    "type given: str",
+                    id="str-or-int-given-str",
+                ),
+                pytest.param(
+                    "tests.script_runner.parameter_inputs:str_or_int_parameter",
+                    [{"name": "my_str_or_int", "value": "3"}],
+                    "type given: int",
+                    id="str-or-int-given-int",
+                ),
+            ]
+            if _PYDANTIC_VERSION > 1
+            else []
         ),
         pytest.param(
             "tests.script_runner.parameter_inputs:str_parameter_expects_jsonstr_dict",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -65,23 +65,17 @@ from hera.workflows.io.v1 import Output
             {},
             id="no-type-dict",
         ),
-        *(
-            [
-                pytest.param(
-                    "tests.script_runner.parameter_inputs:str_or_int_parameter",
-                    [{"name": "my_str_or_int", "value": "hi there"}],
-                    "type given: str",
-                    id="str-or-int-given-str",
-                ),
-                pytest.param(
-                    "tests.script_runner.parameter_inputs:str_or_int_parameter",
-                    [{"name": "my_str_or_int", "value": "3"}],
-                    "type given: int",
-                    id="str-or-int-given-int",
-                ),
-            ]
-            if _PYDANTIC_VERSION > 1
-            else []
+        pytest.param(
+            "tests.script_runner.parameter_inputs:str_or_int_parameter",
+            [{"name": "my_str_or_int", "value": "hi there"}],
+            "type given: str",
+            id="str-or-int-given-str",
+        ),
+        pytest.param(
+            "tests.script_runner.parameter_inputs:str_or_int_parameter",
+            [{"name": "my_str_or_int", "value": "3"}],
+            "type given: int",
+            id="str-or-int-given-int",
         ),
         pytest.param(
             "tests.script_runner.parameter_inputs:str_parameter_expects_jsonstr_dict",

--- a/tests/test_unit/test_shared_type_utils.py
+++ b/tests/test_unit/test_shared_type_utils.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Optional, Union
+from typing import List, NoReturn, Optional, Union
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -111,6 +111,7 @@ def test_get_unsubscripted_type(annotation, expected):
     "annotation, target, expected",
     [
         pytest.param(List[str], str, False, id="list-str-not-subtype-of-str"),
+        pytest.param(NoReturn, str, False, id="special-form-does-not-raise-error"),
         pytest.param(Optional[str], str, False, id="optional-str-not-subtype-of-str"),
         pytest.param(str, str, True, id="str-is-subtype-of-str"),
         pytest.param(Union[int, str], int, False, id="union-int-str-not-subtype-of-str"),
@@ -127,6 +128,7 @@ def test_origin_type_issubtype(annotation, target, expected):
     "annotation, target, expected",
     [
         pytest.param(List[str], str, False, id="list-str-not-supertype-of-str"),
+        pytest.param(NoReturn, str, False, id="special-form-does-not-raise-error"),
         pytest.param(Optional[str], str, True, id="optional-str-is-supertype-of-str"),
         pytest.param(str, str, True, id="str-is-supertype-of-str"),
         pytest.param(Union[int, str], int, True, id="union-int-str-is-supertype-of-int"),

--- a/tests/test_unit/test_shared_type_utils.py
+++ b/tests/test_unit/test_shared_type_utils.py
@@ -116,6 +116,7 @@ def test_get_unsubscripted_type(annotation, expected):
         pytest.param(str, str, True, id="str-is-subtype-of-str"),
         pytest.param(Union[int, str], int, False, id="union-int-str-not-subtype-of-str"),
         pytest.param(Optional[str], (str, NoneType), True, id="optional-str-is-subtype-of-optional-str"),
+        pytest.param(Annotated[Optional[str], "foo"], (str, NoneType), True, id="annotated-optional"),
         pytest.param(str, (str, NoneType), True, id="str-is-subtype-of-optional-str"),
         pytest.param(Union[int, str], (str, NoneType), False, id="union-int-str-not-subtype-of-optional-str"),
     ],
@@ -133,6 +134,7 @@ def test_origin_type_issubtype(annotation, target, expected):
         pytest.param(str, str, True, id="str-is-supertype-of-str"),
         pytest.param(Union[int, str], int, True, id="union-int-str-is-supertype-of-int"),
         pytest.param(Optional[str], NoneType, True, id="optional-str-is-supertype-of-nonetype"),
+        pytest.param(Annotated[Optional[str], "foo"], NoneType, True, id="annotated-optional"),
         pytest.param(str, NoneType, False, id="str-not-supertype-of-nonetype"),
     ],
 )


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [X] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
PR #1168 changed the logic of `map_runner_input` and `_parse` to no longer pass incoming values to `json.loads` if their annotated type was a union that included str, rather than only when given a subtype of `Optional[str]`. This makes it impossible to, for instance, pass an int to a `Union[str, int]`.

This PR splits `origin_type_issubclass` into two functions, `origin_type_issupertype` (which matches the previous behaviour) and `origin_type_issubtype`, and use the latter instead to restore the original behaviour.

Additionally, it fixes a bug where we were passing an annotation to `issubclass` without first checking if it's a type, resulting in a `TypeError` (partially addresses #1173).