### PR TITLE
fix: make `failed`, `phase`, `succeeded` optional in CronWorkflowStatus with defaults

### DIFF
--- a/src/hera/events/models/io/argoproj/workflow/v1alpha1.py
+++ b/src/hera/events/models/io/argoproj/workflow/v1alpha1.py
@@ -623,9 +623,9 @@ class CronWorkflowStatus(BaseModel):
         Field(description="Conditions is a list of conditions the CronWorkflow may have"),
     ] = None
     failed: Annotated[
-        int,
+        Optional[int],
         Field(description=("v3.6 and after: Failed counts how many times child workflows failed")),
-    ]
+    ] = 0
     last_scheduled_time: Annotated[
         Optional[v1_1.Time],
         Field(
@@ -634,18 +634,18 @@ class CronWorkflowStatus(BaseModel):
         ),
     ] = None
     phase: Annotated[
-        str,
+        Optional[str],
         Field(
             description=(
                 "v3.6 and after: Phase is an enum of Active or Stopped. It changes to"
                 " Stopped when stopStrategy.expression is true"
             )
         ),
-    ]
+    ] = None
     succeeded: Annotated[
-        int,
+        Optional[int],
         Field(description=("v3.6 and after: Succeeded counts how many times child workflows succeeded")),
-    ]
+    ] = 0
 
 
 class ArtifactoryArtifact(BaseModel):

--- a/src/hera/workflows/models/io/argoproj/workflow/v1alpha1.py
+++ b/src/hera/workflows/models/io/argoproj/workflow/v1alpha1.py
@@ -623,9 +623,9 @@ class CronWorkflowStatus(BaseModel):
         Field(description="Conditions is a list of conditions the CronWorkflow may have"),
     ] = None
     failed: Annotated[
-        int,
+        Optional[int],
         Field(description=("v3.6 and after: Failed counts how many times child workflows failed")),
-    ]
+    ] = 0
     last_scheduled_time: Annotated[
         Optional[v1_1.Time],
         Field(
@@ -634,18 +634,18 @@ class CronWorkflowStatus(BaseModel):
         ),
     ] = None
     phase: Annotated[
-        str,
+        Optional[str],
         Field(
             description=(
                 "v3.6 and after: Phase is an enum of Active or Stopped. It changes to"
                 " Stopped when stopStrategy.expression is true"
             )
         ),
-    ]
+    ] = None
     succeeded: Annotated[
-        int,
+        Optional[int],
         Field(description=("v3.6 and after: Succeeded counts how many times child workflows succeeded")),
-    ]
+    ] = 0
 
 
 class ArtifactoryArtifact(BaseModel):


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1312 
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
This PR fixes a validation issue with Pydantic. The CronWorkflowStatus model currently requires the `failed`, `phase`, and `succeeded` fields to be explicitly provided. However, these fields may be absent in versions of Argo below 3.6. 
