### PR TITLE
Graduate script annotations

### DIFF
--- a/docs/examples/workflows/dags/callable_dag_with_param_get.md
+++ b/docs/examples/workflows/dags/callable_dag_with_param_get.md
@@ -71,6 +71,11 @@
           parameters:
           - name: name
         name: hello-with-output
+        outputs:
+          parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/hera-outputs/parameters/output-message
         script:
           args:
           - -m
@@ -79,6 +84,9 @@
           - examples.workflows.dags.callable_dag_with_param_get:hello_with_output
           command:
           - python
+          env:
+          - name: hera__outputs_directory
+            value: /tmp/hera-outputs
           image: python:3.9
           source: '{{inputs.parameters}}'
       - dag:

--- a/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
@@ -89,8 +89,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -91,8 +91,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io
@@ -113,8 +111,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -122,8 +122,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io
@@ -147,8 +145,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/new_decorators_basic_script.md
+++ b/docs/examples/workflows/experimental/new_decorators_basic_script.md
@@ -59,8 +59,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io
@@ -83,8 +81,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
+++ b/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
@@ -95,8 +95,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io
@@ -118,8 +116,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/script_runner_io.md
+++ b/docs/examples/workflows/experimental/script_runner_io.md
@@ -108,8 +108,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io
@@ -143,8 +141,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/experimental/template_sets.md
+++ b/docs/examples/workflows/experimental/template_sets.md
@@ -50,8 +50,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           - name: hera__script_pydantic_io

--- a/docs/examples/workflows/scripts/callable_script.md
+++ b/docs/examples/workflows/scripts/callable_script.md
@@ -23,9 +23,6 @@
     # and serializes the output.
     global_config.image = "my-image-with-python-source-code-and-dependencies"
     global_config.set_class_defaults(Script, constructor="runner")
-    # Script annotations is still an experimental feature and we need to explicitly opt in to it
-    # Note that experimental features are subject to breaking changes in future releases of the same major version
-    global_config.experimental_features["script_annotations"] = True
 
 
     # An optional pydantic input type
@@ -157,9 +154,6 @@
           - examples.workflows.scripts.callable_script:my_function
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: my-image-with-python-source-code-and-dependencies
           source: '{{inputs.parameters}}'
       - inputs:
@@ -174,9 +168,6 @@
           - examples.workflows.scripts.callable_script:str_function
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: my-image-with-python-source-code-and-dependencies
           source: '{{inputs.parameters}}'
       - inputs:
@@ -191,9 +182,6 @@
           - examples.workflows.scripts.callable_script:another_function
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: my-image-with-python-source-code-and-dependencies
           source: '{{inputs.parameters}}'
       - inputs:
@@ -213,9 +201,6 @@
           - examples.workflows.scripts.callable_script:function_kebab
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: my-image-with-python-source-code-and-dependencies
           source: '{{inputs.parameters}}'
       - inputs:
@@ -230,9 +215,6 @@
           - examples.workflows.scripts.callable_script:function_kebab_object
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: my-image-with-python-source-code-and-dependencies
           source: '{{inputs.parameters}}'
     ```

--- a/docs/examples/workflows/scripts/callable_script_v1.md
+++ b/docs/examples/workflows/scripts/callable_script_v1.md
@@ -26,9 +26,6 @@
     # and serializes the output.
     global_config.image = "my-image-with-python-source-code-and-dependencies"
     global_config.set_class_defaults(Script, constructor=RunnerScriptConstructor(pydantic_mode=1))
-    # Script annotations is still an experimental feature and we need to explicitly opt in to it
-    # Note that experimental features are subject to breaking changes in future releases of the same major version
-    global_config.experimental_features["script_annotations"] = True
 
 
     # An optional pydantic input type
@@ -161,8 +158,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__pydantic_mode
             value: '1'
           image: my-image-with-python-source-code-and-dependencies
@@ -180,8 +175,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__pydantic_mode
             value: '1'
           image: my-image-with-python-source-code-and-dependencies
@@ -199,8 +192,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__pydantic_mode
             value: '1'
           image: my-image-with-python-source-code-and-dependencies
@@ -223,8 +214,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__pydantic_mode
             value: '1'
           image: my-image-with-python-source-code-and-dependencies
@@ -242,8 +231,6 @@
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__pydantic_mode
             value: '1'
           image: my-image-with-python-source-code-and-dependencies

--- a/docs/examples/workflows/scripts/script_annotations_artifact_custom_volume.md
+++ b/docs/examples/workflows/scripts/script_annotations_artifact_custom_volume.md
@@ -10,7 +10,6 @@ This example will reuse the outputs volume across script steps.
     ```python linenums="1"
     from typing import Annotated
 
-    from hera.shared import global_config
     from hera.workflows import (
         Artifact,
         EmptyDirVolume,
@@ -23,8 +22,6 @@ This example will reuse the outputs volume across script steps.
     )
     from hera.workflows.artifact import ArtifactLoader
     from hera.workflows.volume import Volume
-
-    global_config.experimental_features["script_annotations"] = True
 
 
     @script(
@@ -135,12 +132,10 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_custom_volume:output_artifact_empty_dir
+          - examples.workflows.scripts.script_annotations_artifact_custom_volume:output_artifact_empty_dir
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /mnt/empty/dir
           image: python:3.9
@@ -161,12 +156,9 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_custom_volume:use_artifact
+          - examples.workflows.scripts.script_annotations_artifact_custom_volume:use_artifact
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
       - inputs:
@@ -182,12 +174,10 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_custom_volume:output_artifact_existing_vol
+          - examples.workflows.scripts.script_annotations_artifact_custom_volume:output_artifact_existing_vol
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /mnt/here
           image: python:3.9
@@ -205,12 +195,9 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_custom_volume:use_artifact_existing_vol
+          - examples.workflows.scripts.script_annotations_artifact_custom_volume:use_artifact_existing_vol
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
           volumeMounts:

--- a/docs/examples/workflows/scripts/script_annotations_artifact_loaders.md
+++ b/docs/examples/workflows/scripts/script_annotations_artifact_loaders.md
@@ -12,10 +12,7 @@
     from pathlib import Path
     from typing import Annotated, Dict
 
-    from hera.shared import global_config
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
-
-    global_config.experimental_features["script_annotations"] = True
 
 
     @script(constructor="runner")
@@ -91,12 +88,10 @@
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_loaders:output_dict_artifact
+          - examples.workflows.scripts.script_annotations_artifact_loaders:output_dict_artifact
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           image: python:3.9
@@ -115,12 +110,9 @@
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_loaders:artifact_loaders
+          - examples.workflows.scripts.script_annotations_artifact_loaders:artifact_loaders
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
     ```

--- a/docs/examples/workflows/scripts/script_annotations_artifact_outputs_defaults.md
+++ b/docs/examples/workflows/scripts/script_annotations_artifact_outputs_defaults.md
@@ -1,4 +1,4 @@
-# Script Annotations Artifact Passing
+# Script Annotations Artifact Outputs Defaults
 
 
 
@@ -8,20 +8,17 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
-    from pathlib import Path
     from typing import Annotated
 
-    from hera.shared import global_config
     from hera.workflows import (
         Artifact,
-        ArtifactLoader,
         Parameter,
         Steps,
         Workflow,
         script,
     )
-
-    global_config.experimental_features["script_annotations"] = True
+    from hera.workflows.artifact import ArtifactLoader
+    from hera.workflows.volume import Volume
 
 
     @script(constructor="runner")
@@ -35,16 +32,20 @@ This example will reuse the outputs volume across script steps.
     def use_artifact(
         successor_in: Annotated[
             int,
-            Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
+            Artifact(
+                name="successor_in",
+                path="/tmp/file",
+                loader=ArtifactLoader.json,
+            ),
         ],
     ):
         print(successor_in)
-        print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
     with Workflow(
-        generate_name="annotations-artifact-passing",
+        generate_name="test-output-annotations-",
         entrypoint="my-steps",
+        volumes=[Volume(name="my-vol", size="1Gi")],
     ) as w:
         with Steps(name="my-steps") as s:
             out = output_artifact(arguments={"a_number": 3})
@@ -57,7 +58,7 @@ This example will reuse the outputs volume across script steps.
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow
     metadata:
-      generateName: annotations-artifact-passing
+      generateName: test-output-annotations-
     spec:
       entrypoint: my-steps
       templates:
@@ -88,12 +89,10 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_passing:output_artifact
+          - examples.workflows.scripts.script_annotations_artifact_outputs_defaults:output_artifact
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           image: python:3.9
@@ -101,20 +100,26 @@ This example will reuse the outputs volume across script steps.
       - inputs:
           artifacts:
           - name: successor_in
-            path: /my-path
+            path: /tmp/file
         name: use-artifact
         script:
           args:
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_passing:use_artifact
+          - examples.workflows.scripts.script_annotations_artifact_outputs_defaults:use_artifact
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
+      volumeClaimTemplates:
+      - metadata:
+          name: my-vol
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
     ```
 

--- a/docs/examples/workflows/scripts/script_annotations_artifact_passing.md
+++ b/docs/examples/workflows/scripts/script_annotations_artifact_passing.md
@@ -1,4 +1,4 @@
-# Script Annotations Artifact Outputs Defaults
+# Script Annotations Artifact Passing
 
 
 
@@ -8,20 +8,17 @@ This example will reuse the outputs volume across script steps.
 === "Hera"
 
     ```python linenums="1"
+    from pathlib import Path
     from typing import Annotated
 
-    from hera.shared import global_config
     from hera.workflows import (
         Artifact,
+        ArtifactLoader,
         Parameter,
         Steps,
         Workflow,
         script,
     )
-    from hera.workflows.artifact import ArtifactLoader
-    from hera.workflows.volume import Volume
-
-    global_config.experimental_features["script_annotations"] = True
 
 
     @script(constructor="runner")
@@ -35,20 +32,16 @@ This example will reuse the outputs volume across script steps.
     def use_artifact(
         successor_in: Annotated[
             int,
-            Artifact(
-                name="successor_in",
-                path="/tmp/file",
-                loader=ArtifactLoader.json,
-            ),
+            Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
         ],
     ):
         print(successor_in)
+        print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
     with Workflow(
-        generate_name="test-output-annotations-",
+        generate_name="annotations-artifact-passing",
         entrypoint="my-steps",
-        volumes=[Volume(name="my-vol", size="1Gi")],
     ) as w:
         with Steps(name="my-steps") as s:
             out = output_artifact(arguments={"a_number": 3})
@@ -61,7 +54,7 @@ This example will reuse the outputs volume across script steps.
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow
     metadata:
-      generateName: test-output-annotations-
+      generateName: annotations-artifact-passing
     spec:
       entrypoint: my-steps
       templates:
@@ -92,12 +85,10 @@ This example will reuse the outputs volume across script steps.
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_outputs_defaults:output_artifact
+          - examples.workflows.scripts.script_annotations_artifact_passing:output_artifact
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           image: python:3.9
@@ -105,29 +96,17 @@ This example will reuse the outputs volume across script steps.
       - inputs:
           artifacts:
           - name: successor_in
-            path: /tmp/file
+            path: /my-path
         name: use-artifact
         script:
           args:
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_artifact_outputs_defaults:use_artifact
+          - examples.workflows.scripts.script_annotations_artifact_passing:use_artifact
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
-      volumeClaimTemplates:
-      - metadata:
-          name: my-vol
-        spec:
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
     ```
 

--- a/docs/examples/workflows/scripts/script_annotations_inputs.md
+++ b/docs/examples/workflows/scripts/script_annotations_inputs.md
@@ -10,10 +10,7 @@
     ```python linenums="1"
     from typing import Annotated, Dict
 
-    from hera.shared import global_config
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
-
-    global_config.experimental_features["script_annotations"] = True
 
 
     @script(constructor="runner")
@@ -100,12 +97,10 @@
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_inputs:output_dict_artifact
+          - examples.workflows.scripts.script_annotations_inputs:output_dict_artifact
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
           image: python:3.9
@@ -132,12 +127,9 @@
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_inputs:echo_all
+          - examples.workflows.scripts.script_annotations_inputs:echo_all
           command:
           - python
-          env:
-          - name: hera__script_annotations
-            value: ''
           image: python:3.9
           source: '{{inputs.parameters}}'
     ```

--- a/docs/examples/workflows/scripts/script_annotations_outputs.md
+++ b/docs/examples/workflows/scripts/script_annotations_outputs.md
@@ -14,8 +14,6 @@
     from hera.shared import global_config
     from hera.workflows import Artifact, Parameter, RunnerScriptConstructor, Steps, Workflow, script
 
-    global_config.experimental_features["script_annotations"] = True
-
     global_config.set_class_defaults(RunnerScriptConstructor, outputs_directory="/tmp/user/chosen/outputs")
 
 
@@ -75,12 +73,10 @@
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_annotations_outputs:script_param_artifact_in_function_signature_and_return_type
+          - examples.workflows.scripts.script_annotations_outputs:script_param_artifact_in_function_signature_and_return_type
           command:
           - python
           env:
-          - name: hera__script_annotations
-            value: ''
           - name: hera__outputs_directory
             value: /tmp/user/chosen/outputs
           image: python:3.9

--- a/docs/user-guides/script-annotations.md
+++ b/docs/user-guides/script-annotations.md
@@ -147,8 +147,7 @@ be printed to stdout.
 
 Script annotations can work on top of the `RunnerScriptConstructor` for name aliasing of function
 parameters, in particular to allow a public `kebab-case` parameter, while using a `snake_case`
-Python function parameter. When using a `RunnerScriptConstructor`, an environment variable
-`hera__script_annotations` will be added to the Script template (visible in the exported YAML file).
+Python function parameter.
 
 ## Outputs
 

--- a/docs/user-guides/script-annotations.md
+++ b/docs/user-guides/script-annotations.md
@@ -1,15 +1,8 @@
 # Script Annotations
 
-Annotation syntax is an experimental feature that uses `typing.Annotated` to declare `Parameters` and `Artifacts` as
-metadata on the input and output types of a `script` function. This simplifies script functions with parameters and
-artifacts that require additional fields such as a `description`, and allows Hera to automatically infer fields such as
-`name` and `path`.
-
-This feature must be enabled by setting the `experimental_feature` flag `script_annotations` on the global config.
-
-```py
-global_config.experimental_features["script_annotations"] = True
-```
+Annotation syntax uses `typing.Annotated` to declare `Parameters` and `Artifacts` as metadata on the input and output
+types of a `script` function. This simplifies script functions with parameters and artifacts that require additional
+fields such as a `description`, and allows Hera to automatically infer fields such as `name` and `path`.
 
 ## Parameters
 
@@ -167,7 +160,7 @@ There are two ways to specify output Artifacts and Parameters.
 
 Function return annotations can be used to specify the output type information for output Artifacts and Parameters, and
 the function should return a value or tuple. An example can be seen
-[here](../examples/workflows/experimental/script_annotations_outputs.md).
+[here](../examples/workflows/scripts/script_annotations_outputs.md).
 
 For a simple hello world output artifact example we currently have:
 

--- a/docs/user-guides/script-annotations.md
+++ b/docs/user-guides/script-annotations.md
@@ -6,7 +6,7 @@ fields such as a `description`, and allows Hera to automatically infer fields su
 
 ## Parameters
 
-In Hera, we can currently specify inputs inside the `@script` decorator as follows:
+In Hera, we can specify inputs inside the `@script` decorator as follows:
 
 ```python
 @script(
@@ -45,9 +45,8 @@ variable name if not provided (when exporting to YAML or viewing in the Argo UI,
 
 > Note: `Artifact` annotations are only supported when used with the `RunnerScriptConstructor`.
 
-The feature is even more powerful for `Artifact`s. In Hera we are currently able to specify `Artifact`s in `inputs`, but
-the given path is not programmatically linked to the code within the function unless defined outside the scope of the
-function:
+The feature is even more powerful for `Artifact`s. In Hera we are able to specify `Artifact`s in `inputs`, but the given
+path is not programmatically linked to the code within the function unless defined outside the scope of the function:
 
 ```python
 @script(inputs=Artifact(name="my-artifact", path="/tmp/file"))

--- a/docs/walk-through/advanced-hera-features.md
+++ b/docs/walk-through/advanced-hera-features.md
@@ -1,7 +1,7 @@
 # Advanced Hera Features
 
 This section is used to publicize Hera's features beyond the essentials covered in the walk through. Note that these
-features do not exist in Argo as they are specific to the `hera` module.
+features do not exist in Argo as they are specific to Hera.
 
 ## Pre-Build Hooks
 
@@ -104,21 +104,6 @@ usually announce changes in [the Hera slack channel](https://cloud-native.slack.
 
 ## Currently supported experimental features:
 
-### Script Annotations
-
-Annotation syntax using `typing.Annotated` is supported for `Parameter`s and `Artifact`s as inputs and outputs for
-functions decorated as `scripts`. They use `Annotated` as the type in the function parameters and allow us to simplify
-writing scripts with parameters and artifacts that require additional fields such as a `description` or alternative
-`name`.
-
-This feature can be enabled by setting the `experimental_feature` flag `script_annotations`
-
-```py
-global_config.experimental_features["script_annotations"] = True
-```
-
-Read the full guide on script annotations in [the script user guide](../user-guides/script-annotations.md).
-
 ### Script IO Models
 
 Hera provides Pydantic models for you to create subclasses from, which allow you to more easily declare script template
@@ -159,7 +144,7 @@ Once an experimental feature is robust and reliable, we "graduate" them to allow
 `experimental_features` flag of the `global_config`. This comes with better support and guarantees for their feature
 set. We list graduated features here so you can keep up to date.
 
-### `RunnerScriptConstructor`
+### `RunnerScriptConstructor` (since 5.10)
 
 The `RunnerScriptConstructor` found in `hera.workflows.script` and seen in the
 [callable script example](../examples/workflows/scripts/callable_script.md) is a robust way to run Python functions on
@@ -168,3 +153,12 @@ source code's functions, dependencies, and Hera itself are available to run. The
 compatible with Pydantic so supports deserializing inputs to Python objects and serializing outputs to json strings.
 
 Read [the Script Guide](../user-guides/script-basics.md#runnerscriptconstructor) to learn more!
+
+### Script Annotations (since 5.19)
+
+Annotation syntax using `typing.Annotated` is supported for `Parameter`s and `Artifact`s as inputs and outputs for
+functions decorated as `scripts`. They use `Annotated` as the type in the function parameters and allow us to simplify
+writing scripts with parameters and artifacts that require additional fields such as a `description` or alternative
+`name`.
+
+Read the full guide on script annotations in [the script user guide](../user-guides/script-annotations.md).

--- a/examples/workflows/dags/callable-dag-with-param-get.yaml
+++ b/examples/workflows/dags/callable-dag-with-param-get.yaml
@@ -26,6 +26,11 @@ spec:
       parameters:
       - name: name
     name: hello-with-output
+    outputs:
+      parameters:
+      - name: output-message
+        valueFrom:
+          path: /tmp/hera-outputs/parameters/output-message
     script:
       args:
       - -m
@@ -34,6 +39,9 @@ spec:
       - examples.workflows.dags.callable_dag_with_param_get:hello_with_output
       command:
       - python
+      env:
+      - name: hera__outputs_directory
+        value: /tmp/hera-outputs
       image: python:3.9
       source: '{{inputs.parameters}}'
   - dag:

--- a/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
@@ -25,8 +25,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
@@ -20,8 +20,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
@@ -42,8 +40,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/new-dag-decorator-params.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-params.yaml
@@ -26,8 +26,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
@@ -51,8 +49,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/new-decorators-basic-script.yaml
+++ b/examples/workflows/experimental/new-decorators-basic-script.yaml
@@ -18,8 +18,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
@@ -42,8 +40,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/new-steps-decorator-with-parallel-steps.yaml
+++ b/examples/workflows/experimental/new-steps-decorator-with-parallel-steps.yaml
@@ -23,8 +23,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
@@ -46,8 +44,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/script-runner-io.yaml
+++ b/examples/workflows/experimental/script-runner-io.yaml
@@ -36,8 +36,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io
@@ -71,8 +69,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/experimental/template-sets.yaml
+++ b/examples/workflows/experimental/template-sets.yaml
@@ -14,8 +14,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       - name: hera__script_pydantic_io

--- a/examples/workflows/scripts/callable-script-v1.yaml
+++ b/examples/workflows/scripts/callable-script-v1.yaml
@@ -52,8 +52,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__pydantic_mode
         value: '1'
       image: my-image-with-python-source-code-and-dependencies
@@ -71,8 +69,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__pydantic_mode
         value: '1'
       image: my-image-with-python-source-code-and-dependencies
@@ -90,8 +86,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__pydantic_mode
         value: '1'
       image: my-image-with-python-source-code-and-dependencies
@@ -114,8 +108,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__pydantic_mode
         value: '1'
       image: my-image-with-python-source-code-and-dependencies
@@ -133,8 +125,6 @@ spec:
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__pydantic_mode
         value: '1'
       image: my-image-with-python-source-code-and-dependencies

--- a/examples/workflows/scripts/callable-script.yaml
+++ b/examples/workflows/scripts/callable-script.yaml
@@ -51,9 +51,6 @@ spec:
       - examples.workflows.scripts.callable_script:my_function
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: my-image-with-python-source-code-and-dependencies
       source: '{{inputs.parameters}}'
   - inputs:
@@ -68,9 +65,6 @@ spec:
       - examples.workflows.scripts.callable_script:str_function
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: my-image-with-python-source-code-and-dependencies
       source: '{{inputs.parameters}}'
   - inputs:
@@ -85,9 +79,6 @@ spec:
       - examples.workflows.scripts.callable_script:another_function
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: my-image-with-python-source-code-and-dependencies
       source: '{{inputs.parameters}}'
   - inputs:
@@ -107,9 +98,6 @@ spec:
       - examples.workflows.scripts.callable_script:function_kebab
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: my-image-with-python-source-code-and-dependencies
       source: '{{inputs.parameters}}'
   - inputs:
@@ -124,8 +112,5 @@ spec:
       - examples.workflows.scripts.callable_script:function_kebab_object
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: my-image-with-python-source-code-and-dependencies
       source: '{{inputs.parameters}}'

--- a/examples/workflows/scripts/callable_script.py
+++ b/examples/workflows/scripts/callable_script.py
@@ -13,9 +13,6 @@ from hera.workflows import Parameter, Script, Steps, Workflow, script
 # and serializes the output.
 global_config.image = "my-image-with-python-source-code-and-dependencies"
 global_config.set_class_defaults(Script, constructor="runner")
-# Script annotations is still an experimental feature and we need to explicitly opt in to it
-# Note that experimental features are subject to breaking changes in future releases of the same major version
-global_config.experimental_features["script_annotations"] = True
 
 
 # An optional pydantic input type

--- a/examples/workflows/scripts/callable_script_v1.py
+++ b/examples/workflows/scripts/callable_script_v1.py
@@ -16,9 +16,6 @@ from hera.workflows import Parameter, RunnerScriptConstructor, Script, Steps, Wo
 # and serializes the output.
 global_config.image = "my-image-with-python-source-code-and-dependencies"
 global_config.set_class_defaults(Script, constructor=RunnerScriptConstructor(pydantic_mode=1))
-# Script annotations is still an experimental feature and we need to explicitly opt in to it
-# Note that experimental features are subject to breaking changes in future releases of the same major version
-global_config.experimental_features["script_annotations"] = True
 
 
 # An optional pydantic input type

--- a/examples/workflows/scripts/script-annotations-artifact-custom-volume.yaml
+++ b/examples/workflows/scripts/script-annotations-artifact-custom-volume.yaml
@@ -40,12 +40,10 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_custom_volume:output_artifact_empty_dir
+      - examples.workflows.scripts.script_annotations_artifact_custom_volume:output_artifact_empty_dir
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /mnt/empty/dir
       image: python:3.9
@@ -66,12 +64,9 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_custom_volume:use_artifact
+      - examples.workflows.scripts.script_annotations_artifact_custom_volume:use_artifact
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'
   - inputs:
@@ -87,12 +82,10 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_custom_volume:output_artifact_existing_vol
+      - examples.workflows.scripts.script_annotations_artifact_custom_volume:output_artifact_existing_vol
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /mnt/here
       image: python:3.9
@@ -110,12 +103,9 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_custom_volume:use_artifact_existing_vol
+      - examples.workflows.scripts.script_annotations_artifact_custom_volume:use_artifact_existing_vol
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'
       volumeMounts:

--- a/examples/workflows/scripts/script-annotations-artifact-loaders.yaml
+++ b/examples/workflows/scripts/script-annotations-artifact-loaders.yaml
@@ -16,18 +16,13 @@ spec:
     - - arguments:
           artifacts:
           - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
-            name: my-artifact
+            name: my-artifact-path
           - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
-            name: my-artifact-no-path
-          parameters:
-          - name: an_int
-            value: '1'
-          - name: a_bool
-            value: 'true'
-          - name: a_string
-            value: a
-        name: echo-all
-        template: echo-all
+            name: my-artifact-as-str
+          - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
+            name: my-artifact-as-json
+        name: artifact-loaders
+        template: artifact-loaders
   - inputs:
       parameters:
       - name: a_number
@@ -41,43 +36,30 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_inputs:output_dict_artifact
+      - examples.workflows.scripts.script_annotations_artifact_loaders:output_dict_artifact
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       image: python:3.9
       source: '{{inputs.parameters}}'
   - inputs:
       artifacts:
-      - name: my-artifact
-        path: /tmp/file
-      - name: my-artifact-no-path
-        path: /tmp/hera-inputs/artifacts/my-artifact-no-path
-      parameters:
-      - default: '1'
-        description: an_int parameter
-        name: an_int
-      - default: 'true'
-        description: a_bool parameter
-        name: a_bool
-      - default: a
-        description: a_string parameter
-        name: a_string
-    name: echo-all
+      - name: my-artifact-path
+        path: /tmp/hera-inputs/artifacts/my-artifact-path
+      - name: my-artifact-as-str
+        path: /tmp/hera-inputs/artifacts/my-artifact-as-str
+      - name: my-artifact-as-json
+        path: /tmp/hera-inputs/artifacts/my-artifact-as-json
+    name: artifact-loaders
     script:
       args:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_inputs:echo_all
+      - examples.workflows.scripts.script_annotations_artifact_loaders:artifact_loaders
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'

--- a/examples/workflows/scripts/script-annotations-artifact-outputs-defaults.yaml
+++ b/examples/workflows/scripts/script-annotations-artifact-outputs-defaults.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: annotations-artifact-passing
+  generateName: test-output-annotations-
 spec:
   entrypoint: my-steps
   templates:
@@ -32,12 +32,10 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_passing:output_artifact
+      - examples.workflows.scripts.script_annotations_artifact_outputs_defaults:output_artifact
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       image: python:3.9
@@ -45,18 +43,24 @@ spec:
   - inputs:
       artifacts:
       - name: successor_in
-        path: /my-path
+        path: /tmp/file
     name: use-artifact
     script:
       args:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_passing:use_artifact
+      - examples.workflows.scripts.script_annotations_artifact_outputs_defaults:use_artifact
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'
+  volumeClaimTemplates:
+  - metadata:
+      name: my-vol
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi

--- a/examples/workflows/scripts/script-annotations-artifact-passing.yaml
+++ b/examples/workflows/scripts/script-annotations-artifact-passing.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: test-output-annotations-
+  generateName: annotations-artifact-passing
 spec:
   entrypoint: my-steps
   templates:
@@ -32,12 +32,10 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_outputs_defaults:output_artifact
+      - examples.workflows.scripts.script_annotations_artifact_passing:output_artifact
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       image: python:3.9
@@ -45,27 +43,15 @@ spec:
   - inputs:
       artifacts:
       - name: successor_in
-        path: /tmp/file
+        path: /my-path
     name: use-artifact
     script:
       args:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_outputs_defaults:use_artifact
+      - examples.workflows.scripts.script_annotations_artifact_passing:use_artifact
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'
-  volumeClaimTemplates:
-  - metadata:
-      name: my-vol
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi

--- a/examples/workflows/scripts/script-annotations-inputs.yaml
+++ b/examples/workflows/scripts/script-annotations-inputs.yaml
@@ -16,13 +16,18 @@ spec:
     - - arguments:
           artifacts:
           - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
-            name: my-artifact-path
+            name: my-artifact
           - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
-            name: my-artifact-as-str
-          - from: '{{steps.output-dict-artifact.outputs.artifacts.a_dict}}'
-            name: my-artifact-as-json
-        name: artifact-loaders
-        template: artifact-loaders
+            name: my-artifact-no-path
+          parameters:
+          - name: an_int
+            value: '1'
+          - name: a_bool
+            value: 'true'
+          - name: a_string
+            value: a
+        name: echo-all
+        template: echo-all
   - inputs:
       parameters:
       - name: a_number
@@ -36,35 +41,38 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_loaders:output_dict_artifact
+      - examples.workflows.scripts.script_annotations_inputs:output_dict_artifact
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
       image: python:3.9
       source: '{{inputs.parameters}}'
   - inputs:
       artifacts:
-      - name: my-artifact-path
-        path: /tmp/hera-inputs/artifacts/my-artifact-path
-      - name: my-artifact-as-str
-        path: /tmp/hera-inputs/artifacts/my-artifact-as-str
-      - name: my-artifact-as-json
-        path: /tmp/hera-inputs/artifacts/my-artifact-as-json
-    name: artifact-loaders
+      - name: my-artifact
+        path: /tmp/file
+      - name: my-artifact-no-path
+        path: /tmp/hera-inputs/artifacts/my-artifact-no-path
+      parameters:
+      - default: '1'
+        description: an_int parameter
+        name: an_int
+      - default: 'true'
+        description: a_bool parameter
+        name: a_bool
+      - default: a
+        description: a_string parameter
+        name: a_string
+    name: echo-all
     script:
       args:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_artifact_loaders:artifact_loaders
+      - examples.workflows.scripts.script_annotations_inputs:echo_all
       command:
       - python
-      env:
-      - name: hera__script_annotations
-        value: ''
       image: python:3.9
       source: '{{inputs.parameters}}'

--- a/examples/workflows/scripts/script-annotations-outputs.yaml
+++ b/examples/workflows/scripts/script-annotations-outputs.yaml
@@ -35,12 +35,10 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_annotations_outputs:script_param_artifact_in_function_signature_and_return_type
+      - examples.workflows.scripts.script_annotations_outputs:script_param_artifact_in_function_signature_and_return_type
       command:
       - python
       env:
-      - name: hera__script_annotations
-        value: ''
       - name: hera__outputs_directory
         value: /tmp/user/chosen/outputs
       image: python:3.9

--- a/examples/workflows/scripts/script_annotations_artifact_custom_volume.py
+++ b/examples/workflows/scripts/script_annotations_artifact_custom_volume.py
@@ -2,7 +2,6 @@
 
 from typing import Annotated
 
-from hera.shared import global_config
 from hera.workflows import (
     Artifact,
     EmptyDirVolume,
@@ -15,8 +14,6 @@ from hera.workflows import (
 )
 from hera.workflows.artifact import ArtifactLoader
 from hera.workflows.volume import Volume
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(

--- a/examples/workflows/scripts/script_annotations_artifact_loaders.py
+++ b/examples/workflows/scripts/script_annotations_artifact_loaders.py
@@ -2,10 +2,7 @@ import json
 from pathlib import Path
 from typing import Annotated, Dict
 
-from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(constructor="runner")

--- a/examples/workflows/scripts/script_annotations_artifact_outputs_defaults.py
+++ b/examples/workflows/scripts/script_annotations_artifact_outputs_defaults.py
@@ -1,19 +1,16 @@
 """This example will reuse the outputs volume across script steps."""
 
-from pathlib import Path
 from typing import Annotated
 
-from hera.shared import global_config
 from hera.workflows import (
     Artifact,
-    ArtifactLoader,
     Parameter,
     Steps,
     Workflow,
     script,
 )
-
-global_config.experimental_features["script_annotations"] = True
+from hera.workflows.artifact import ArtifactLoader
+from hera.workflows.volume import Volume
 
 
 @script(constructor="runner")
@@ -27,16 +24,20 @@ def output_artifact(
 def use_artifact(
     successor_in: Annotated[
         int,
-        Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
+        Artifact(
+            name="successor_in",
+            path="/tmp/file",
+            loader=ArtifactLoader.json,
+        ),
     ],
 ):
     print(successor_in)
-    print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
 with Workflow(
-    generate_name="annotations-artifact-passing",
+    generate_name="test-output-annotations-",
     entrypoint="my-steps",
+    volumes=[Volume(name="my-vol", size="1Gi")],
 ) as w:
     with Steps(name="my-steps") as s:
         out = output_artifact(arguments={"a_number": 3})

--- a/examples/workflows/scripts/script_annotations_artifact_passing.py
+++ b/examples/workflows/scripts/script_annotations_artifact_passing.py
@@ -1,19 +1,16 @@
 """This example will reuse the outputs volume across script steps."""
 
+from pathlib import Path
 from typing import Annotated
 
-from hera.shared import global_config
 from hera.workflows import (
     Artifact,
+    ArtifactLoader,
     Parameter,
     Steps,
     Workflow,
     script,
 )
-from hera.workflows.artifact import ArtifactLoader
-from hera.workflows.volume import Volume
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(constructor="runner")
@@ -27,20 +24,16 @@ def output_artifact(
 def use_artifact(
     successor_in: Annotated[
         int,
-        Artifact(
-            name="successor_in",
-            path="/tmp/file",
-            loader=ArtifactLoader.json,
-        ),
+        Artifact(name="successor_in", path="/my-path", loader=ArtifactLoader.json),
     ],
 ):
     print(successor_in)
+    print(Path("/my-path").read_text())  # if you still need the actual path, it is still mounted where you specify
 
 
 with Workflow(
-    generate_name="test-output-annotations-",
+    generate_name="annotations-artifact-passing",
     entrypoint="my-steps",
-    volumes=[Volume(name="my-vol", size="1Gi")],
 ) as w:
     with Steps(name="my-steps") as s:
         out = output_artifact(arguments={"a_number": 3})

--- a/examples/workflows/scripts/script_annotations_inputs.py
+++ b/examples/workflows/scripts/script_annotations_inputs.py
@@ -1,9 +1,6 @@
 from typing import Annotated, Dict
 
-from hera.shared import global_config
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
-
-global_config.experimental_features["script_annotations"] = True
 
 
 @script(constructor="runner")

--- a/examples/workflows/scripts/script_annotations_outputs.py
+++ b/examples/workflows/scripts/script_annotations_outputs.py
@@ -4,8 +4,6 @@ from typing import Annotated, Tuple
 from hera.shared import global_config
 from hera.workflows import Artifact, Parameter, RunnerScriptConstructor, Steps, Workflow, script
 
-global_config.experimental_features["script_annotations"] = True
-
 global_config.set_class_defaults(RunnerScriptConstructor, outputs_directory="/tmp/user/chosen/outputs")
 
 

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -199,7 +199,6 @@ class BaseMixin(BaseModel):
 GlobalConfig = global_config = _GlobalConfig()
 register_pre_build_hook = global_config.register_pre_build_hook
 
-_SCRIPT_ANNOTATIONS_FLAG = "script_annotations"
 _SCRIPT_PYDANTIC_IO_FLAG = "script_pydantic_io"
 _DECORATOR_SYNTAX_FLAG = "decorator_syntax"
 
@@ -207,7 +206,6 @@ _DECORATOR_SYNTAX_FLAG = "decorator_syntax"
 # the given flag key can also be switched on by any of the flags in the list. Using simple flat lists
 # for now, otherwise with many superseding flags we may want to have a recursive structure.
 _SUPERSEDING_FLAGS: Dict[str, List] = {
-    _SCRIPT_ANNOTATIONS_FLAG: [_SCRIPT_PYDANTIC_IO_FLAG, _DECORATOR_SYNTAX_FLAG],
     _SCRIPT_PYDANTIC_IO_FLAG: [_DECORATOR_SYNTAX_FLAG],
     _DECORATOR_SYNTAX_FLAG: [],
 }

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -49,7 +49,6 @@ from hera.shared._type_util import (
     get_workflow_annotation,
     is_subscripted,
     origin_type_issupertype,
-    set_enum_based_on_type,
 )
 from hera.shared.serialization import serialize
 from hera.workflows._context import _context
@@ -95,7 +94,7 @@ from hera.workflows.models import (
     TemplateRef,
     ValueFrom,
 )
-from hera.workflows.parameter import MISSING, Parameter
+from hera.workflows.parameter import Parameter
 from hera.workflows.protocol import Templatable
 from hera.workflows.steps import Step
 from hera.workflows.task import Task
@@ -357,24 +356,6 @@ class Script(
 
         if volume not in self.volumes:
             self.volumes.append(volume)
-
-
-def _get_parameters_from_callable(source: Callable) -> List[Parameter]:
-    # If there are any kwargs arguments associated with the function signature,
-    # we store these as we can set them as default values for argo arguments
-    parameters = []
-
-    for p in inspect.signature(source).parameters.values():
-        if p.default != inspect.Parameter.empty and p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
-            default = p.default
-        else:
-            default = MISSING
-
-        param = Parameter(name=p.name, default=default)
-        set_enum_based_on_type(param, p.annotation)
-        parameters.append(param)
-
-    return parameters
 
 
 def _get_outputs_from_return_annotation(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -116,7 +116,6 @@ def test_parameter_loading(
     monkeypatch: pytest.MonkeyPatch,
 ):
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -166,7 +165,6 @@ def test_runner_parameter_inputs(
     monkeypatch: pytest.MonkeyPatch,
 ):
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -229,7 +227,6 @@ def test_runner_annotated_parameter_inputs(
     monkeypatch: pytest.MonkeyPatch,
 ):
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -336,7 +333,6 @@ def test_script_annotations_outputs(
 ):
     """Test that the output annotations are parsed correctly and save outputs to correct destinations."""
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
 
@@ -382,7 +378,6 @@ def test_script_raising_error_still_outputs(
 ):
     """Test that the output annotations are parsed correctly and save outputs to correct destinations."""
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
 
@@ -438,7 +433,6 @@ def test_script_annotations_outputs_exceptions(
 ):
     """Test that the output annotations throw the expected exceptions."""
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     with pytest.raises(ValueError) as e:
@@ -446,29 +440,6 @@ def test_script_annotations_outputs_exceptions(
 
     # THEN
     assert exception in str(e.value)
-
-
-@pytest.mark.parametrize(
-    "entrypoint,kwargs_list,expected_output",
-    [
-        (
-            "tests.script_runner.annotated_outputs:script_param",
-            [{"name": "a_number", "value": "3"}],
-            "4",
-        )
-    ],
-)
-def test_script_annotations_outputs_no_global_config(
-    entrypoint,
-    kwargs_list: Dict[str, str],
-    expected_output,
-):
-    """Test that the output annotations are ignored when global_config is not set."""
-    # WHEN
-    output = _runner(entrypoint, kwargs_list)
-
-    # THEN
-    assert serialize(output) == expected_output
 
 
 @pytest.mark.parametrize(
@@ -522,7 +493,6 @@ def test_script_annotations_artifact_inputs(
     importlib.reload(module)
 
     kwargs_list = []
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     output = _runner(f"{module.__name__}:{function}", kwargs_list)
@@ -538,7 +508,6 @@ def test_script_annotations_artifact_input_loader_error(
     # GIVEN
     function_name = "no_loader_invalid_type"
     kwargs_list = []
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # Force a reload of the test module, as the runner performs "importlib.import_module", which
     # may fetch a cached version which will not have the correct ARTIFACT_PATH
@@ -579,7 +548,6 @@ def test_script_annotations_artifacts_no_path(
     monkeypatch.setattr("hera.workflows.artifact._DEFAULT_ARTIFACT_INPUT_DIRECTORY", f"{tmp_path}/")
 
     kwargs_list = []
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -595,7 +563,6 @@ def test_script_annotations_artifacts_wrong_loader(
     # GIVEN
     entrypoint = "tests.script_runner.artifact_with_invalid_loader:invalid_loader"
     kwargs_list = []
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     with pytest.raises(ValueError) as e:
@@ -612,7 +579,6 @@ def test_script_annotations_unknown_type(
     expected_output = "a string"
     entrypoint = "tests.script_runner.unknown_annotation_types:unknown_annotations_ignored"
     kwargs_list = [{"name": "my_string", "value": expected_output}]
-    monkeypatch.setenv("hera__script_annotations", "")
 
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -721,7 +687,6 @@ def test_runner_pydantic_inputs_params(
     # GIVEN
     entrypoint = entrypoint.replace("pydantic_io_vX", f"pydantic_io_v{pydantic_mode}")
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     # WHEN
@@ -754,7 +719,6 @@ def test_runner_pydantic_output_params(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     import tests.script_runner.pydantic_io_v1 as module
@@ -807,7 +771,6 @@ def test_runner_pydantic_input_artifacts(
     monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path))
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     import tests.script_runner.pydantic_io_v1 as module
@@ -856,7 +819,6 @@ def test_runner_pydantic_output_artifacts(
     monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path))
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     import tests.script_runner.pydantic_io_v1 as module
@@ -899,7 +861,6 @@ def test_runner_pydantic_output_with_exit_code(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     import tests.script_runner.pydantic_io_v1 as module
@@ -949,7 +910,6 @@ def test_run_pydantic_output_with_exit_code(
     mock_parse_args.return_value = args
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     import tests.script_runner.pydantic_io_v1 as module
@@ -996,7 +956,6 @@ def test_runner_pydantic_output_with_result(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
@@ -1040,7 +999,6 @@ def test_runner_pydantic_with_invalid_annotations(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_annotations", "")
     monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
@@ -1081,14 +1039,10 @@ def test_runner_pydantic_with_invalid_annotations(
     ],
 )
 def test_script_optional_parameter(
-    monkeypatch: pytest.MonkeyPatch,
     entrypoint,
     kwargs_list,
     expected_output,
 ):
-    # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
-
     # WHEN
     output = _runner(entrypoint, kwargs_list)
 
@@ -1127,14 +1081,10 @@ def test_script_optional_parameter(
     ],
 )
 def test_script_with_complex_types(
-    monkeypatch: pytest.MonkeyPatch,
     entrypoint,
     kwargs_list,
     expected_output,
 ):
-    # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
-
     # WHEN
     output = _runner(entrypoint, kwargs_list)
 
@@ -1142,9 +1092,8 @@ def test_script_with_complex_types(
     assert serialize(output) == expected_output
 
 
-def test_script_partially_annotated_tuple_should_raise_an_error(monkeypatch: pytest.MonkeyPatch):
+def test_script_partially_annotated_tuple_should_raise_an_error():
     # GIVEN
-    monkeypatch.setenv("hera__script_annotations", "")
     entrypoint = "tests.script_runner.parameter_with_complex_types:fn_with_output_tuple_partially_annotated"
     kwargs_list = [{"name": "my_string", "value": "123"}]
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1286 
- [x] Tests updated
- [x] Documentation/examples updated
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Graduate script annotations
* Users no longer need to set the `experimental_features["script_annotations"]` flag
* We no longer add the `hera__script_annotations` environment variable to scripts, so no longer need to check it in the runner `util.py` code
* Update documentation and examples - I am intending to follow this PR with a review/rearranging of the walk through section, which will also address #1273

With this change, the default code path becomes the "script annotations" path, so we always check for `Annotated`, rather than using simple kwarg checks, so we are able to remove the `_get_parameters_from_callable` function.