### PR TITLE
Use a `readiness_probe` on daemon example

### DIFF
--- a/docs/examples/workflows/misc/daemon.md
+++ b/docs/examples/workflows/misc/daemon.md
@@ -2,19 +2,21 @@
 
 
 
-Enablement of https://argoproj.github.io/argo-workflows/variables/
-This example creates two tasks, one of the Tasks is a deamond task and its IP address is shared with the second task
-The daemoned task operates as server, serving an example payload, with the second task operating as a client, making
-http requests to the server.
+Demonstrates usage of [daemon container IP](https://argoproj.github.io/argo-workflows/variables/).
+
+This example creates two tasks, one of the Tasks is a daemon task and its IP address is shared with the second task. The
+daemon task operates as server, serving an example payload, with the second task operating as a client, making http
+requests to the server.
 
 
 === "Hera"
 
     ```python linenums="1"
     from hera.workflows import DAG, Workflow, script
+    from hera.workflows.models import HTTPGetAction, Probe
 
 
-    @script(daemon=True)
+    @script(daemon=True, readiness_probe=Probe(http_get=HTTPGetAction(path="/", port=8080)))
     def server():
         from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -92,6 +94,10 @@ http requests to the server.
             webServer.serve_forever()
           command:
           - python
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
       - name: consumer
         inputs:
           parameters:

--- a/examples/workflows/misc/daemon.py
+++ b/examples/workflows/misc/daemon.py
@@ -1,12 +1,14 @@
-"""Enablement of https://argoproj.github.io/argo-workflows/variables/
-This example creates two tasks, one of the Tasks is a deamond task and its IP address is shared with the second task
-The daemoned task operates as server, serving an example payload, with the second task operating as a client, making
-http requests to the server."""
+"""Demonstrates usage of [daemon container IP](https://argoproj.github.io/argo-workflows/variables/).
+
+This example creates two tasks, one of the Tasks is a daemon task and its IP address is shared with the second task. The
+daemon task operates as server, serving an example payload, with the second task operating as a client, making http
+requests to the server."""
 
 from hera.workflows import DAG, Workflow, script
+from hera.workflows.models import HTTPGetAction, Probe
 
 
-@script(daemon=True)
+@script(daemon=True, readiness_probe=Probe(http_get=HTTPGetAction(path="/", port=8080)))
 def server():
     from http.server import BaseHTTPRequestHandler, HTTPServer
 

--- a/examples/workflows/misc/daemon.yaml
+++ b/examples/workflows/misc/daemon.yaml
@@ -38,6 +38,10 @@ spec:
         webServer.serve_forever()
       command:
       - python
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 8080
   - name: consumer
     inputs:
       parameters:


### PR DESCRIPTION
* Exemplify best practice which is used in [the upstream docs](https://argo-workflows.readthedocs.io/en/latest/walk-through/daemon-containers/)
