### PR TITLE
Support Literal types in script runner

### DIFF
--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -83,11 +83,16 @@ def get_workflow_annotation(annotation: Any) -> Optional[Union[Artifact, Paramet
     return metadata[0]
 
 
-def add_metadata_from_type(parameter: Parameter, annotation: Any) -> None:
-    if not parameter.enum:
-        type_ = unwrap_annotation(annotation)
-        if get_origin(type_) is Literal:
-            parameter.enum = list(get_args(type_))
+def set_enum_based_on_type(parameter: Parameter, annotation: Any) -> None:
+    """Sets the enum field of a Parameter based on its type annotation.
+
+    Currently, only supports Literals.
+    """
+    if parameter.enum:
+        return
+    type_ = unwrap_annotation(annotation)
+    if get_origin(type_) is Literal:
+        parameter.enum = list(get_args(type_))
 
 
 def construct_io_from_annotation(python_name: str, annotation: Any) -> Union[Parameter, Artifact]:
@@ -107,7 +112,7 @@ def construct_io_from_annotation(python_name: str, annotation: Any) -> Union[Par
 
     io.name = io.name or python_name
     if isinstance(io, Parameter):
-        add_metadata_from_type(io, annotation)
+        set_enum_based_on_type(io, annotation)
 
     return io
 

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Iterable,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
@@ -120,6 +121,8 @@ def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]])
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:
         return all(origin_type_issubtype(arg, type_) for arg in get_args(unwrapped_type))
+    if origin_type is Literal:
+        return all(isinstance(value, type_) for value in get_args(unwrapped_type))
     return isinstance(origin_type, type) and issubclass(origin_type, type_)
 
 

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -83,6 +83,13 @@ def get_workflow_annotation(annotation: Any) -> Optional[Union[Artifact, Paramet
     return metadata[0]
 
 
+def add_metadata_from_type(parameter: Parameter, annotation: Any) -> None:
+    if not parameter.enum:
+        type_ = unwrap_annotation(annotation)
+        if get_origin(type_) is Literal:
+            parameter.enum = list(get_args(type_))
+
+
 def construct_io_from_annotation(python_name: str, annotation: Any) -> Union[Parameter, Artifact]:
     """Constructs a Parameter or Artifact object based on annotations.
 

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -106,10 +106,8 @@ def construct_io_from_annotation(python_name: str, annotation: Any) -> Union[Par
         io = Parameter()
 
     io.name = io.name or python_name
-    if isinstance(io, Parameter) and not io.enum:
-        type_ = unwrap_annotation(annotation)
-        if get_origin(type_) is Literal:
-            io.enum = list(get_args(type_))
+    if isinstance(io, Parameter):
+        add_metadata_from_type(io, annotation)
 
     return io
 

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -48,6 +48,7 @@ from hera.shared._global_config import (
 )
 from hera.shared._pydantic import _PYDANTIC_VERSION, root_validator, validator
 from hera.shared._type_util import (
+    add_metadata_from_type,
     construct_io_from_annotation,
     get_workflow_annotation,
     is_subscripted,
@@ -379,6 +380,7 @@ def _get_parameters_from_callable(source: Callable) -> List[Parameter]:
             default = MISSING
 
         param = Parameter(name=p.name, default=default)
+        add_metadata_from_type(param, p.annotation)
         parameters.append(param)
 
     return parameters

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -48,11 +48,11 @@ from hera.shared._global_config import (
 )
 from hera.shared._pydantic import _PYDANTIC_VERSION, root_validator, validator
 from hera.shared._type_util import (
-    add_metadata_from_type,
     construct_io_from_annotation,
     get_workflow_annotation,
     is_subscripted,
     origin_type_issupertype,
+    set_enum_based_on_type,
 )
 from hera.shared.serialization import serialize
 from hera.workflows._context import _context
@@ -380,7 +380,7 @@ def _get_parameters_from_callable(source: Callable) -> List[Parameter]:
             default = MISSING
 
         param = Parameter(name=p.name, default=default)
-        add_metadata_from_type(param, p.annotation)
+        set_enum_based_on_type(param, p.annotation)
         parameters.append(param)
 
     return parameters

--- a/tests/script_annotations/annotated_literals.py
+++ b/tests/script_annotations/annotated_literals.py
@@ -1,0 +1,18 @@
+from typing import Annotated, Literal
+
+from hera.shared import global_config
+from hera.workflows import Parameter, Steps, Workflow, script
+
+global_config.experimental_features["script_annotations"] = True
+
+
+@script(constructor="runner")
+def literal_str(
+    my_str: Annotated[Literal["foo", "bar"], Parameter(name="my-str")],
+) -> Annotated[Literal[1, 2], Parameter(name="index")]:
+    return {"foo": 1, "bar": 2}[my_str]
+
+
+with Workflow(name="my-workflow", entrypoint="steps") as w:
+    with Steps(name="steps"):
+        literal_str()

--- a/tests/script_annotations/literals.py
+++ b/tests/script_annotations/literals.py
@@ -1,0 +1,13 @@
+from typing import Literal
+
+from hera.workflows import Steps, Workflow, script
+
+
+@script(constructor="runner")
+def literal_str(my_str: Literal["foo", "bar"]) -> Literal[1, 2]:
+    return {"foo": 1, "bar": 2}[my_str]
+
+
+with Workflow(name="my-workflow", entrypoint="steps") as w:
+    with Steps(name="steps"):
+        literal_str()

--- a/tests/script_annotations/pydantic_io_literals.py
+++ b/tests/script_annotations/pydantic_io_literals.py
@@ -1,0 +1,24 @@
+from typing import Literal
+
+from hera.shared import global_config
+from hera.workflows import Input, Output, Steps, Workflow, script
+
+global_config.experimental_features["script_pydantic_io"] = True
+
+
+class ExampleInput(Input):
+    my_str: Literal["foo", "bar"]
+
+
+class ExampleOutput(Output):
+    index: Literal[1, 2]
+
+
+@script(constructor="runner")
+def literal_str(input: ExampleInput) -> ExampleOutput:
+    return ExampleOutput(index={"foo": 1, "bar": 2}[input.my_str])
+
+
+with Workflow(name="my-workflow", entrypoint="steps") as w:
+    with Steps(name="steps"):
+        literal_str()

--- a/tests/script_runner/parameter_inputs.py
+++ b/tests/script_runner/parameter_inputs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Union
+from typing import Any, List, Literal, Union
 
 try:
     from typing import Annotated
@@ -54,6 +54,11 @@ def annotated_basic_types_with_other_metadata(
 
 
 @script()
+def annotated_str_literal(my_literal: Annotated[Literal["1", "2"], Parameter(name="str-literal")]) -> str:
+    return f"type given: {type(my_literal).__name__}"
+
+
+@script()
 def annotated_object(annotated_input_value: Annotated[Input, Parameter(name="input-value")]) -> Output:
     return Output(output=[annotated_input_value])
 
@@ -79,6 +84,11 @@ def no_type_parameter(my_anything) -> Any:
 @script()
 def str_or_int_parameter(my_str_or_int: Union[int, str]) -> str:
     return f"type given: {type(my_str_or_int).__name__}"
+
+
+@script()
+def str_literal(my_literal: Literal["1", "2"]) -> str:
+    return f"type given: {type(my_literal).__name__}"
 
 
 @script()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -78,6 +78,12 @@ from hera.workflows.io.v1 import Output
             id="str-or-int-given-int",
         ),
         pytest.param(
+            "tests.script_runner.parameter_inputs:str_literal",
+            [{"name": "my_literal", "value": "1"}],
+            "type given: str",
+            id="str-literal",
+        ),
+        pytest.param(
             "tests.script_runner.parameter_inputs:str_parameter_expects_jsonstr_dict",
             [{"name": "my_json_str", "value": json.dumps({"my": "dict"})}],
             {"my": "dict"},
@@ -88,6 +94,12 @@ from hera.workflows.io.v1 import Output
             [{"name": "my_json_str", "value": json.dumps([{"my": "dict"}])}],
             [{"my": "dict"}],
             id="str-json-param-as-list",
+        ),
+        pytest.param(
+            "tests.script_runner.parameter_inputs:annotated_str_literal",
+            [{"name": "my_literal", "value": "1"}],
+            "type given: str",
+            id="annotated-str-literal",
         ),
         pytest.param(
             "tests.script_runner.parameter_inputs:annotated_str_parameter_expects_jsonstr_dict",

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -486,10 +486,12 @@ def test_script_with_param(global_config_fixture, module_name):
         pytest.param("tests.script_annotations.pydantic_io_literals", "my_str", id="pydantic-io"),
     ],
 )
-def test_script_literals(global_config_fixture, module_name, input_name):
+@pytest.mark.parametrize("experimental_feature", ["", "script_annotations", "script_pydantic_io"])
+def test_script_literals(global_config_fixture, module_name, input_name, experimental_feature):
     """Test that Literals work correctly as direct type annotations."""
     # GIVEN
-    global_config_fixture.experimental_features["script_annotations"] = True
+    if experimental_feature:
+        global_config_fixture.experimental_features[experimental_feature] = True
 
     # Force a reload of the test module, as the runner performs "importlib.import_module", which
     # may fetch a cached version

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -182,6 +182,15 @@ def test_invalid_script_when_optional_parameter_does_not_have_default_value_5():
         _get_inputs_from_callable(unknown_annotations_ignored)
 
 
+def test_invalid_script_when_optional_parameter_does_not_have_default_value_6():
+    @script()
+    def unknown_annotations_ignored(my_optional_string: Annotated[Optional[str], Parameter(name="my-string")]) -> str:
+        return "Got: {}".format(my_optional_string)
+
+    with pytest.raises(ValueError, match="Optional parameter 'my_optional_string' must have a default value of None."):
+        _get_inputs_from_callable(unknown_annotations_ignored)
+
+
 def test_invalid_script_when_multiple_input_workflow_annotations_are_given():
     @script()
     def invalid_script(a_str: Annotated[str, Artifact(name="a_str"), Parameter(name="a_str")] = "123") -> str:

--- a/tests/test_unit/test_shared_type_utils.py
+++ b/tests/test_unit/test_shared_type_utils.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, NoReturn, Optional, Union
+from typing import List, Literal, NoReturn, Optional, Union
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -151,6 +151,10 @@ def test_get_unsubscripted_type(annotation, expected):
         pytest.param(Annotated[Optional[str], "foo"], (str, NoneType), True, id="annotated-optional"),
         pytest.param(str, (str, NoneType), True, id="str-is-subtype-of-optional-str"),
         pytest.param(Union[int, str], (str, NoneType), False, id="union-int-str-not-subtype-of-optional-str"),
+        pytest.param(Literal["foo", "bar"], (str, NoneType), True, id="literal-str-is-subtype-of-optional-str"),
+        pytest.param(Literal["foo", None], (str, NoneType), True, id="literal-none-is-subtype-of-optional-str"),
+        pytest.param(Literal[1, 2], (str, NoneType), False, id="literal-int-not-subtype-of-optional-str"),
+        pytest.param(Literal[1, "foo"], (str, NoneType), False, id="mixed-literal-not-subtype-of-optional-str"),
     ],
 )
 def test_origin_type_issubtype(annotation, target, expected):


### PR DESCRIPTION
**Pull Request Checklist**
- [X] Fixes #1173
- [X] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, the script runner does not support `Literal` types, as `origin_type_issubtype` does not special-case them, so `_is_str_kwarg_of` does not return True.

This PR adds supports for Literals to `origin_type_issubtype`, and additionally copies their values from the annotation into the `enum` field on input Parameters. It also combines two paths in `_get_inputs_from_callable` into one by using `construct_io_from_annotation` instead of having a fallback branch if `get_workflow_annotation` returns `None`; this fixes a bug where the default was being verified as None for optional strings only if there was no IO annotation.
