### PR TITLE
Add test for automatic base model output

### DIFF
--- a/tests/script_runner/annotated_outputs.py
+++ b/tests/script_runner/annotated_outputs.py
@@ -8,6 +8,11 @@ from tests.helper import ARTIFACT_PATH
 from hera.shared import global_config
 from hera.workflows import Artifact, Parameter, script
 
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
+
 global_config.experimental_features["script_annotations"] = True
 
 
@@ -134,3 +139,13 @@ def script_param_artifact_in_function_signature_and_return_type(
     successor.write_text(str(a_number + 1))
     successor2.write_text(str(a_number + 2))
     return a_number + 3, a_number + 4
+
+
+class MyParameter(BaseModel):
+    a: str
+    b: str
+
+
+@script(constructor="runner")
+def return_base_model() -> Annotated[MyParameter, Parameter(name="base-model-output")]:
+    return MyParameter(a="foo", b="bar")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -316,6 +316,11 @@ def test_runner_annotated_parameter_inputs(
             [],
             [{"subpath": "tmp/hera-outputs/parameters/dict-of-str", "value": '{"my-key": "my-value"}'}],
         ),
+        (
+            "return_base_model",
+            [],
+            [{"subpath": "tmp/hera-outputs/parameters/base-model-output", "value": '{"a": "foo", "b": "bar"}'}],
+        ),
     ],
 )
 def test_script_annotations_outputs(


### PR DESCRIPTION
Working on custom [de]serialisation, wanted to confirm that we can already output regular `BaseModel` subclasses as serialised json. I'll be updating #1166 with the rough proposal and putting up the PR in a bit.