### PR TITLE
Streamline quick start guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ workflows-service              Generate the Workflows service option of Hera
 
 You can install Argo and try running Hera code in GitHub Codespaces. First, open the Hera repository in Codespaces using the link below:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/argoproj-labs/hera)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/argoproj-labs/hera)
 
 Then, you can run the `make` commands to install k3d (a lightweight Kubernetes CLI), and then install the Argo Workflows controller on the cluster:
 
@@ -97,7 +97,7 @@ You can [take a look at `test_submission.py`](https://github.com/argoproj-labs/h
 make test-on-cluster
 ```
 
-See the [Viewing the Argo UI from a Codespace](../CONTRIBUTING.md#viewing-the-argo-ui-from-a-codespace) guide to see the Workflow in the UI.
+See the [Viewing the Argo UI from a Codespace](#viewing-the-argo-ui-from-a-codespace) guide to see the Workflow in the UI.
 
 Otherwise you can install the Argo CLI with
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,38 @@ workflows-models               Generate the Workflows models portion of Argo Wor
 workflows-service              Generate the Workflows service option of Hera
 ```
 
+#### Installing Argo Workflows in GitHub Codespaces
+
+You can install Argo and try running Hera code in GitHub Codespaces. First, open the Hera repository in Codespaces using the link below:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/argoproj-labs/hera)
+
+Then, you can run the `make` commands to install k3d (a lightweight Kubernetes CLI), and then install the Argo Workflows controller on the cluster:
+
+```
+make install-k3d run-argo
+```
+
+You can [take a look at `test_submission.py`](https://github.com/argoproj-labs/hera/blob/ec06876f1abc0d3309b000f3cd2e0eca64891da9/tests/test_submission.py) to see how to submit a Workflow using Hera and write your own. You can run the test Workflow using:
+
+```
+make test-on-cluster
+```
+
+See the [Viewing the Argo UI from a Codespace](../CONTRIBUTING.md#viewing-the-argo-ui-from-a-codespace) guide to see the Workflow in the UI.
+
+Otherwise you can install the Argo CLI with
+
+```
+make install-argo
+```
+
+which will then let you do things like listing the Workflows in the `argo` namespace with
+
+```
+argo list --namespace argo
+```
+
 #### Working in VSCode
 
 If your preferred IDE is VSCode, you may have an issue using the integrated Testing extension where breakpoints are not

--- a/docs/walk-through/quick-start.md
+++ b/docs/walk-through/quick-start.md
@@ -5,7 +5,8 @@
 [![Pypi](https://img.shields.io/pypi/v/hera.svg)](https://pypi.python.org/pypi/hera)
 
 Hera is available on PyPi as the `hera` package. Add this dependency to your project with your favourite package
-manager, e.g. [pip](https://packaging.python.org/en/latest/guides/tool-recommendations/#installing-packages) or [poetry](https://python-poetry.org/), or install directly with
+manager, e.g. [poetry](https://python-poetry.org/), or install directly with
+[pip](https://packaging.python.org/en/latest/guides/tool-recommendations/#installing-packages):
 
 ```
 pip install hera
@@ -19,7 +20,8 @@ can go straight to [Running Workflows from Hera](#running-workflows-from-hera) b
 
 ### Install Locally
 
-If you want to run on a local Kubernetes cluster (e.g. Docker Desktop), follow the Argo Workflows [Quick Start guide](https://argoproj.github.io/argo-workflows/quick-start/).
+If you want to run on a local Kubernetes cluster (e.g. Docker Desktop), follow the
+[Argo Workflows Quick Start guide](https://argoproj.github.io/argo-workflows/quick-start/).
 
 Ensure you are able to submit a workflow to Argo as in the example:
 
@@ -27,7 +29,8 @@ Ensure you are able to submit a workflow to Argo as in the example:
 argo submit -n argo --watch https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/hello-world.yaml
 ```
 
-Use the following command to port-forward the Argo Server to access the UI and so you can submit Workflows from Hera:
+Use the following command to port-forward the Argo Server; this allows you to access the UI and submit Workflows from
+Hera:
 
 ```console
 kubectl -n argo port-forward service/argo-server 2746:2746

--- a/docs/walk-through/quick-start.md
+++ b/docs/walk-through/quick-start.md
@@ -1,43 +1,25 @@
 # Quick Start
 
-## Install in GitHub Codespaces
+## Install Hera
 
-You can install Argo and try running Hera code in GitHub Codespaces. First, open the Hera repository in Codespaces using the link below:
+[![Pypi](https://img.shields.io/pypi/v/hera.svg)](https://pypi.python.org/pypi/hera)
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/argoproj-labs/hera)
-
-Then, you can run the `make` commands to install k3d (a lightweight Kubernetes CLI), and then install the Argo Workflows controller on the cluster:
-
-```
-make install-k3d run-argo
-```
-
-You can [take a look at `test_submission.py`](https://github.com/argoproj-labs/hera/blob/ec06876f1abc0d3309b000f3cd2e0eca64891da9/tests/test_submission.py) to see how to submit a Workflow using Hera and write your own. You can run the test Workflow using:
+Hera is available on PyPi as the `hera` package. Add this dependency to your project with your favourite package
+manager, e.g. [pip](https://packaging.python.org/en/latest/guides/tool-recommendations/#installing-packages) or [poetry](https://python-poetry.org/), or install directly with
 
 ```
-make test-on-cluster
+pip install hera
 ```
 
-See the [Viewing the Argo UI from a Codespace](../CONTRIBUTING.md#viewing-the-argo-ui-from-a-codespace) guide to see the Workflow in the UI.
+## Install Argo Workflows
 
-Otherwise you can install the Argo CLI with
+Hera is a Python SDK built for Argo Workflows, which runs on Kubernetes, therefore you will need a Kubernetes
+environment to run Argo Workflows and test out Hera. If you already have an existing Argo Workflows installation, you
+can go straight to [Running Workflows from Hera](#running-workflows-from-hera) below.
 
-```
-make install-argo
-```
+### Install Locally
 
-which will then let you do things like listing the Workflows in the `argo` namespace with
-
-```
-argo list --namespace argo
-```
-
-## Install locally
-
-### Install Argo tools
-
-Ensure you have a Kubernetes cluster, kubectl and Argo Workflows installed by following the
-[Argo Workflows Quick Start](https://argoproj.github.io/argo-workflows/quick-start/).
+If you want to run on a local Kubernetes cluster (e.g. Docker Desktop), follow the Argo Workflows [Quick Start guide](https://argoproj.github.io/argo-workflows/quick-start/).
 
 Ensure you are able to submit a workflow to Argo as in the example:
 
@@ -45,16 +27,21 @@ Ensure you are able to submit a workflow to Argo as in the example:
 argo submit -n argo --watch https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/hello-world.yaml
 ```
 
-### Install Hera
+Use the following command to port-forward the Argo Server to access the UI and so you can submit Workflows from Hera:
 
-[![Pypi](https://img.shields.io/pypi/v/hera.svg)](https://pypi.python.org/pypi/hera)
+```console
+kubectl -n argo port-forward service/argo-server 2746:2746
+```
 
-Hera is available on PyPi as the `hera` package. Add this dependency to your project in your usual way, e.g. pip or
-poetry, or install directly with `pip install hera`.
+Check that you can see the UI at <https://localhost:2746>.
 
-### Hello World
+Then go to [Running Workflows from Hera](#running-workflows-from-hera) below.
 
-If you were able to run the `argo submit` command above, copy the following Workflow definition into a local file
+## Running Workflows from Hera
+
+### Local Argo Workflows Installation
+
+Copy the following Workflow definition into a local file
 `hello_world.py`.
 
 ```py
@@ -75,7 +62,8 @@ with Workflow(
     with Steps(name="steps"):
         echo(arguments={"message": "Hello world!"})
 
-w.create()
+submitted_workflow = w.create()
+print(f"Workflow at https://localhost:2746/workflows/argo/{submitted_workflow.metadata.name}")
 ```
 
 Run the file
@@ -84,20 +72,20 @@ Run the file
 python -m hello_world
 ```
 
-You will then see the Workflow at <https://localhost:2746/>
+You will then see the Workflow at the specified link.
 
-## Using an existing Argo installation
+### Existing Cloud Installation of Argo Workflows
 
 If you or your organization are already running on Argo and you're interested in using Hera to write your Workflow
-definitions, you will need to set up some config variables in `hera.shared.global_config`. Copy the following as a basis
-and fill in the blanks.
+definitions, you will need to set up some config variables in `hera.shared.global_config`. Copy the following into a
+local file as a basis and fill in the blanks.
 
 ```py
 from hera.workflows import Steps, Workflow, script
 from hera.shared import global_config
 
 global_config.host = "https://<your-host-name>"
-global_config.token = ""  # Copy token value after "Bearer" from the `argo auth token` command
+global_config.token = ""  # Copy token value after "Bearer" from the CLI command `argo auth token`
 global_config.image = "<your-image-repository>/python:3.9"  # Set the image if you cannot access "python:3.9" via Docker Hub
 
 
@@ -123,4 +111,4 @@ Run the file
 python -m hello_world
 ```
 
-You will then see the Workflow at https://your-host-name
+You will then see the Workflow at `https://<your-host-name>`


### PR DESCRIPTION
**Description of PR**
* Reorder sections so that pip install is first, then describe local and cloud installations of Argo Workflows more clearly
* Move instructions for installing Argo Workflows in GitHub Codespaces to CONTRIBUTING.md
* Related to #965 but mainly comes from developer survey feedback
* Part of #1385 