### PR TITLE
Add human readable yaml ordering

### DIFF
--- a/examples/workflows/misc/hello-world.yaml
+++ b/examples/workflows/misc/hello-world.yaml
@@ -3,19 +3,13 @@ kind: Workflow
 metadata:
   generateName: hello-world-
 spec:
-  arguments:
-    parameters:
-    - name: s
-      value: world
   entrypoint: hello
   templates:
-  - inputs:
+  - name: hello
+    inputs:
       parameters:
       - name: s
-    name: hello
     script:
-      command:
-      - python
       image: python:3.9
       source: |-
         import os
@@ -26,3 +20,9 @@ spec:
         except: s = r'''{{inputs.parameters.s}}'''
 
         print('Hello, {s}!'.format(s=s))
+      command:
+      - python
+  arguments:
+    parameters:
+    - name: s
+      value: world

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -343,7 +343,39 @@ class Workflow(
 
     def to_yaml(self, *args, **kwargs) -> str:
         """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
-        return _yaml.dump(self.to_dict(), *args, **kwargs)
+
+        def human_readable_ordering(kv: tuple) -> int:
+            """Key ordering function for ordering in a more human-readable fashion.
+
+            Ordering is:
+            1. "name" keys always first (if present)
+            2. POD (not dicts/lists)
+            3. lists
+            4. dict
+            """
+            k, v = kv
+            if k == "name" and isinstance(v, str):
+                return 0
+            if not isinstance(v, (dict, list)):
+                return 1
+            if isinstance(v, list):
+                return 2
+            return 3
+
+        def order_dict(d: dict) -> dict:
+            """Recursively orders `d` by the custom_ordering function by inserting them into a copy of the dict in order."""
+            d_copy = dict()
+            for k, v in sorted(d.items(), key=human_readable_ordering):
+                if isinstance(v, dict):
+                    d_copy[k] = order_dict(v)
+                elif isinstance(v, list):
+                    d_copy[k] = [order_dict(i) if isinstance(i, dict) else i for i in v]
+                else:
+                    d_copy[k] = v
+            return d_copy
+
+        human_ordered_dict = order_dict(self.to_dict())
+        return _yaml.dump(human_ordered_dict, *args, **kwargs)
 
     def create(self, wait: bool = False, poll_interval: int = 5) -> TWorkflow:
         """Creates the Workflow on the Argo cluster.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -122,8 +122,7 @@ def test_hera_output(path, module_name, filename, global_config_fixture):
 
     # THEN
     if _generate_yaml(generated_yaml_path):
-        generated_yaml_path.write_text(yaml.dump(output, sort_keys=False, default_flow_style=False))
-
+        generated_yaml_path.write_text(workflow.to_yaml())
     # Check there have been no regressions from the generated yaml committed in the repo
     assert generated_yaml_path.exists()
     _compare_workflows(workflow, output, yaml.safe_load(generated_yaml_path.read_text()))
@@ -154,7 +153,7 @@ def test_hera_output_upstream(module_name, global_config_fixture):
 
     # THEN - generate the yaml if HERA_REGENERATE or it does not exist
     if _generate_yaml(generated_yaml_path):
-        generated_yaml_path.write_text(yaml.dump(output, sort_keys=False, default_flow_style=False))
+        generated_yaml_path.write_text(workflow.to_yaml())
     if _generate_yaml(upstream_yaml_path):
         upstream_yaml_path.write_text(
             requests.get(f"{ARGO_EXAMPLES_URL}/{module_name.replace('__', '/').replace('_', '-')}.yaml").text


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1316
- [x] Tests updated
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Based on YAML being a bunch of nested dictionaries, we can order the nested dictionaries by the `name` key always-first, then plain data types, then lists, and then dicts, which should go some way towards making Hera-outputted YAMLs much friendlier to DevOps and YAML-first collaborators. As YAML makes no guarantee on dictionary ordering, this change is entirely cosmetic to improve human readability (IMO it really does make the YAML better to read).