### PR TITLE
Add validation on assignment

### DIFF
--- a/src/hera/shared/_pydantic.py
+++ b/src/hera/shared/_pydantic.py
@@ -92,6 +92,9 @@ class BaseModel(PydanticBaseModel):
         smart_union = True
         """uses smart union for matching a field's specified value to the underlying type that's part of a union"""
 
+        validate_assignment = True
+        """validates on assignment to a field"""
+
 
 __all__ = [
     "BaseModel",


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1169 
- [ ] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, any assignment to fields of a Pydantic model is not revalidated. This causes problems in e.g. `arguments` as the `normalize_to_list_or(ModelArguments)` doesn't fire, so we have a dictionary instead of a list of one (of the dict).