### PR TITLE
Fetch new upstream examples

### DIFF
--- a/docs/examples/workflows-examples.md
+++ b/docs/examples/workflows-examples.md
@@ -37,6 +37,7 @@ Explore the examples through the side bar!
 | [dag-coinflip](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-coinflip.yaml) |
 | [dag-conditional-artifacts](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-conditional-artifacts.yaml) |
 | [dag-continue-on-fail](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-continue-on-fail.yaml) |
+| [dag-daemon-retry-strategy](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-daemon-retry-strategy.yaml) |
 | [dag-daemon-task](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-daemon-task.yaml) |
 | [dag-diamond-steps](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-diamond-steps.yaml) |
 | [dag-disable-failFast](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-disable-failFast.yaml) |
@@ -101,10 +102,14 @@ Explore the examples through the side bar!
 | [retry-with-steps](https://github.com/argoproj/argo-workflows/blob/main/examples/retry-with-steps.yaml) |
 | [scripts-bash](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-bash.yaml) |
 | [scripts-javascript](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-javascript.yaml) |
-| [scripts-python](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-python.yaml) |
 | [secrets](https://github.com/argoproj/argo-workflows/blob/main/examples/secrets.yaml) |
 | [status-reference](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml) |
 | [step-level-timeout](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml) |
+| [steps-daemon-retry-strategy](https://github.com/argoproj/argo-workflows/blob/main/examples/steps-daemon-retry-strategy.yaml) |
+| [synchronization-db-mutex-tmpl-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-db-mutex-tmpl-level.yaml) |
+| [synchronization-db-mutex-wf-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-db-mutex-wf-level.yaml) |
+| [synchronization-db-tmpl-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-db-tmpl-level.yaml) |
+| [synchronization-db-wf-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-db-wf-level.yaml) |
 | [synchronization-mutex-tmpl-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level.yaml) |
 | [synchronization-mutex-wf-level](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level.yaml) |
 | [synchronization-mutex-wf-level-legacy](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level-legacy.yaml) |

--- a/examples/workflows/upstream/dag-daemon-retry-strategy.upstream.yaml
+++ b/examples/workflows/upstream/dag-daemon-retry-strategy.upstream.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-daemon-retry-
+spec:
+  entrypoint: main
+
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: server
+        template: server
+      - name: client
+        depends: server
+        template: client
+        arguments:
+          parameters:
+          - name: server-ip
+            value: "{{tasks.server.ip}}"
+        withSequence:
+          count: "10"
+
+  - name: server
+    retryStrategy:
+      limit: "10"
+    daemon: true
+    container:
+      image: nginx:latest
+      command: ["nginx"]
+      args: ["-g", "daemon off;"]
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 2
+        timeoutSeconds: 1
+
+  - name: client
+    inputs:
+      parameters:
+      - name: server-ip
+    synchronization:
+      mutex:
+        name: client-{{workflow.uid}}
+    container:
+      image: appropriate/curl:latest
+      command: ["/bin/sh", "-c"]
+      args: ["echo curl --silent -G http://{{inputs.parameters.server-ip}}:80/ && curl --silent -G http://{{inputs.parameters.server-ip}}:80/"]
+

--- a/examples/workflows/upstream/steps-daemon-retry-strategy.upstream.yaml
+++ b/examples/workflows/upstream/steps-daemon-retry-strategy.upstream.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-daemon-retry-
+spec:
+  entrypoint: main
+
+  templates:
+  - name: main
+    steps:
+    - - name: server
+        template: server
+    - - name: client
+        template: client
+        arguments:
+          parameters:
+          - name: server-ip
+            value: "{{steps.server.ip}}"
+        withSequence:
+          count: "10"
+
+  - name: server
+    retryStrategy:
+      limit: "10"
+    daemon: true
+    container:
+      image: nginx:latest
+      command: ["nginx"]
+      args: ["-g", "daemon off;"]
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 2
+        timeoutSeconds: 1
+
+  - name: client
+    inputs:
+      parameters:
+      - name: server-ip
+    synchronization:
+      mutex:
+        name: client-{{workflow.uid}}
+    container:
+      image: appropriate/curl:latest
+      command: ["/bin/sh", "-c"]
+      args: ["echo curl --silent -G http://{{inputs.parameters.server-ip}}:80/ && curl --silent -G http://{{inputs.parameters.server-ip}}:80/"]
+

--- a/examples/workflows/upstream/synchronization-db-mutex-tmpl-level.upstream.yaml
+++ b/examples/workflows/upstream/synchronization-db-mutex-tmpl-level.upstream.yaml
@@ -1,0 +1,46 @@
+# This example demonstrates the use of a Synchronization Mutex lock on template execution. Mutex lock limits
+# only one of the template execution across the workflows in the namespace which has same Mutex lock.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-db-tmpl-level-mutex-
+spec:
+  entrypoint: synchronization-db-tmpl-level-mutex-example
+  templates:
+  - name: synchronization-db-tmpl-level-mutex-example
+    steps:
+    - - name: synchronization-acquire-lock
+        template: acquire-lock
+        arguments:
+          parameters:
+          - name: seconds
+            value: "{{item}}"
+        withParam: '["1","2","3","4","5"]'
+
+      - name: synchronization-acquire-lock1
+        template: acquire-lock-1
+        arguments:
+          parameters:
+            - name: seconds
+              value: "{{item}}"
+        withParam: '["1","2","3","4","5"]'
+
+  - name: acquire-lock
+    synchronization:
+      mutexes:
+        - name: welcome
+          database: true # v3.7 and after
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["sleep 20; echo acquired lock"]
+
+  - name: acquire-lock-1
+    synchronization:
+      mutexes:
+        - name: test
+          database: true # v3.7 and after
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["sleep 50; echo acquired lock"]

--- a/examples/workflows/upstream/synchronization-db-mutex-wf-level.upstream.yaml
+++ b/examples/workflows/upstream/synchronization-db-mutex-wf-level.upstream.yaml
@@ -1,0 +1,18 @@
+# This example demonstrates the use of a Synchronization Mutex lock on workflow execution. Mutex lock limits
+# only one of the workflow execution in the namespace which has same Mutex lock.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-db-wf-level-
+spec:
+  entrypoint: hello-world
+  synchronization:
+    mutexes:
+      - name: test
+        database: true # v3.7 and after
+  templates:
+    - name: hello-world
+      container:
+        image: busybox
+        command: [echo]
+        args: ["hello world"]

--- a/examples/workflows/upstream/synchronization-db-tmpl-level.upstream.yaml
+++ b/examples/workflows/upstream/synchronization-db-tmpl-level.upstream.yaml
@@ -1,0 +1,30 @@
+# This example demonstrates the use of a Synchronization lock on template execution. Synchronization lock limits
+# the number of concurrent template execution across the workflows in the namespace which has same Synchronization lock.
+# Synchronization limit value can be configured in the database.
+# INSERT INTO sync_limit (name, sizeLimit) VALUES ('<namespace>/template', 2);
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-db-tmpl-level-
+spec:
+  entrypoint: synchronization-db-tmpl-level-example
+  templates:
+  - name: synchronization-db-tmpl-level-example
+    steps:
+    - - name: synchronization-acquire-lock
+        template: acquire-lock
+        arguments:
+          parameters:
+          - name: seconds
+            value: "{{item}}"
+        withParam: '["1","2","3","4","5"]'
+
+  - name: acquire-lock
+    synchronization:
+      semaphores:
+        - database: # v3.7 and after
+            key: template
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["sleep 10; echo acquired lock"]

--- a/examples/workflows/upstream/synchronization-db-wf-level.upstream.yaml
+++ b/examples/workflows/upstream/synchronization-db-wf-level.upstream.yaml
@@ -1,0 +1,19 @@
+# This example demonstrates the use of a database Synchronization lock on workflow execution. Synchronization lock limits the number of concurrent workflow execution in the namespace which has same Synchronization lock.
+# Synchronization limit value can be configured in the database.
+# INSERT INTO sync_limit (name, sizeLimit) VALUES ('<namespace>/workflow', 2);
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-db-wf-level-
+spec:
+  entrypoint: hello-world
+  synchronization:
+    semaphores:
+      - database: # v3.7 and after
+          key: workflow
+  templates:
+    - name: hello-world
+      container:
+        image: busybox
+        command: [echo]
+        args: ["hello world"]

--- a/tests/test_remaining_examples.py
+++ b/tests/test_remaining_examples.py
@@ -24,6 +24,10 @@ UPSTREAM_EXAMPLE_XFAIL_FILES = [
     "loops-param-argument.upstream.yaml",
     "retry-backoff.upstream.yaml",
     "workflow-event-binding__github-path-filter-workflowtemplate.upstream.yaml",
+    "synchronization-db-tmpl-level.upstream.yaml",
+    "synchronization-db-mutex-tmpl-level.upstream.yaml",
+    "synchronization-db-mutex-wf-level.upstream.yaml",
+    "synchronization-db-wf-level.upstream.yaml",
 ]
 
 


### PR DESCRIPTION
Ran `make test` on 3.9 to fetch new upstream examples