### PR TITLE
Fix command for complex_expr example

### DIFF
--- a/docs/examples/workflows/misc/complex_expr.md
+++ b/docs/examples/workflows/misc/complex_expr.md
@@ -56,7 +56,10 @@ https://github.com/argoproj/argo-workflows/blob/main/examples/expression-reusing
                 Env(name="MAX", value=f"{week_temps_jsonpath('$.max'):=}"),
                 Env(name="AVG", value=f"{week_temps_jsonpath('$.avg'):=}"),
             ],
-            command=["echo", "The week's average temperature was $AVG with a minimum of $MIN and a maximum of $MAX."],
+            command=[
+                "echo",
+                "The week's average temperature was $(AVG) with a minimum of $(MIN) and a maximum of $(MAX).",
+            ],
             image="alpine:3.7",
         )
     ```
@@ -76,8 +79,8 @@ https://github.com/argoproj/argo-workflows/blob/main/examples/expression-reusing
           image: alpine:3.7
           command:
           - echo
-          - The week's average temperature was $AVG with a minimum of $MIN and a maximum
-            of $MAX.
+          - The week's average temperature was $(AVG) with a minimum of $(MIN) and a maximum
+            of $(MAX).
           env:
           - name: MIN
             value: '{{=jsonpath(inputs.parameters[''week-temps''], ''$.min'')}}'

--- a/examples/workflows/misc/complex-expr.yaml
+++ b/examples/workflows/misc/complex-expr.yaml
@@ -10,8 +10,8 @@ spec:
       image: alpine:3.7
       command:
       - echo
-      - The week's average temperature was $AVG with a minimum of $MIN and a maximum
-        of $MAX.
+      - The week's average temperature was $(AVG) with a minimum of $(MIN) and a maximum
+        of $(MAX).
       env:
       - name: MIN
         value: '{{=jsonpath(inputs.parameters[''week-temps''], ''$.min'')}}'

--- a/examples/workflows/misc/complex_expr.py
+++ b/examples/workflows/misc/complex_expr.py
@@ -49,6 +49,9 @@ with Workflow(
             Env(name="MAX", value=f"{week_temps_jsonpath('$.max'):=}"),
             Env(name="AVG", value=f"{week_temps_jsonpath('$.avg'):=}"),
         ],
-        command=["echo", "The week's average temperature was $AVG with a minimum of $MIN and a maximum of $MAX."],
+        command=[
+            "echo",
+            "The week's average temperature was $(AVG) with a minimum of $(MIN) and a maximum of $(MAX).",
+        ],
         image="alpine:3.7",
     )


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #742 

**Description of PR**
Command was just missing parentheses for the env vars. Now working e.g.

```
The week's average temperature was 35.8 with a minimum of 15 and a maximum of 57.
```