### PR TITLE
Set Artifact `name` to `None` by default

### DIFF
--- a/src/hera/workflows/artifact.py
+++ b/src/hera/workflows/artifact.py
@@ -49,7 +49,7 @@ class ArtifactLoader(Enum):
 class Artifact(BaseModel):
     """Base artifact representation."""
 
-    name: Optional[str]
+    name: Optional[str] = None
     """name of the artifact"""
 
     archive: Optional[Union[_ModelArchiveStrategy, ArchiveStrategy]] = None


### PR DESCRIPTION
**Description of PR**
1 liner to fix instantiating `Artifact` without writing `Artifact(name=None)`

Reported by @alicederyn 