### PR TITLE
Remove override for `default` usage in `Parameter` annotations

### DIFF
--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -202,7 +202,6 @@ register_pre_build_hook = global_config.register_pre_build_hook
 _SCRIPT_ANNOTATIONS_FLAG = "script_annotations"
 _SCRIPT_PYDANTIC_IO_FLAG = "script_pydantic_io"
 _DECORATOR_SYNTAX_FLAG = "decorator_syntax"
-_SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG = "suppress_parameter_default_error"
 
 # A dictionary where each key is a flag that has a list of flags which supersede it, hence
 # the given flag key can also be switched on by any of the flags in the list. Using simple flat lists

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Type, Union
 
 if sys.version_info >= (3, 11):
@@ -8,7 +7,6 @@ else:
     from typing_extensions import Self
 
 
-from hera.shared import global_config
 from hera.shared._pydantic import _PYDANTIC_VERSION, FieldInfo, get_field_annotations, get_fields
 from hera.shared._type_util import construct_io_from_annotation, get_workflow_annotation
 from hera.shared.serialization import MISSING, serialize

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -9,7 +9,6 @@ else:
 
 
 from hera.shared import global_config
-from hera.shared._global_config import _SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG
 from hera.shared._pydantic import _PYDANTIC_VERSION, FieldInfo, get_field_annotations, get_fields
 from hera.shared._type_util import construct_io_from_annotation, get_workflow_annotation
 from hera.shared.serialization import MISSING, serialize
@@ -80,16 +79,9 @@ class InputMixin(BaseModel):
         for field, field_info, param in _construct_io_from_fields(cls):
             if isinstance(param, Parameter):
                 if param.default is not None:
-                    warnings.warn(
-                        "Using the default field for Parameters in Annotations is deprecated since v5.16"
-                        "and will be removed in a future minor version, use a Python default value instead. "
+                    raise ValueError(
+                        "default cannot be set via the Parameter's default, use a Python default value instead."
                     )
-                    if not global_config.experimental_features[_SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG]:
-                        raise ValueError(
-                            "default cannot be set via the Parameter's default, use a Python default value instead. "
-                            "You can suppress this error by setting "
-                            f'global_config.experimental_features["{_SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG}"] = True'
-                        )
                 if object_override:
                     param.default = serialize(getattr(object_override, field))
                 elif field_info.default is not None and field_info.default != PydanticUndefined:  # type: ignore

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -9,7 +9,6 @@ import copy
 import inspect
 import sys
 import textwrap
-import warnings
 from abc import abstractmethod
 from functools import wraps
 from typing import (

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -43,7 +43,6 @@ from hera.shared import BaseMixin, global_config
 from hera.shared._global_config import (
     _SCRIPT_ANNOTATIONS_FLAG,
     _SCRIPT_PYDANTIC_IO_FLAG,
-    _SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG,
     _flag_enabled,
 )
 from hera.shared._pydantic import _PYDANTIC_VERSION, root_validator, validator
@@ -509,23 +508,10 @@ def _get_inputs_from_callable(source: Callable) -> Tuple[List[Parameter], List[A
                 artifacts.append(io)
             elif isinstance(io, Parameter):
                 if io.default is not None:
-                    # TODO: in 5.18 remove the flag check and `warn`, and raise the ValueError directly (minus "flag" text)
-                    warnings.warn(
-                        "Using the default field for Parameters in Annotations is deprecated since v5.16"
-                        "and will be removed in a future minor version, use a Python default value instead. "
+                    raise ValueError(
+                        "default cannot be set via the Parameter's default, use a Python default value instead."
                     )
-                    if not global_config.experimental_features[_SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG]:
-                        raise ValueError(
-                            "default cannot be set via the Parameter's default, use a Python default value instead"
-                            "You can suppress this error by setting "
-                            f'global_config.experimental_features["{_SUPPRESS_PARAMETER_DEFAULT_ERROR_FLAG}"] = True'
-                        )
                 if func_param.default != inspect.Parameter.empty:
-                    # TODO: remove this check in 5.18:
-                    if io.default is not None:
-                        raise ValueError(
-                            "default cannot be set via both the function parameter default and the Parameter's default"
-                        )
                     io.default = serialize(func_param.default)
 
                 if origin_type_issupertype(func_param.annotation, NoneType) and io.default != "null":

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -7,6 +7,7 @@ import pytest
 
 from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.workflows import Workflow, script
+from hera.workflows.io import Input
 from hera.workflows.parameter import Parameter
 from hera.workflows.steps import Steps
 
@@ -71,6 +72,30 @@ def test_parameter_default_throws_a_value_error(global_config_fixture):
     @script()
     def echo_int(an_int: Annotated[int, Parameter(default=1)]):
         print(an_int)
+
+    global_config_fixture.experimental_features["script_annotations"] = True
+    with pytest.raises(ValueError) as e:
+        with Workflow(generate_name="test-default-", entrypoint="my-steps") as w:
+            with Steps(name="my-steps"):
+                echo_int()
+
+        w.to_dict()
+
+    assert ("default cannot be set via the Parameter's default, use a Python default value instead") in str(e.value)
+
+
+def test_pydantic_input_with_default_throws_a_value_error(global_config_fixture):
+    """Test asserting that it is not possible to define default in the annotation in a Hera Input class."""
+
+    # GIVEN
+    global_config_fixture.experimental_features["script_pydantic_io"] = True
+
+    class ExampleInput(Input):
+        an_int: Annotated[int, Parameter(default=1)]
+
+    @script()
+    def echo_int(pydantic_input: ExampleInput):
+        print(pydantic_input.an_int)
 
     global_config_fixture.experimental_features["script_annotations"] = True
     with pytest.raises(ValueError) as e:

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -64,33 +64,10 @@ def test_script_annotations_artifact_regression(module_name, global_config_fixtu
     _compare_workflows(workflow_old, output_old, output_new)
 
 
-def test_double_default_throws_a_value_error(global_config_fixture):
-    """Test asserting that it is not possible to define default in the annotation and normal Python."""
+def test_parameter_default_throws_a_value_error(global_config_fixture):
+    """Test asserting that it is not possible to define default in the annotation."""
 
     # GIVEN
-    global_config_fixture.experimental_features["suppress_parameter_default_error"] = True
-
-    @script()
-    def echo_int(an_int: Annotated[int, Parameter(default=1)] = 2):
-        print(an_int)
-
-    global_config_fixture.experimental_features["script_annotations"] = True
-    with pytest.raises(ValueError) as e:
-        with Workflow(generate_name="test-default-", entrypoint="my-steps") as w:
-            with Steps(name="my-steps"):
-                echo_int()
-
-        w.to_dict()
-
-    assert "default cannot be set via both the function parameter default and the Parameter's default" in str(e.value)
-
-
-def test_parameter_default_without_suppression_throws_a_value_error(global_config_fixture):
-    """Test asserting that it is not possible to define default in the annotation and normal Python."""
-
-    # GIVEN
-    global_config_fixture.experimental_features["suppress_parameter_default_error"] = False
-
     @script()
     def echo_int(an_int: Annotated[int, Parameter(default=1)]):
         print(an_int)
@@ -103,11 +80,7 @@ def test_parameter_default_without_suppression_throws_a_value_error(global_confi
 
         w.to_dict()
 
-    assert (
-        "default cannot be set via the Parameter's default, use a Python default value instead"
-        "You can suppress this error by setting "
-        'global_config.experimental_features["suppress_parameter_default_error"] = True'
-    ) in str(e.value)
+    assert ("default cannot be set via the Parameter's default, use a Python default value instead") in str(e.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/workflow_decorators/steps.py
+++ b/tests/workflow_decorators/steps.py
@@ -22,7 +22,7 @@ def setup() -> SetupOutput:
 
 
 class ConcatInput(Input):
-    word_a: Annotated[str, Parameter(name="word_a", default="")]
+    word_a: Annotated[str, Parameter(name="word_a")] = ""
     word_b: str
 
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #812 (final step)
- [x] Tests adjusted
- [x] Documentation/examples added previously
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, when using the default attribute in Parameters (`Parameter(default="x")`) users can supress the error with the `suppress_parameter_default_error` experimental feature flag. If users have not updated their code (which is a very easy change) they will now get errors when upgrading Hera, the warning has been there for 2 minor versions and this is an experimental feature - we will be able to graduate it in the next version once this is released.