### PR TITLE
PodGC delete_delay_duration bug Fixed with issue #1292

### DIFF
--- a/src/hera/workflows/models/io/argoproj/workflow/v1alpha1.py
+++ b/src/hera/workflows/models/io/argoproj/workflow/v1alpha1.py
@@ -2627,7 +2627,7 @@ class NodeStatus(BaseModel):
 
 class PodGC(BaseModel):
     delete_delay_duration: Annotated[
-        Optional[v1_1.Duration],
+        Optional[str],
         Field(
             alias="deleteDelayDuration",
             description=("DeleteDelayDuration specifies the duration before pods in the GC queue" " get deleted."),


### PR DESCRIPTION
bug fixed with delete_delay_duration. not Duration class but str only for Go struct json Unmarshal.

**Pull Request Checklist**
- [x] Fixes #1292
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, to use pod_gc with workflow, we need to make PodGC class and set `delete_delay_duration`. And this `delete_delay_duration` should be the `Duration` class but for Go Unmarshal, it seems to be just string. So I changed some code and the bug fixed. See the following changes.

before the commit (v1_1.Duration)
![image](https://github.com/user-attachments/assets/86313dbc-f537-41c3-b68b-215def87bce8)

---

after the commit (str)
![image](https://github.com/user-attachments/assets/e253b799-b31c-4b7b-ab2e-0504f2e3ddb9)

---

As you can see, the error code does not appear on my fastAPI app, and I also can check the pod deleted after around 30s on Pod Success, which means no logs on my argo dashboard.
![image](https://github.com/user-attachments/assets/e8d66d23-d597-4c5c-b11e-c0eb4392a9d0)


This PR adds/changes/fixes...
