### PR TITLE
Allow Artifacts in argument dictionaries

### DIFF
--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -579,34 +579,40 @@ class ArgumentsMixin(BaseMixin):
         elif isinstance(self.arguments, ModelArguments):
             return self.arguments
 
+        def add_argument(k: str, v: Any, result: ModelArguments):
+            if isinstance(v, Parameter):
+                value = v.with_name(k).as_argument()
+                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+            elif isinstance(v, ModelParameter):
+                value = Parameter.from_model(v).as_argument()
+                value.name = k
+                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+            elif isinstance(v, ModelArtifact):
+                copy_art = v.copy(deep=True)
+                copy_art.name = k
+                result.artifacts = [copy_art] if result.artifacts is None else result.artifacts + [copy_art]
+            elif isinstance(v, Artifact):
+                v = v.with_name(k)
+                result.artifacts = (
+                    [v._build_artifact()] if result.artifacts is None else result.artifacts + [v._build_artifact()]
+                )
+            else:
+                # POD types are assumed to be parameters, which will be serialised upon creation
+                value = Parameter(name=k, value=v).as_argument()
+                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+
         result = ModelArguments()
         for arg in self.arguments:
             if isinstance(arg, dict):
                 for k, v in arg.items():
-                    if isinstance(v, Parameter):
-                        value = v.with_name(k).as_argument()
-                    elif isinstance(v, ModelParameter):
-                        value = Parameter.from_model(v).as_argument()
-                        value.name = k
-                    else:
-                        value = Parameter(name=k, value=v).as_argument()
+                    add_argument(k, v, result)
+            elif isinstance(arg, (Parameter, ModelParameter, Artifact, ModelArtifact)):
+                # name can only be None for Parameters/Artifacts if they have not been
+                # "built" yet (see the `_check_name` function)
+                add_argument(arg.name or "", arg, result)
+            else:
+                raise ValueError(f"Invalid argument type {type(arg)}")
 
-                    if result.parameters is None:
-                        result.parameters = [value]
-                    else:
-                        result.parameters.append(value)
-            elif isinstance(arg, ModelArtifact):
-                result.artifacts = [arg] if result.artifacts is None else result.artifacts + [arg]
-            elif isinstance(arg, Artifact):
-                result.artifacts = (
-                    [arg._build_artifact()] if result.artifacts is None else result.artifacts + [arg._build_artifact()]
-                )
-            elif isinstance(arg, Parameter):
-                result.parameters = (
-                    [arg.as_argument()] if result.parameters is None else result.parameters + [arg.as_argument()]
-                )
-            elif isinstance(arg, ModelParameter):
-                result.parameters = [arg] if result.parameters is None else result.parameters + [arg]
         # returning `None` for `Arguments` means the submission to the server will not even have the
         # `arguments` field set, which saves some payload
         if result.parameters is None and result.artifacts is None:

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -592,10 +592,8 @@ class ArgumentsMixin(BaseMixin):
                 copy_art.name = k
                 result.artifacts = [copy_art] if result.artifacts is None else result.artifacts + [copy_art]
             elif isinstance(v, Artifact):
-                v = v.with_name(k)
-                result.artifacts = (
-                    [v._build_artifact()] if result.artifacts is None else result.artifacts + [v._build_artifact()]
-                )
+                copy_art = v.with_name(k)._build_artifact()
+                result.artifacts = [copy_art] if result.artifacts is None else result.artifacts + [copy_art]
             else:
                 # POD types are assumed to be parameters, which will be serialised upon creation
                 value = Parameter(name=k, value=v).as_argument()

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -581,23 +581,23 @@ class ArgumentsMixin(BaseMixin):
 
         def add_argument(k: str, v: Any, result: ModelArguments):
             if isinstance(v, Parameter):
-                value = v.with_name(k).as_argument()
-                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+                parameter = v.with_name(k).as_argument()
+                result.parameters = (result.parameters or []) + [parameter]
             elif isinstance(v, ModelParameter):
-                value = Parameter.from_model(v).as_argument()
-                value.name = k
-                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+                parameter = Parameter.from_model(v).as_argument()
+                parameter.name = k
+                result.parameters = (result.parameters or []) + [parameter]
             elif isinstance(v, ModelArtifact):
-                copy_art = v.copy(deep=True)
-                copy_art.name = k
-                result.artifacts = [copy_art] if result.artifacts is None else result.artifacts + [copy_art]
+                artifact = v.copy(deep=True)
+                artifact.name = k
+                result.artifacts = (result.artifacts or []) + [artifact]
             elif isinstance(v, Artifact):
-                copy_art = v.with_name(k)._build_artifact()
-                result.artifacts = [copy_art] if result.artifacts is None else result.artifacts + [copy_art]
+                artifact = v.with_name(k)._build_artifact()
+                result.artifacts = (result.artifacts or []) + [artifact]
             else:
-                # POD types are assumed to be parameters, which will be serialised upon creation
-                value = Parameter(name=k, value=v).as_argument()
-                result.parameters = [value] if result.parameters is None else result.parameters + [value]
+                # Primitive types are assumed to be parameters, which will be serialised upon creation
+                parameter = Parameter(name=k, value=v).as_argument()
+                result.parameters = (result.parameters or []) + [parameter]
 
         result = ModelArguments()
         for arg in self.arguments:
@@ -609,7 +609,7 @@ class ArgumentsMixin(BaseMixin):
                 # "built" yet (see the `_check_name` function)
                 add_argument(arg.name or "", arg, result)
             else:
-                # Unreachable code (if Pydantic is validating correctly)
+                # Unreachable code (unless model validation is overridden)
                 raise TypeError(f"Invalid argument type {type(arg)}")
 
         # returning `None` for `Arguments` means the submission to the server will not even have the

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -611,7 +611,8 @@ class ArgumentsMixin(BaseMixin):
                 # "built" yet (see the `_check_name` function)
                 add_argument(arg.name or "", arg, result)
             else:
-                raise ValueError(f"Invalid argument type {type(arg)}")
+                # Unreachable code (if Pydantic is validating correctly)
+                raise TypeError(f"Invalid argument type {type(arg)}")
 
         # returning `None` for `Arguments` means the submission to the server will not even have the
         # `arguments` field set, which saves some payload

--- a/tests/test_unit/test_arguments.py
+++ b/tests/test_unit/test_arguments.py
@@ -114,9 +114,6 @@ def test_argument_parameter_build(arguments, expected_built_arguments):
     )
 
 
-model_artifact = ModelArtifact(name="artifact-name", from_="somewhere")
-
-
 @pytest.mark.parametrize(
     "arguments,expected_built_arguments",
     (
@@ -173,27 +170,6 @@ model_artifact = ModelArtifact(name="artifact-name", from_="somewhere")
             id="model-artifact-in-dict",
         ),
         pytest.param(
-            [
-                {
-                    "a-key": model_artifact,
-                },
-                model_artifact,
-            ],
-            ModelArguments(
-                artifacts=[
-                    ModelArtifact(
-                        name="a-key",
-                        from_="somewhere",
-                    ),
-                    ModelArtifact(
-                        name="artifact-name",
-                        from_="somewhere",
-                    ),
-                ],
-            ),
-            id="do-not-rename-original-artifact-object",
-        ),
-        pytest.param(
             {"a-key": Artifact(name="artifact-name", from_="somewhere").with_name("ignore-me")},
             ModelArguments(
                 artifacts=[
@@ -226,6 +202,35 @@ def test_argument_artifact_build(arguments, expected_built_arguments):
         )._build_arguments()
         == expected_built_arguments
     )
+
+
+def test_original_artifact_is_unchanged():
+    model_artifact = ModelArtifact(name="artifact-name", from_="somewhere")
+    arguments = [
+        {
+            "a-key": model_artifact,
+        },
+        model_artifact,
+    ]
+    expected_built_arguments = ModelArguments(
+        artifacts=[
+            ModelArtifact(
+                name="a-key",
+                from_="somewhere",
+            ),
+            ModelArtifact(
+                name="artifact-name",
+                from_="somewhere",
+            ),
+        ],
+    )
+    assert (
+        ArgumentsMixin(
+            arguments=arguments,
+        )._build_arguments()
+        == expected_built_arguments
+    )
+    assert model_artifact.name == "artifact-name"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_arguments.py
+++ b/tests/test_unit/test_arguments.py
@@ -328,3 +328,10 @@ def test_mixed_arguments_build(arguments, expected_built_arguments):
         )._build_arguments()
         == expected_built_arguments
     )
+
+
+def test_invalid_type_in_argument_list():
+    with pytest.raises(TypeError):
+        ArgumentsMixin.construct(
+            arguments=[1],
+        )._build_arguments()

--- a/tests/test_unit/test_arguments.py
+++ b/tests/test_unit/test_arguments.py
@@ -91,6 +91,18 @@ from hera.workflows.parameter import Parameter
             ),
             id="key-model-param-dict",
         ),
+        pytest.param(
+            {"a-key": Parameter(value="a-value")},
+            ModelArguments(
+                parameters=[
+                    ModelParameter(
+                        name="a-key",
+                        value="a-value",
+                    )
+                ],
+            ),
+            id="unnamed-param",
+        ),
     ),
 )
 def test_argument_parameter_build(arguments, expected_built_arguments):
@@ -192,6 +204,18 @@ model_artifact = ModelArtifact(name="artifact-name", from_="somewhere")
                 ],
             ),
             id="hera-artifact-ignore-alt-name",
+        ),
+        pytest.param(
+            {"a-key": Artifact(from_="somewhere")},
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="unnamed-artifact",
         ),
     ),
 )

--- a/tests/test_unit/test_arguments.py
+++ b/tests/test_unit/test_arguments.py
@@ -3,8 +3,10 @@
 import pytest
 
 from hera.workflows._mixins import ArgumentsMixin
+from hera.workflows.artifact import Artifact
 from hera.workflows.models import (
     Arguments as ModelArguments,
+    Artifact as ModelArtifact,
     Parameter as ModelParameter,
 )
 from hera.workflows.parameter import Parameter
@@ -92,6 +94,210 @@ from hera.workflows.parameter import Parameter
     ),
 )
 def test_argument_parameter_build(arguments, expected_built_arguments):
+    assert (
+        ArgumentsMixin(
+            arguments=arguments,
+        )._build_arguments()
+        == expected_built_arguments
+    )
+
+
+model_artifact = ModelArtifact(name="artifact-name", from_="somewhere")
+
+
+@pytest.mark.parametrize(
+    "arguments,expected_built_arguments",
+    (
+        pytest.param(
+            ModelArtifact(
+                name="artifact-name",
+                from_="somewhere",
+            ),
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="artifact-name",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="single-model-artifact",
+        ),
+        pytest.param(
+            [
+                ModelArtifact(
+                    name="artifact-name-1",
+                    from_="somewhere",
+                ),
+                ModelArtifact(
+                    name="artifact-name-2",
+                    from_="somewhere",
+                ),
+            ],
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="artifact-name-1",
+                        from_="somewhere",
+                    ),
+                    ModelArtifact(
+                        name="artifact-name-2",
+                        from_="somewhere",
+                    ),
+                ],
+            ),
+            id="list-model-artifacts",
+        ),
+        pytest.param(
+            {"a-key": ModelArtifact(name="artifact-name", from_="somewhere")},
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="model-artifact-in-dict",
+        ),
+        pytest.param(
+            [
+                {
+                    "a-key": model_artifact,
+                },
+                model_artifact,
+            ],
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    ),
+                    ModelArtifact(
+                        name="artifact-name",
+                        from_="somewhere",
+                    ),
+                ],
+            ),
+            id="do-not-rename-original-artifact-object",
+        ),
+        pytest.param(
+            {"a-key": Artifact(name="artifact-name", from_="somewhere").with_name("ignore-me")},
+            ModelArguments(
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="hera-artifact-ignore-alt-name",
+        ),
+    ),
+)
+def test_argument_artifact_build(arguments, expected_built_arguments):
+    assert (
+        ArgumentsMixin(
+            arguments=arguments,
+        )._build_arguments()
+        == expected_built_arguments
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments,expected_built_arguments",
+    (
+        pytest.param(
+            None,
+            None,
+            id="no-arguments",
+        ),
+        pytest.param(
+            ModelArguments(),
+            ModelArguments(),
+            id="model-arguments",
+        ),
+        pytest.param(
+            [Parameter(name="param-name", value="a-value"), Artifact(name="artifact-name", from_="somewhere")],
+            ModelArguments(
+                parameters=[
+                    ModelParameter(
+                        name="param-name",
+                        value="a-value",
+                    )
+                ],
+                artifacts=[
+                    ModelArtifact(
+                        name="artifact-name",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="mixed-list",
+        ),
+        pytest.param(
+            {"param-name": "a-value", "a-key": ModelArtifact(name="artifact-name", from_="somewhere")},
+            ModelArguments(
+                parameters=[
+                    ModelParameter(
+                        name="param-name",
+                        value="a-value",
+                    )
+                ],
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="mixed-dict",
+        ),
+        pytest.param(
+            [
+                {"param-name": "a-value"},
+                ModelArtifact(name="artifact-name", from_="somewhere"),
+            ],
+            ModelArguments(
+                parameters=[
+                    ModelParameter(
+                        name="param-name",
+                        value="a-value",
+                    )
+                ],
+                artifacts=[
+                    ModelArtifact(
+                        name="artifact-name",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="param-dict-in-list",
+        ),
+        pytest.param(
+            [
+                {"param-name": "a-value"},
+                {"a-key": Artifact(name="artifact-name", from_="somewhere").with_name("ignore-me")},
+            ],
+            ModelArguments(
+                parameters=[
+                    ModelParameter(
+                        name="param-name",
+                        value="a-value",
+                    )
+                ],
+                artifacts=[
+                    ModelArtifact(
+                        name="a-key",
+                        from_="somewhere",
+                    )
+                ],
+            ),
+            id="multiple-dicts-in-list",
+        ),
+    ),
+)
+def test_mixed_arguments_build(arguments, expected_built_arguments):
     assert (
         ArgumentsMixin(
             arguments=arguments,


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1315 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, only Parameters can be passed in dictionaries of arguments. This PR allows Artifacts to be passed in dictionaries, taking the key value as the new name of the Artifact (ignoring any `with_name` or original `name` values).

Also refactored `_build_arguments`, as promised 😎 