### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -29,7 +29,7 @@ def generate_markdown(path: Path, sub_folder: str) -> str:
     else:
         docstring = ""
     # remove the module docstring at the top of the python file using regex
-    py_contents = re.sub(r'^(""".*?""")', "", py_contents, 1, re.DOTALL)
+    py_contents = re.sub(r'^(""".*?""")', "", py_contents, count=1, flags=re.DOTALL)
     title = path.stem.replace("_", " ").title()
     yaml_filename = path.stem.replace("_", "-")
     yaml_contents = (path.parent / (yaml_filename + ".yaml")).read_text()


### PR DESCRIPTION
# PR Summary
This small PR resolves the `re` deprecation warnings:
```python
DeprecationWarning: 'count' is passed as positional argument
```