### PR TITLE
Add Hera `RetryStrategy` to `TemplateMixin` and `Workflow`

### DIFF
--- a/docs/examples/workflows/misc/retry_workflow.md
+++ b/docs/examples/workflows/misc/retry_workflow.md
@@ -1,0 +1,67 @@
+# Retry Workflow
+
+
+
+This examples uses a RetryStrategy at the Workflow level, rather than the template level.
+
+The Workflow is functionally equivalent to the
+[Retry Container To Completion](../upstream/retry_container_to_completion.md) example, but as the RetryStrategy is on
+the Workflow itself, it will apply by default to *all* templates in the Workflow.
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import (
+        Container,
+        RetryStrategy,
+        Workflow,
+        models as m,
+    )
+
+    with Workflow(
+        generate_name="retry-backoff-",
+        entrypoint="retry-backoff",
+        retry_strategy=RetryStrategy(
+            limit="10",
+            backoff=m.Backoff(
+                duration="1",
+                factor="2",
+                max_duration="1m",
+            ),
+        ),
+    ) as w:
+        retry_backoff = Container(
+            name="retry-backoff",
+            image="python:alpine3.6",
+            command=["python", "-c"],
+            args=["import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)"],
+        )
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: retry-backoff-
+    spec:
+      entrypoint: retry-backoff
+      templates:
+      - name: retry-backoff
+        container:
+          image: python:alpine3.6
+          args:
+          - import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)
+          command:
+          - python
+          - -c
+      retryStrategy:
+        limit: '10'
+        backoff:
+          duration: '1'
+          factor: '2'
+          maxDuration: 1m
+    ```
+

--- a/examples/workflows/misc/retry-workflow.yaml
+++ b/examples/workflows/misc/retry-workflow.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: retry-backoff-
+spec:
+  entrypoint: retry-backoff
+  templates:
+  - name: retry-backoff
+    container:
+      image: python:alpine3.6
+      args:
+      - import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)
+      command:
+      - python
+      - -c
+  retryStrategy:
+    limit: '10'
+    backoff:
+      duration: '1'
+      factor: '2'
+      maxDuration: 1m

--- a/examples/workflows/misc/retry_workflow.py
+++ b/examples/workflows/misc/retry_workflow.py
@@ -1,0 +1,32 @@
+"""This examples uses a RetryStrategy at the Workflow level, rather than the template level.
+
+The Workflow is functionally equivalent to the
+[Retry Container To Completion](../upstream/retry_container_to_completion.md) example, but as the RetryStrategy is on
+the Workflow itself, it will apply by default to *all* templates in the Workflow.
+"""
+
+from hera.workflows import (
+    Container,
+    RetryStrategy,
+    Workflow,
+    models as m,
+)
+
+with Workflow(
+    generate_name="retry-backoff-",
+    entrypoint="retry-backoff",
+    retry_strategy=RetryStrategy(
+        limit="10",
+        backoff=m.Backoff(
+            duration="1",
+            factor="2",
+            max_duration="1m",
+        ),
+    ),
+) as w:
+    retry_backoff = Container(
+        name="retry-backoff",
+        image="python:alpine3.6",
+        command=["python", "-c"],
+        args=["import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)"],
+    )

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -54,7 +54,7 @@ from hera.workflows.models import (
     Probe,
     Prometheus as ModelPrometheus,
     ResourceRequirements,
-    RetryStrategy,
+    RetryStrategy as ModelRetryStrategy,
     Sequence,
     Synchronization,
     Template,
@@ -68,6 +68,7 @@ from hera.workflows.models import (
 from hera.workflows.parameter import Parameter
 from hera.workflows.protocol import Templatable
 from hera.workflows.resources import Resources
+from hera.workflows.retry_strategy import RetryStrategy
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import Volume, _BaseVolume
 
@@ -456,7 +457,7 @@ class TemplateMixin(SubNodeMixin, HookMixin, MetricsMixin):
     pod_spec_patch: Optional[str] = None
     priority: Optional[int] = None
     priority_class_name: Optional[str] = None
-    retry_strategy: Optional[RetryStrategy] = None
+    retry_strategy: Optional[Union[RetryStrategy, ModelRetryStrategy]] = None
     scheduler_name: Optional[str] = None
     pod_security_context: Optional[PodSecurityContext] = None
     service_account_name: Optional[str] = None
@@ -497,6 +498,15 @@ class TemplateMixin(SubNodeMixin, HookMixin, MetricsMixin):
             annotations=self.annotations,
             labels=self.labels,
         )
+
+    def _build_retry_strategy(self) -> Optional[ModelRetryStrategy]:
+        if self.retry_strategy is None:
+            return None
+
+        if isinstance(self.retry_strategy, RetryStrategy):
+            return self.retry_strategy.build()
+
+        return self.retry_strategy
 
 
 class ResourceMixin(BaseMixin):

--- a/src/hera/workflows/container.py
+++ b/src/hera/workflows/container.py
@@ -103,7 +103,7 @@ class Container(
             pod_spec_patch=self.pod_spec_patch,
             priority=self.priority,
             priority_class_name=self.priority_class_name,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -189,7 +189,7 @@ class ContainerSet(
             pod_spec_patch=self.pod_spec_patch,
             priority=self.priority,
             priority_class_name=self.priority_class_name,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -80,7 +80,7 @@ class DAG(
             pod_spec_patch=self.pod_spec_patch,
             priority=self.priority,
             priority_class_name=self.priority_class_name,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/data.py
+++ b/src/hera/workflows/data.py
@@ -56,7 +56,7 @@ class Data(TemplateMixin, IOMixin, CallableTemplateMixin):
             plugin=self.plugin,
             priority=self.priority,
             priority_class_name=self.priority_class_name,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/http_template.py
+++ b/src/hera/workflows/http_template.py
@@ -58,7 +58,7 @@ class HTTP(TemplateMixin, IOMixin, CallableTemplateMixin):
             plugin=self.plugin,
             priority=self.priority,
             priority_class_name=self.priority_class_name,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/resource.py
+++ b/src/hera/workflows/resource.py
@@ -75,7 +75,7 @@ class Resource(CallableTemplateMixin, TemplateMixin, SubNodeMixin, IOMixin):
             priority=self.priority,
             priority_class_name=self.priority_class_name,
             resource=self._build_resource_template(),
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -217,7 +217,7 @@ class Script(
                 pod_spec_patch=self.pod_spec_patch,
                 priority=self.priority,
                 priority_class_name=self.priority_class_name,
-                retry_strategy=self.retry_strategy,
+                retry_strategy=self._build_retry_strategy(),
                 scheduler_name=self.scheduler_name,
                 script=self._build_script(),
                 security_context=self.pod_security_context,

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -224,7 +224,7 @@ class Steps(
             priority=self.priority,
             priority_class_name=self.priority_class_name,
             resource=None,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             script=None,
             security_context=self.pod_security_context,

--- a/src/hera/workflows/suspend.py
+++ b/src/hera/workflows/suspend.py
@@ -96,7 +96,7 @@ class Suspend(
             plugin=self.plugin,
             priority_class_name=self.priority_class_name,
             priority=self.priority,
-            retry_strategy=self.retry_strategy,
+            retry_strategy=self._build_retry_strategy(),
             scheduler_name=self.scheduler_name,
             security_context=self.pod_security_context,
             service_account_name=self.service_account_name,

--- a/tests/test_unit/test_mixins.py
+++ b/tests/test_unit/test_mixins.py
@@ -1,13 +1,22 @@
 import pytest
 
 from hera.workflows import Env, Parameter, Workflow
-from hera.workflows._mixins import ArgumentsMixin, ContainerMixin, EnvMixin, IOMixin, VolumeMixin, VolumeMountMixin
+from hera.workflows._mixins import (
+    ArgumentsMixin,
+    ContainerMixin,
+    EnvMixin,
+    IOMixin,
+    TemplateMixin,
+    VolumeMixin,
+    VolumeMountMixin,
+)
 from hera.workflows.models import (
     Arguments as ModelArguments,
     Artifact as ModelArtifact,
     EmptyDirVolumeSource,
     ImagePullPolicy,
     Inputs as ModelInputs,
+    IntOrString,
     ObjectMeta,
     Outputs as ModelOutputs,
     Parameter as ModelParameter,
@@ -15,10 +24,12 @@ from hera.workflows.models import (
     PersistentVolumeClaimSpec,
     PersistentVolumeClaimVolumeSource,
     Quantity,
+    RetryStrategy as ModelRetryStrategy,
     Volume as ModelVolume,
     VolumeMount,
     VolumeResourceRequirements,
 )
+from hera.workflows.retry_strategy import RetryStrategy
 from hera.workflows.volume import ExistingVolume, Volume
 
 
@@ -30,6 +41,22 @@ class TestContainerMixin:
             == ImagePullPolicy.always.value
         )
         assert ContainerMixin()._build_image_pull_policy() is None
+
+
+class TestTemplateMixin:
+    def test_build_retry_strategy(self):
+        # None
+        assert TemplateMixin(retry_strategy=None)._build_retry_strategy() is None
+
+        # Model class
+        assert TemplateMixin(
+            retry_strategy=ModelRetryStrategy(limit=IntOrString(__root__=2))
+        )._build_retry_strategy() == ModelRetryStrategy(limit=IntOrString(__root__=2))
+
+        # Hera class
+        assert TemplateMixin(retry_strategy=RetryStrategy(limit=2))._build_retry_strategy() == ModelRetryStrategy(
+            limit=IntOrString(__root__=2)
+        )
 
 
 class TestIOMixin:


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1454 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, the `RetryStrategy` from `hera.workflows.retry_strategy` is not used for fields of `TemplateMixin` and `Workflow`, which actually use the `RetryStrategy` from `hera.workflows.models`, meaning the use of the Hera class will fail linting (but otherwise worked correctly as the fields were the same). This PR updates the type to the a union of the two, and adds the build function.