### PR TITLE
Fix `from_model` method in `Parameter` class

### DIFF
--- a/src/hera/workflows/parameter.py
+++ b/src/hera/workflows/parameter.py
@@ -68,8 +68,8 @@ class Parameter(_ModelParameter):
 
     @classmethod
     def from_model(cls, model: _ModelParameter) -> Parameter:
-        """Creates a `Parameter` from a `Parameter` model."""
-        return cls(**model.dict())
+        """Creates a `Parameter` from a `Parameter` model without running validation."""
+        return cls.construct(**model.dict())
 
     def with_name(self, name: str) -> Parameter:
         """Returns a copy of the parameter with the name set to the value."""

--- a/tests/test_unit/test_workflow_template.py
+++ b/tests/test_unit/test_workflow_template.py
@@ -5,6 +5,7 @@ import pytest
 from hera.exceptions import NotFound
 from hera.workflows import Container, Steps
 from hera.workflows.models import (
+    Parameter as ModelParameter,
     WorkflowCreateRequest,
     WorkflowStatus,
     WorkflowTemplateCreateRequest,
@@ -251,4 +252,36 @@ def test_workflow_template_with_default_param_arguments():
     built_wt = wt.build()
 
     # THEN
-    assert built_wt.spec.arguments.parameters[0].default == "foo"
+
+    assert built_wt.spec.arguments.parameters[0] == ModelParameter(
+        default="foo",
+        description=None,
+        enum=None,
+        global_name=None,
+        name="my-arg",
+        value=None,
+        value_from=None,
+    )
+
+
+def test_workflow_template_with_default_param_arguments_model_parameter():
+    # GIVEN
+    with WorkflowTemplate(
+        name="my-wt",
+        arguments=ModelParameter(name="my-arg", default="foo"),
+    ) as wt:
+        pass
+
+    # WHEN
+    built_wt = wt.build()
+
+    # THEN
+    assert built_wt.spec.arguments.parameters[0] == ModelParameter(
+        default="foo",
+        description=None,
+        enum=None,
+        global_name=None,
+        name="my-arg",
+        value=None,
+        value_from=None,
+    )


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1335 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
* The `from_model` method was running the Parameter's validator when instantiating, which incorrectly converted the `value` field (`None` was serialised to `"null"`)
* Use `Parameter.construct` instead of `cls` to create a new instance
* Add a test for WorkflowTemplate using ModelParameter as reported in https://github.com/argoproj-labs/hera/commit/897f66e41560057e986a4f56b5e08405592519f4#commitcomment-153322551