### PR TITLE
Normalise arguments on assignment

### DIFF
--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -575,12 +575,12 @@ class ArgumentsMixin(BaseMixin):
     def _build_arguments(self) -> Optional[ModelArguments]:
         """Processes the `arguments` field and builds the optional generated `Arguments` to set as arguments."""
         # Reapply the validator in case arguments was assigned to as a dictionary
-        self.arguments = normalize_to_list_or(ModelArguments)(self.arguments)
+        normalized_arguments = normalize_to_list_or(ModelArguments)(self.arguments)
 
-        if self.arguments is None:
+        if normalized_arguments is None:
             return None
-        elif isinstance(self.arguments, ModelArguments):
-            return self.arguments
+        elif isinstance(normalized_arguments, ModelArguments):
+            return normalized_arguments
 
         from hera.workflows.workflow_template import WorkflowTemplate
 
@@ -609,7 +609,7 @@ class ArgumentsMixin(BaseMixin):
                 result.parameters = (result.parameters or []) + [parameter]
 
         result = ModelArguments()
-        for arg in self.arguments:
+        for arg in normalized_arguments:
             if isinstance(arg, dict):
                 for k, v in arg.items():
                     add_argument(k, v, result)

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -574,6 +574,9 @@ class ArgumentsMixin(BaseMixin):
 
     def _build_arguments(self) -> Optional[ModelArguments]:
         """Processes the `arguments` field and builds the optional generated `Arguments` to set as arguments."""
+        # Reapply the validator in case arguments was assigned to as a dictionary
+        self.arguments = normalize_to_list_or(ModelArguments)(self.arguments)
+
         if self.arguments is None:
             return None
         elif isinstance(self.arguments, ModelArguments):

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -6,7 +6,11 @@ import pytest
 
 from hera.workflows.container import Container
 from hera.workflows.exceptions import InvalidTemplateCall
-from hera.workflows.models import ImagePullPolicy, WorkflowCreateRequest
+from hera.workflows.models import (
+    ImagePullPolicy,
+    Parameter as ModelParameter,
+    WorkflowCreateRequest,
+)
 from hera.workflows.parameter import Parameter
 from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService
@@ -133,3 +137,18 @@ def test_builds_successfully_using_containers():
         Container(image_pull_policy="Always")
 
     w.to_yaml()
+
+
+def test_reassign_workflow_arguments():
+    with Workflow(name="my-workflow", arguments={"a-param": "a-value"}) as w:
+        pass
+
+    built_workflow = w.build()
+
+    assert built_workflow.spec.arguments.parameters == [ModelParameter(name="a-param", value="a-value")]
+
+    w.arguments = {"another-param": "another-value"}
+
+    built_workflow = w.build()
+
+    assert built_workflow.spec.arguments.parameters == [ModelParameter(name="another-param", value="another-value")]


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1169 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
When reassigning the `arguments` field of a workflow (e.g. to submit the same workflow multiple times with different arguments), the validator should be reapplied to ensure that the field is a list. This is because the field can be assigned to as a dictionary which causes an error when building the workflow. This is a special case just for the arguments field, no plans to do the same with inputs/outputs/etc.