### PR TITLE
Fix module for script runners generated by CLI and from `__main__`

### DIFF
--- a/src/hera/_cli/generate/__init__.py
+++ b/src/hera/_cli/generate/__init__.py
@@ -1,3 +1,5 @@
+"""Code generation CLI functions."""
+
 from hera._cli.generate import yaml
 
 __all__ = [

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -47,8 +48,13 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
     Returns:
         A list containing all `Workflow` objects defined within that module.
     """
-    module_name = path.stem
-    spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
+    try:
+        module_name = ".".join(str(path.resolve().relative_to(Path(os.getcwd()))).replace(".py", "").split("/"))
+        spec = importlib.util.spec_from_file_location(module_name, path)
+    except ValueError:
+        module_name = path.stem
+        spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
+
     assert spec
 
     module = importlib.util.module_from_spec(spec)

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -46,13 +46,8 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
     Returns:
         A list containing all `Workflow` objects defined within that module.
     """
-    try:
-        module_name = create_module_string(path)
-        spec = importlib.util.spec_from_file_location(module_name, path)
-    except ValueError:
-        module_name = path.stem
-        spec = importlib.util.spec_from_file_location(module_name, path, submodule_search_locations=[str(path.parent)])
-
+    module_name = create_module_string(path)
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec
 
     module = importlib.util.module_from_spec(spec)

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -1,5 +1,3 @@
-"""The main entrypoint for hera CLI."""
-
 from __future__ import annotations
 
 import importlib.util

--- a/src/hera/_cli/generate/yaml.py
+++ b/src/hera/_cli/generate/yaml.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 from pathlib import Path
 
 from hera._cli.base import GenerateYaml
 from hera._cli.generate.util import YAML_EXTENSIONS, convert_code, expand_paths, write_output
+from hera.workflows._runner.util import create_module_string
 from hera.workflows.workflow import Workflow
 
 DEFAULT_EXTENSION = ".yaml"
@@ -49,7 +49,7 @@ def load_workflows_from_module(path: Path) -> list[Workflow]:
         A list containing all `Workflow` objects defined within that module.
     """
     try:
-        module_name = ".".join(str(path.resolve().relative_to(Path(os.getcwd()))).replace(".py", "").split("/"))
+        module_name = create_module_string(path)
         spec = importlib.util.spec_from_file_location(module_name, path)
     except ValueError:
         module_name = path.stem

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -300,11 +300,27 @@ def _run() -> None:
 
 
 def create_module_string(path: Path) -> str:
-    """Create a Python module path from the relative path to the file from the current working directory.
+    """Create a Python module path from the given path.
 
-    e.g. if cwd is "/project" and the file is "/project/workflows/wf_a.py", then the returned string will be
+    We find the most specific sys.path to create a valid, importable module path to the given path.
+
+    e.g. if sys.path contains "/project" and the file is "/project/workflows/wf_a.py", then the returned string will be
     "workflows.wf_a"
 
-    Raises a ValueError if the path is not a subpath of cwd
+    If we cannot find a valid sys.path, we simply use the file stem, e.g. for the
+    file "/project/workflows/wf_a.py", return `wf_a`.
     """
-    return ".".join(str(path.resolve().relative_to(Path(os.getcwd()))).replace(".py", "").split("/"))
+    path = path.resolve()
+
+    # find the most specific sys.path that contains the given path
+    candidates = []
+    for base in map(lambda p: Path(p).resolve(), sys.path + [os.getcwd()]):
+        if path.is_relative_to(base):
+            candidates.append(base)
+
+    if not candidates:
+        return path.stem
+
+    # use the most specific sys.path to construct a valid module path to import
+    base_path = max(candidates, key=lambda p: len(str(p)))
+    return ".".join(str(path.resolve().relative_to(base_path)).replace(".py", "").split("/"))

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -297,3 +297,12 @@ def _run() -> None:
         exit(result.exit_code)
 
     print(serialize(result))
+
+
+def create_module_string(path: Path) -> str:
+    """Create a Python module path from the relative path to the file from the current working directory.
+
+    e.g. if cwd is "/project" and the file is "/project/workflows/wf_a.py", then module_path will be
+    ["workflows", "wf_a"]
+    """
+    return ".".join(str(path.resolve().relative_to(Path(os.getcwd()))).replace(".py", "").split("/"))

--- a/src/hera/workflows/_runner/util.py
+++ b/src/hera/workflows/_runner/util.py
@@ -302,7 +302,9 @@ def _run() -> None:
 def create_module_string(path: Path) -> str:
     """Create a Python module path from the relative path to the file from the current working directory.
 
-    e.g. if cwd is "/project" and the file is "/project/workflows/wf_a.py", then module_path will be
-    ["workflows", "wf_a"]
+    e.g. if cwd is "/project" and the file is "/project/workflows/wf_a.py", then the returned string will be
+    "workflows.wf_a"
+
+    Raises a ValueError if the path is not a subpath of cwd
     """
     return ".".join(str(path.resolve().relative_to(Path(os.getcwd()))).replace(".py", "").split("/"))

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -7,7 +7,6 @@ for more on scripts in Argo Workflows.
 import ast
 import copy
 import inspect
-import os
 import sys
 import textwrap
 from abc import abstractmethod
@@ -858,12 +857,9 @@ class RunnerScriptConstructor(ScriptConstructor):
         module = values["source"].__module__
 
         if module == "__main__":
-            file_path = (
-                str(Path(values["source"].__globals__["__file__"]).relative_to(Path(os.getcwd())))
-                .replace(".py", "")
-                .split("/")
-            )
-            module = ".".join(file_path)
+            from hera.workflows._runner.util import create_module_string
+
+            module = create_module_string(Path(values["source"].__globals__["__file__"]))
 
         values["args"] = [
             "-m",

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -7,10 +7,12 @@ for more on scripts in Argo Workflows.
 import ast
 import copy
 import inspect
+import os
 import sys
 import textwrap
 from abc import abstractmethod
 from functools import wraps
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -852,11 +854,22 @@ class RunnerScriptConstructor(ScriptConstructor):
 
         if values.get("args") is not None:
             raise ValueError("Cannot specify args when callable is True")
+
+        module = values["source"].__module__
+
+        if module == "__main__":
+            file_path = (
+                str(Path(values["source"].__globals__["__file__"]).relative_to(Path(os.getcwd())))
+                .replace(".py", "")
+                .split("/")
+            )
+            module = ".".join(file_path)
+
         values["args"] = [
             "-m",
             "hera.workflows.runner",
             "-e",
-            f"{values['source'].__module__}:{values['source'].__name__}",
+            f"{module}:{values['source'].__name__}",
         ]
 
         return values

--- a/tests/cli/examples/runner_workflow.py
+++ b/tests/cli/examples/runner_workflow.py
@@ -1,0 +1,13 @@
+from hera.workflows import Workflow, script
+
+
+@script(constructor="runner")
+def hello():
+    pass
+
+
+with Workflow(
+    generate_name="runner-workflow-",
+    entrypoint="hello",
+) as w:
+    hello()

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -118,6 +119,16 @@ def test_runner_workflow(capsys):
 
     output = get_stdout(capsys)
     assert output == runner_workflow_output
+
+
+@pytest.mark.cli
+def test_runner_workflow_not_in_cwd(capsys, tmp_path):
+    shutil.copy("tests/cli/examples/runner_workflow.py", tmp_path)
+    runner.invoke(str(tmp_path / "runner_workflow.py"))
+
+    output = get_stdout(capsys)
+    # The module is not in sys.path so we just use the stem of the workflow (i.e. best guess)
+    assert output == runner_workflow_output.replace("tests.cli.examples.runner_workflow", "runner_workflow")
 
 
 @pytest.mark.cli

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -23,43 +23,65 @@ def patch_open():
     return patch("io.open", new=mock_open())
 
 
-single_workflow_output = dedent("""\
-    apiVersion: argoproj.io/v1alpha1
-    kind: Workflow
-    metadata:
-      name: single
-    spec: {}
-    """)
+single_workflow_output = """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: single
+spec: {}
+"""
 
-workflow_template_output = dedent("""\
-    apiVersion: argoproj.io/v1alpha1
-    kind: WorkflowTemplate
-    metadata:
-      name: workflow-template
-    spec: {}
-    """)
+runner_workflow_output = """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: runner-workflow-
+spec:
+  entrypoint: hello
+  templates:
+  - name: hello
+    script:
+      image: python:3.9
+      source: '{{inputs.parameters}}'
+      args:
+      - -m
+      - hera.workflows.runner
+      - -e
+      - tests.cli.examples.runner_workflow:hello
+      command:
+      - python
+"""
 
-cluster_workflow_template_output = dedent("""\
-    apiVersion: argoproj.io/v1alpha1
-    kind: ClusterWorkflowTemplate
-    metadata:
-      name: cluster-workflow-template
-    spec: {}
-    """)
 
-multiple_workflow_output = dedent("""\
-    apiVersion: argoproj.io/v1alpha1
-    kind: Workflow
-    metadata:
-      name: one
-    spec: {}
-    ---
-    apiVersion: argoproj.io/v1alpha1
-    kind: Workflow
-    metadata:
-      name: two
-    spec: {}
-    """)
+workflow_template_output = """\
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: workflow-template
+spec: {}
+"""
+
+cluster_workflow_template_output = """\
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: cluster-workflow-template
+spec: {}
+"""
+
+multiple_workflow_output = """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: one
+spec: {}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: two
+spec: {}
+"""
 
 whole_folder_output = join_output(
     cluster_workflow_template_output,
@@ -87,6 +109,14 @@ def test_single_workflow(capsys):
 
     output = get_stdout(capsys)
     assert output == single_workflow_output
+
+
+@pytest.mark.cli
+def test_runner_workflow(capsys):
+    runner.invoke("tests/cli/examples/runner_workflow.py")
+
+    output = get_stdout(capsys)
+    assert output == runner_workflow_output
 
 
 @pytest.mark.cli

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -86,6 +86,7 @@ spec: {}
 whole_folder_output = join_output(
     cluster_workflow_template_output,
     multiple_workflow_output,
+    runner_workflow_output,
     single_workflow_output,
     workflow_template_output,
 )
@@ -338,7 +339,11 @@ def test_exclude_one(capsys):
     runner.invoke("tests/cli/examples", "--exclude=*/examples/*template*")
 
     output = get_stdout(capsys)
-    assert output == join_output(multiple_workflow_output, single_workflow_output)
+    assert output == join_output(
+        multiple_workflow_output,
+        runner_workflow_output,
+        single_workflow_output,
+    )
 
 
 @pytest.mark.cli
@@ -350,7 +355,7 @@ def test_exclude_two(capsys):
     )
 
     output = get_stdout(capsys)
-    assert output == multiple_workflow_output
+    assert output == join_output(multiple_workflow_output, runner_workflow_output)
 
 
 @pytest.mark.cli

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1096,4 +1096,9 @@ def test_script_runner_generation_from_main():
     ) as w:
         Script(name="hello", source=hello, constructor="runner")
 
-    assert w.to_dict()["spec"]["templates"][0]["script"]["args"][3] == "tests.test_runner:hello"
+    assert w.to_dict()["spec"]["templates"][0]["script"]["args"] == [
+        "-m",
+        "hera.workflows.runner",
+        "-e",
+        "tests.test_runner:hello",
+    ]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1079,3 +1079,21 @@ def test_script_partially_annotated_tuple_should_raise_an_error():
         ),
     ):
         _runner(entrypoint, kwargs_list)
+
+
+def test_script_runner_generation_from_main():
+    from hera.workflows import Script, Workflow
+
+    def hello(s: str):
+        print("Hello, {s}!".format(s=s))
+
+    hello.__module__ = "__main__"
+
+    with Workflow(
+        generate_name="hello-world-",
+        entrypoint="hello",
+        arguments={"s": "world"},
+    ) as w:
+        Script(name="hello", source=hello, constructor="runner")
+
+    assert w.to_dict()["spec"]["templates"][0]["script"]["args"][3] == "tests.test_runner:hello"


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #573, Fixes #1161
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, Script Runners cannot be exported to YAML correctly if they are contained in the same module as `__main__`, i.e. when trying to export a workflow using the file it's written in, as the `transform_values` sees `__main__` as the module. The CLI also ignores the full path spec of the function, only using the stem.

This PR fixes both cases by using a utility function to construct a valid module path.