### PR TITLE
Add missing volume claim to user-container example

### DIFF
--- a/docs/examples/workflows/misc/user_container.md
+++ b/docs/examples/workflows/misc/user_container.md
@@ -26,7 +26,19 @@ This example showcases the user of a user container with a volume mount.
         print("hi")
 
 
-    with Workflow(generate_name="sidecar-volume-mount-", entrypoint="d") as w:
+    with Workflow(
+        generate_name="sidecar-volume-mount-",
+        entrypoint="d",
+        volume_claim_templates=[
+            m.PersistentVolumeClaim(
+                metadata=m.ObjectMeta(name="something"),
+                spec=m.PersistentVolumeClaimSpec(
+                    access_modes=["ReadWriteOnce"],
+                    resources=m.ResourceRequirements(requests={"storage": "64Mi"}),
+                ),
+            )
+        ],
+    ) as w:
         with DAG(name="d"):
             foo()
     ```
@@ -61,5 +73,14 @@ This example showcases the user of a user container with a volume mount.
           volumeMounts:
           - mountPath: /whatever
             name: something
+      volumeClaimTemplates:
+      - metadata:
+          name: something
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 64Mi
     ```
 

--- a/examples/workflows/misc/user-container.yaml
+++ b/examples/workflows/misc/user-container.yaml
@@ -25,3 +25,12 @@ spec:
       volumeMounts:
       - mountPath: /whatever
         name: something
+  volumeClaimTemplates:
+  - metadata:
+      name: something
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 64Mi

--- a/examples/workflows/misc/user_container.py
+++ b/examples/workflows/misc/user_container.py
@@ -18,6 +18,18 @@ def foo():
     print("hi")
 
 
-with Workflow(generate_name="sidecar-volume-mount-", entrypoint="d") as w:
+with Workflow(
+    generate_name="sidecar-volume-mount-",
+    entrypoint="d",
+    volume_claim_templates=[
+        m.PersistentVolumeClaim(
+            metadata=m.ObjectMeta(name="something"),
+            spec=m.PersistentVolumeClaimSpec(
+                access_modes=["ReadWriteOnce"],
+                resources=m.ResourceRequirements(requests={"storage": m.Quantity(__root__="64Mi")}),
+            ),
+        )
+    ],
+) as w:
     with DAG(name="d"):
         foo()

--- a/examples/workflows/misc/user_container.py
+++ b/examples/workflows/misc/user_container.py
@@ -26,7 +26,7 @@ with Workflow(
             metadata=m.ObjectMeta(name="something"),
             spec=m.PersistentVolumeClaimSpec(
                 access_modes=["ReadWriteOnce"],
-                resources=m.ResourceRequirements(requests={"storage": m.Quantity(__root__="64Mi")}),
+                resources=m.ResourceRequirements(requests={"storage": "64Mi"}),
             ),
         )
     ],


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #973
- [ ] ~~Tests added~~ not needed here
- [ ] ~~Documentation/examples added~~ not needed here
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Following the volumes page in argo workflows document, updated user-container examples to have `volumeClaimTemplates`.
- https://argo-workflows.readthedocs.io/en/latest/walk-through/volumes/
