### PR TITLE
Refactor runner utils for clarity

### DIFF
--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -21,18 +21,12 @@ from hera.shared._type_util import (
 from hera.shared.serialization import serialize
 from hera.workflows import Artifact, Parameter
 from hera.workflows.artifact import ArtifactLoader
-from hera.workflows.io.v1 import (
-    Output as OutputV1,
-)
+from hera.workflows.io.v1 import Output as OutputV1
 
 try:
-    from hera.workflows.io.v2 import (  # type: ignore
-        Output as OutputV2,
-    )
+    from hera.workflows.io.v2 import Output as OutputV2
 except ImportError:
-    from hera.workflows.io.v1 import (  # type: ignore
-        Output as OutputV2,
-    )
+    from hera.workflows.io.v1 import Output as OutputV2  # type: ignore
 
 
 def _get_outputs_path(destination: Union[Parameter, Artifact]) -> Path:

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -154,7 +154,7 @@ def _is_output_kwarg(key: str, f: Callable) -> bool:
     return False
 
 
-def _map_function_annotations(function: Callable, kwargs: Dict[str, str]) -> Dict:
+def _map_function_annotations(function: Callable, template_inputs: Dict[str, str]) -> Dict:
     """Parse annotations to substitute values from Argo for the function parameters.
 
     For Parameter inputs:
@@ -169,33 +169,35 @@ def _map_function_annotations(function: Callable, kwargs: Dict[str, str]) -> Dic
     * update value to a Path object
     """
     if _contains_var_kwarg(function):
-        return kwargs
+        return template_inputs
 
-    mapped_kwargs: Dict[str, Any] = {}
+    function_kwargs: Dict[str, Any] = {}
 
     for func_param_name, func_param in inspect.signature(function).parameters.items():
         if param_or_artifact := get_workflow_annotation(func_param.annotation):
             if isinstance(param_or_artifact, Parameter):
-                mapped_kwargs[func_param_name] = get_annotated_param_value(func_param_name, param_or_artifact, kwargs)
+                function_kwargs[func_param_name] = get_annotated_param_value(
+                    func_param_name, param_or_artifact, template_inputs
+                )
             else:
-                mapped_kwargs[func_param_name] = get_annotated_artifact_value(param_or_artifact)
+                function_kwargs[func_param_name] = get_annotated_artifact_value(param_or_artifact)
 
         elif not is_subscripted(func_param.annotation) and issubclass(func_param.annotation, (InputV1, InputV2)):
             # We collect all relevant kwargs for the single `Input` function parameter
-            mapped_kwargs[func_param_name] = map_runner_input(func_param.annotation, kwargs)
+            function_kwargs[func_param_name] = map_runner_input(func_param.annotation, template_inputs)
 
         else:
             # Use the kwarg value as-is
-            mapped_kwargs[func_param_name] = kwargs[func_param_name]
-    return mapped_kwargs
+            function_kwargs[func_param_name] = template_inputs[func_param_name]
+    return function_kwargs
 
 
-def _runner(entrypoint: str, kwargs_list: List) -> Any:
+def _runner(entrypoint: str, template_inputs_list: List) -> Any:
     """Run the function defined by the entrypoint with the given list of kwargs.
 
     Args:
         entrypoint: The module path to the script within the container to execute. "package.submodule:function"
-        kwargs_list: A list of dicts with "name" and "value" keys, representing the kwargs of the function.
+        template_inputs_list: A list of dicts with "name" and "value" keys, to be mapped to the kwargs of the function.
 
     Returns:
         The result of the function or `None` if the outputs are to be saved.
@@ -207,17 +209,18 @@ def _runner(entrypoint: str, kwargs_list: List) -> Any:
     # this may happen if the function is decorated with @script
     if hasattr(function, "wrapped_function"):
         function = function.wrapped_function
-    # convert the kwargs list to a dict
-    kwargs: Dict[str, str] = {}
-    for kwarg in kwargs_list:
+
+    # convert the template inputs list to a dict
+    template_inputs: Dict[str, str] = {}
+    for kwarg in template_inputs_list:
         if "name" not in kwarg or "value" not in kwarg:
             continue
         # sanitize the key for python
         key = cast(str, serialize(kwarg["name"]))
         value = kwarg["value"]
-        kwargs[key] = value
+        template_inputs[key] = value
 
-    kwargs = _map_function_annotations(function, kwargs)
+    function_kwargs = _map_function_annotations(function, template_inputs)
 
     # The imported validate_arguments uses smart union by default just in case clients do not rely on it. This means that if a function uses a union
     # type for any of its inputs, then this will at least try to map those types correctly if the input object is
@@ -242,13 +245,13 @@ def _runner(entrypoint: str, kwargs_list: List) -> Any:
         # This will save outputs returned from the function only. Any function parameters/artifacts marked as
         # outputs should be written to within the function itself.
         try:
-            output = _save_annotated_return_outputs(function(**kwargs), output_annotations)
+            output = _save_annotated_return_outputs(function(**function_kwargs), output_annotations)
         except Exception as e:
             _save_dummy_outputs(output_annotations)
             raise e
         return output or None
 
-    return function(**kwargs)
+    return function(**function_kwargs)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -272,9 +275,9 @@ def _run() -> None:
     # 1. Protect against trying to json.loads on empty files with inner `or r"[]`
     # 2. Protect against files containing `null` as text with outer `or []` (as a result of using
     #    `{{inputs.parameters}}` where the parameters key doesn't exist in `inputs`)
-    kwargs_list = json.loads(args.args_path.read_text() or r"[]") or []
-    assert isinstance(kwargs_list, List)
-    result = _runner(args.entrypoint, kwargs_list)
+    template_inputs = json.loads(args.args_path.read_text() or r"[]") or []
+    assert isinstance(template_inputs, List)
+    result = _runner(args.entrypoint, template_inputs)
     if not result:
         return
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -113,10 +113,7 @@ def test_parameter_loading(
     entrypoint: str,
     kwargs_list: List[Dict[str, str]],
     expected_output: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    # GIVEN
-
     # WHEN
     output = _runner(entrypoint, kwargs_list)
 
@@ -162,10 +159,7 @@ def test_runner_parameter_inputs(
     entrypoint,
     kwargs_list: List[Dict[str, str]],
     expected_output,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    # GIVEN
-
     # WHEN
     output = _runner(entrypoint, kwargs_list)
     # THEN

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -327,7 +327,6 @@ def test_script_annotations_outputs(
 ):
     """Test that the output annotations are parsed correctly and save outputs to correct destinations."""
     # GIVEN
-
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
 
     monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path))
@@ -423,11 +422,8 @@ def test_script_annotations_outputs_exceptions(
     function_name,
     kwargs_list: List[Dict[str, str]],
     exception,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     """Test that the output annotations throw the expected exceptions."""
-    # GIVEN
-
     # WHEN
     with pytest.raises(ValueError) as e:
         _ = _runner(f"tests.script_runner.annotated_outputs:{function_name}", kwargs_list)
@@ -495,9 +491,7 @@ def test_script_annotations_artifact_inputs(
     assert serialize(output) == expected_output
 
 
-def test_script_annotations_artifact_input_loader_error(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_script_annotations_artifact_input_loader_error():
     """Test that the input artifact loaded with wrong type throws the expected exception."""
     # GIVEN
     function_name = "no_loader_invalid_type"
@@ -550,9 +544,7 @@ def test_script_annotations_artifacts_no_path(
     assert serialize(output) == expected_output
 
 
-def test_script_annotations_artifacts_wrong_loader(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_script_annotations_artifacts_wrong_loader():
     """Test that the input artifact annotation with no loader throws an exception."""
     # GIVEN
     entrypoint = "tests.script_runner.artifact_with_invalid_loader:invalid_loader"
@@ -566,9 +558,7 @@ def test_script_annotations_artifacts_wrong_loader(
     assert "value is not a valid enumeration member" in str(e.value)
 
 
-def test_script_annotations_unknown_type(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_script_annotations_unknown_type():
     # GIVEN
     expected_output = "a string"
     entrypoint = "tests.script_runner.unknown_annotation_types:unknown_annotations_ignored"
@@ -676,7 +666,6 @@ def test_runner_pydantic_inputs_params(
     expected_output,
     pydantic_mode,
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ):
     # GIVEN
     entrypoint = entrypoint.replace("pydantic_io_vX", f"pydantic_io_v{pydantic_mode}")

--- a/tests/test_unit/test_script_annotations_util.py
+++ b/tests/test_unit/test_script_annotations_util.py
@@ -8,7 +8,8 @@ import pytest
 from hera.workflows._runner.script_annotations_util import (
     _get_outputs_path,
     get_annotated_artifact_value,
-    get_annotated_param_value,
+    get_annotated_input_param,
+    get_annotated_output_param,
     map_runner_input,
 )
 from hera.workflows.artifact import Artifact, ArtifactLoader
@@ -59,39 +60,47 @@ def test_get_outputs_path(destination: Union[Parameter, Artifact], expected_path
             "value",
             id="user-passes-func-param-name-instead-of-annotation",
         ),
-        pytest.param(
-            "dummy_name",
-            Parameter(name="output-default-path-test", output=True),
-            {},
-            Path("/tmp/hera-outputs/parameters/output-default-path-test"),
-            id="output-parameter-with-default",
-        ),
-        pytest.param(
-            "dummy_name",
-            Parameter(name="output-path-test", value_from=ValueFrom(path="/tmp/test"), output=True),
-            {},
-            Path("/tmp/test"),
-            id="output-parameter-with-custom-path",
-        ),
     ],
 )
-def test_get_annotated_param_value(
+def test_get_annotated_input_param(
     func_param_name,
     param_annotation,
     kwargs,
     expected_value,
 ):
-    assert get_annotated_param_value(func_param_name, param_annotation, kwargs) == expected_value
+    assert get_annotated_input_param(func_param_name, param_annotation, kwargs) == expected_value
 
 
-def test_get_annotated_param_value_error():
+@pytest.mark.parametrize(
+    "param_annotation,expected_value",
+    [
+        pytest.param(
+            Parameter(name="output-default-path-test", output=True),
+            Path("/tmp/hera-outputs/parameters/output-default-path-test"),
+            id="output-parameter-with-default",
+        ),
+        pytest.param(
+            Parameter(name="output-path-test", value_from=ValueFrom(path="/tmp/test"), output=True),
+            Path("/tmp/test"),
+            id="output-parameter-with-custom-path",
+        ),
+    ],
+)
+def test_get_annotated_output_param(
+    param_annotation,
+    expected_value,
+):
+    assert get_annotated_output_param(param_annotation) == expected_value
+
+
+def test_get_annotated_input_param_error():
     with pytest.raises(RuntimeError, match="my_func_param was not given a value"):
-        get_annotated_param_value("my_func_param", Parameter(), {})
+        get_annotated_input_param("my_func_param", Parameter(), {})
 
 
-def test_get_annotated_param_value_error_param_name():
+def test_get_annotated_input_param_error_param_name():
     with pytest.raises(RuntimeError, match="my-func-param was not given a value"):
-        get_annotated_param_value("my_func_param", Parameter(name="my-func-param"), {})
+        get_annotated_input_param("my_func_param", Parameter(name="my-func-param"), {})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Among other changes, rename _map_argo_inputs_to_function to _map_function_annotations and move the function to `util.py` from `script_annotations_util.py`
* Prepares us for adding `Parameter` loader functionality (#1166)