### PR TITLE
Allow Parameter defaults in WorkflowTemplate arguments

### DIFF
--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -606,7 +606,7 @@ class ArgumentsMixin(BaseMixin):
                 # Primitive types are assumed to be parameters, which will be serialised upon creation
                 parameter = Parameter(name=k, value=v)
                 param_as_argument = parameter.as_input() if is_workflow_template else parameter.as_argument()
-                result.parameters = (result.parameters or []) + [parameter]
+                result.parameters = (result.parameters or []) + [param_as_argument]
 
         result = ModelArguments()
         for arg in normalized_arguments:

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -574,10 +574,13 @@ class ArgumentsMixin(BaseMixin):
 
     def _build_arguments(self) -> Optional[ModelArguments]:
         """Processes the `arguments` field and builds the optional generated `Arguments` to set as arguments."""
-        if self.arguments is None:
+        # Reapply the validator in case arguments was assigned to as a dictionary
+        normalized_arguments = normalize_to_list_or(ModelArguments)(self.arguments)
+
+        if normalized_arguments is None:
             return None
-        elif isinstance(self.arguments, ModelArguments):
-            return self.arguments
+        elif isinstance(normalized_arguments, ModelArguments):
+            return normalized_arguments
 
         from hera.workflows.workflow_template import WorkflowTemplate
 
@@ -606,7 +609,7 @@ class ArgumentsMixin(BaseMixin):
                 result.parameters = (result.parameters or []) + [parameter]
 
         result = ModelArguments()
-        for arg in self.arguments:
+        for arg in normalized_arguments:
             if isinstance(arg, dict):
                 for k, v in arg.items():
                     add_argument(k, v, result)

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -6,7 +6,11 @@ import pytest
 
 from hera.workflows.container import Container
 from hera.workflows.exceptions import InvalidTemplateCall
-from hera.workflows.models import ImagePullPolicy, WorkflowCreateRequest
+from hera.workflows.models import (
+    ImagePullPolicy,
+    Parameter as ModelParameter,
+    WorkflowCreateRequest,
+)
 from hera.workflows.parameter import Parameter
 from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService
@@ -133,3 +137,18 @@ def test_builds_successfully_using_containers():
         Container(image_pull_policy="Always")
 
     w.to_yaml()
+
+
+def test_reassign_workflow_arguments():
+    with Workflow(name="my-workflow", arguments={"a-param": "a-value"}) as w:
+        pass
+
+    built_workflow = w.build()
+
+    assert built_workflow.spec.arguments.parameters == [ModelParameter(name="a-param", value="a-value")]
+
+    w.arguments = {"another-param": "another-value"}
+
+    built_workflow = w.build()
+
+    assert built_workflow.spec.arguments.parameters == [ModelParameter(name="another-param", value="another-value")]

--- a/tests/test_unit/test_workflow_template.py
+++ b/tests/test_unit/test_workflow_template.py
@@ -11,6 +11,7 @@ from hera.workflows.models import (
     WorkflowTemplateLintRequest,
     WorkflowTemplateUpdateRequest,
 )
+from hera.workflows.parameter import Parameter
 from hera.workflows.service import WorkflowsService
 from hera.workflows.workflow import NAME_LIMIT, Workflow
 from hera.workflows.workflow_template import _TRUNCATE_LENGTH, WorkflowTemplate
@@ -236,3 +237,18 @@ def test_workflow_template_update_non_existent():
         WorkflowTemplateCreateRequest(template=wt.build()), namespace="my-namespace"
     )
     wt.workflows_service.update_workflow_template.assert_not_called()
+
+
+def test_workflow_template_with_default_param_arguments():
+    # GIVEN
+    with WorkflowTemplate(
+        name="my-wt",
+        arguments=Parameter(name="my-arg", default="foo"),
+    ) as wt:
+        pass
+
+    # WHEN
+    built_wt = wt.build()
+
+    # THEN
+    assert built_wt.spec.arguments.parameters[0].default == "foo"


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1268 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, WorkflowTemplates take Parameters within Arguments. If you set `default` it is not included in the YAML output. Added a test for this behaviour and fixed by checking if `self` is a WorkflowTemplate in the `_build_arguments` function in `ArgumentsMixin`.