### PR TITLE
Add `set_next_defaults` function for `Task` and allow multiple `on` values

### DIFF
--- a/docs/examples/workflows/dags/dag_configurable_rshift.md
+++ b/docs/examples/workflows/dags/dag_configurable_rshift.md
@@ -1,0 +1,121 @@
+# Dag Configurable Rshift
+
+
+
+This example shows how to override the defaults for the "next" function to configure the rshift (`>>`) behaviour.
+
+This is useful if you want `A >> B` to mean "run B _only if_ A succeeded", otherwise the
+[default depends logic](https://argo-workflows.readthedocs.io/en/latest/enhanced-depends-logic/) means `A >> B` is
+equivalent to "B depends on `A.Succeeded || A.Skipped || A.Daemoned`".
+
+By setting the values in `Task.set_next_defaults`, we can configure the rshift behaviour to use a different operator
+and TaskResult. Then, the following
+
+```py
+with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+    A >> [B, C] >> D
+```
+
+is equivalent to
+
+```py
+A.next(B, on=TaskResult.succeeded)
+A.next(C, on=TaskResult.succeeded)
+B.next(D, on=TaskResult.succeeded)
+C.next(D, operator=Operator.or_, on=TaskResult.succeeded)
+```
+
+> Note the `Operator.or_` for D's `depends` is set when calling `C.next` which can also be confusing! This is because we
+> use `next` to describe the forward relationships, while the Argo field is `depends` which describes the backward
+> relationships.
+
+Or, described using the backward relationship of `depends` (which only accepts strings):
+```py
+B.depends = "A.Succeeded"
+C.depends = "A.Succeeded"
+D.depends = "B.Succeeded || C.Succeeded"
+```
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import DAG, Task, TaskResult, Workflow, script
+    from hera.workflows.operator import Operator
+
+
+    @script(image="python:3.12")
+    def echo(message):
+        print(message)
+
+
+    with Workflow(generate_name="dag-configurable-rshift-", entrypoint="diamond") as w:
+        with DAG(name="diamond"):
+            A = echo(name="A", arguments={"message": "A"})
+            B = echo(name="B", arguments={"message": "B"})
+            C = echo(name="C", arguments={"message": "C"})
+            D = echo(name="D", arguments={"message": "D"})
+
+            with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+                A >> [B, C] >> D
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: dag-configurable-rshift-
+    spec:
+      entrypoint: diamond
+      templates:
+      - name: diamond
+        dag:
+          tasks:
+          - name: A
+            template: echo
+            arguments:
+              parameters:
+              - name: message
+                value: A
+          - name: B
+            depends: A.Succeeded
+            template: echo
+            arguments:
+              parameters:
+              - name: message
+                value: B
+          - name: C
+            depends: A.Succeeded
+            template: echo
+            arguments:
+              parameters:
+              - name: message
+                value: C
+          - name: D
+            depends: B.Succeeded || C.Succeeded
+            template: echo
+            arguments:
+              parameters:
+              - name: message
+                value: D
+      - name: echo
+        inputs:
+          parameters:
+          - name: message
+        script:
+          image: python:3.12
+          source: |-
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: message = json.loads(r'''{{inputs.parameters.message}}''')
+            except: message = r'''{{inputs.parameters.message}}'''
+
+            print(message)
+          command:
+          - python
+    ```
+

--- a/docs/examples/workflows/dags/dag_configurable_rshift.md
+++ b/docs/examples/workflows/dags/dag_configurable_rshift.md
@@ -36,6 +36,8 @@ C.depends = "A.Succeeded"
 D.depends = "B.Succeeded || C.Succeeded"
 ```
 
+> `set_next_defaults` also accepts lists or multiple values using the `|` operator!
+
 
 === "Hera"
 

--- a/docs/walk-through/dags.md
+++ b/docs/walk-through/dags.md
@@ -271,4 +271,13 @@ C.depends = "A.Succeeded"
 D.depends = "B.Succeeded || C.Succeeded"
 ```
 
+The `set_next_defaults` function also accepts lists or values applying the `|` operator for the `on` value, meaning you can also specify conditions like `B.depends = "A.Succeeded || A.Daemoned"`, without affecting the `operator` used. E.g:
+
+```py
+with Task.set_next_defaults(operator=Operator.and_, on=TaskResult.succeeded | TaskResult.skipped):
+    [task_a, task_b] >> task_c
+
+assert task_c.depends == "(task-a.Skipped || task-a.Succeeded) && (task-b.Skipped || task-b.Succeeded)"
+```
+
 See the [DAG Configurable rshift example](../examples/workflows/dags/dag_configurable_rshift.md) for the full code!

--- a/docs/walk-through/dags.md
+++ b/docs/walk-through/dags.md
@@ -233,3 +233,42 @@ A   B
 | X |
 C   D
 ```
+
+## Configuring the Default "Next" Behaviour for `>>`
+
+Hera v5.24 added the `Task.set_next_defaults` function, allowing you to set the default `operator` and `on` values
+within a scoped context, which by extension allows you to configure the rshift (`>>`) behaviour.
+
+This is useful if you want `A >> B` to mean "run B _only if_ A succeeded", otherwise the
+[default depends logic](https://argo-workflows.readthedocs.io/en/latest/enhanced-depends-logic/) means `A >> B` is
+equivalent to "B depends on `A.Succeeded || A.Skipped || A.Daemoned`".
+
+By setting the values in `Task.set_next_defaults`, we can configure the rshift behaviour to use a different operator
+and TaskResult. Then, the following
+
+```py
+with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+    A >> [B, C] >> D
+```
+
+is equivalent to
+
+```py
+A.next(B, on=TaskResult.succeeded)
+A.next(C, on=TaskResult.succeeded)
+B.next(D, on=TaskResult.succeeded)
+C.next(D, operator=Operator.or_, on=TaskResult.succeeded)
+```
+
+> Note the `Operator.or_` for D's `depends` is set when calling `C.next` which can also be confusing! This is because we
+> use `next` to describe the forward relationships, while the Argo field is `depends` which describes the backward
+> relationships.
+
+Or, described using the backward relationship of `depends` (which only accepts strings):
+```py
+B.depends = "A.Succeeded"
+C.depends = "A.Succeeded"
+D.depends = "B.Succeeded || C.Succeeded"
+```
+
+See the [DAG Configurable rshift example](../examples/workflows/dags/dag_configurable_rshift.md) for the full code!

--- a/examples/workflows/dags/dag-configurable-rshift.yaml
+++ b/examples/workflows/dags/dag-configurable-rshift.yaml
@@ -1,0 +1,54 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-configurable-rshift-
+spec:
+  entrypoint: diamond
+  templates:
+  - name: diamond
+    dag:
+      tasks:
+      - name: A
+        template: echo
+        arguments:
+          parameters:
+          - name: message
+            value: A
+      - name: B
+        depends: A.Succeeded
+        template: echo
+        arguments:
+          parameters:
+          - name: message
+            value: B
+      - name: C
+        depends: A.Succeeded
+        template: echo
+        arguments:
+          parameters:
+          - name: message
+            value: C
+      - name: D
+        depends: B.Succeeded || C.Succeeded
+        template: echo
+        arguments:
+          parameters:
+          - name: message
+            value: D
+  - name: echo
+    inputs:
+      parameters:
+      - name: message
+    script:
+      image: python:3.12
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import json
+        try: message = json.loads(r'''{{inputs.parameters.message}}''')
+        except: message = r'''{{inputs.parameters.message}}'''
+
+        print(message)
+      command:
+      - python

--- a/examples/workflows/dags/dag_configurable_rshift.py
+++ b/examples/workflows/dags/dag_configurable_rshift.py
@@ -1,0 +1,53 @@
+"""This example shows how to override the defaults for the "next" function to configure the rshift (`>>`) behaviour.
+
+This is useful if you want `A >> B` to mean "run B _only if_ A succeeded", otherwise the
+[default depends logic](https://argo-workflows.readthedocs.io/en/latest/enhanced-depends-logic/) means `A >> B` is
+equivalent to "B depends on `A.Succeeded || A.Skipped || A.Daemoned`".
+
+By setting the values in `Task.set_next_defaults`, we can configure the rshift behaviour to use a different operator
+and TaskResult. Then, the following
+
+```py
+with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+    A >> [B, C] >> D
+```
+
+is equivalent to
+
+```py
+A.next(B, on=TaskResult.succeeded)
+A.next(C, on=TaskResult.succeeded)
+B.next(D, on=TaskResult.succeeded)
+C.next(D, operator=Operator.or_, on=TaskResult.succeeded)
+```
+
+> Note the `Operator.or_` for D's `depends` is set when calling `C.next` which can also be confusing! This is because we
+> use `next` to describe the forward relationships, while the Argo field is `depends` which describes the backward
+> relationships.
+
+Or, described using the backward relationship of `depends` (which only accepts strings):
+```py
+B.depends = "A.Succeeded"
+C.depends = "A.Succeeded"
+D.depends = "B.Succeeded || C.Succeeded"
+```
+"""
+
+from hera.workflows import DAG, Task, TaskResult, Workflow, script
+from hera.workflows.operator import Operator
+
+
+@script(image="python:3.12")
+def echo(message):
+    print(message)
+
+
+with Workflow(generate_name="dag-configurable-rshift-", entrypoint="diamond") as w:
+    with DAG(name="diamond"):
+        A = echo(name="A", arguments={"message": "A"})
+        B = echo(name="B", arguments={"message": "B"})
+        C = echo(name="C", arguments={"message": "C"})
+        D = echo(name="D", arguments={"message": "D"})
+
+        with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+            A >> [B, C] >> D

--- a/examples/workflows/dags/dag_configurable_rshift.py
+++ b/examples/workflows/dags/dag_configurable_rshift.py
@@ -31,6 +31,8 @@ B.depends = "A.Succeeded"
 C.depends = "A.Succeeded"
 D.depends = "B.Succeeded || C.Succeeded"
 ```
+
+> `set_next_defaults` also accepts lists or multiple values using the `|` operator!
 """
 
 from hera.workflows import DAG, Task, TaskResult, Workflow, script

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -130,7 +130,7 @@ class Task(
         on: OnType = None,
     ) -> Task:
         """Set self as a dependency of `other`."""
-        operator = operator if operator is not None else self.__class__._default_next_operator
+        operator = operator or self.__class__._default_next_operator
         on_list = _normalise_on(on, self.__class__._default_next_on)
 
         # Build condition string:

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -160,15 +160,15 @@ class Task(
     @contextmanager
     def set_next_defaults(
         cls,
-        operator: Operator = Operator.and_,
+        operator: Optional[Operator] = None,
         on: Union[TaskResult, Iterable[TaskResult], None] = None,
     ):
-        """Temporarily override the default operator and on."""
+        """Temporarily modify the default behaviour of `next` and `>>`."""
         on_list = _normalise_on(on)
 
         old_operator = cls._default_next_operator
         old_on = cls._default_next_on
-        cls._default_next_operator = operator
+        cls._default_next_operator = operator or cls._default_next_operator
         cls._default_next_on = on_list
         try:
             yield

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -73,20 +73,17 @@ OnType = Optional[Union[TaskResult, Iterable[TaskResult]]]
 
 def _normalise_on(
     on: OnType,
-    default: OnType = None,
+    default: Optional[List[TaskResult]] = None,
 ) -> Optional[List[TaskResult]]:
     """Turn `on` into a list[TaskResult] or None.
 
     Accepts:
-      - None -> return normalised default (which may also be None)
+      - None -> return default (which may also be None)
       - TaskResult -> [TaskResult]
       - Iterable[TaskResult] -> list(...)
     """
     if on is None:
-        if default is None:
-            return None
-
-        return _normalise_on(default)
+        return default
     if isinstance(on, TaskResult):
         return [on]
     return list(_TaskResultGroup(on))
@@ -105,7 +102,7 @@ class Task(
     depends: Optional[str] = None
 
     _default_next_operator: ClassVar[Operator] = Operator.and_
-    _default_next_on: ClassVar[OnType] = None
+    _default_next_on: ClassVar[Optional[List[TaskResult]]] = None
 
     def _get_dependency_tasks(self) -> List[str]:
         if self.depends is None:

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -43,7 +43,7 @@ class TaskResult(Enum):
     any_succeeded = "AnySucceeded"
     all_failed = "AllFailed"
 
-    def __or__(self, other: TaskResult) -> Iterable[TaskResult]:
+    def __or__(self, other: TaskResult) -> _TaskResultGroup:
         """Create an "or" condition over multiple TaskResults."""
         return _TaskResultGroup([self, other])
 
@@ -59,7 +59,7 @@ class _TaskResultGroup(Iterable[TaskResult]):
             if r not in self._results:
                 self._results.append(r)
 
-    def __or__(self, other: Union[Iterable[TaskResult], TaskResult]):
+    def __or__(self, other: Union[Iterable[TaskResult], TaskResult]) -> _TaskResultGroup:
         if isinstance(other, TaskResult):
             return _TaskResultGroup(self._results + [other])
         return _TaskResultGroup(self._results + list(other))

--- a/tests/test_unit/test_task.py
+++ b/tests/test_unit/test_task.py
@@ -1,0 +1,43 @@
+from hera.workflows.operator import Operator
+from hera.workflows.task import Task, TaskResult
+
+
+def test_task_rshift():
+    task_a = Task(name="task-a", template="dummy")
+    task_b = Task(name="task-b", template="dummy")
+
+    task_a >> task_b
+
+    assert task_b.depends == "task-a"
+
+
+def test_override_task_next_success_only():
+    task_a = Task(name="task-a", template="dummy")
+    task_b = Task(name="task-b", template="dummy")
+
+    with Task.set_next_defaults(on=TaskResult.succeeded):
+        task_a >> task_b
+
+    assert task_b.depends == "task-a.Succeeded"
+
+
+def test_override_task_next_operator_or():
+    task_a = Task(name="task-a", template="dummy")
+    task_b = Task(name="task-b", template="dummy")
+    task_c = Task(name="task-c", template="dummy")
+
+    with Task.set_next_defaults(operator=Operator.or_):
+        [task_a, task_b] >> task_c
+
+    assert task_c.depends == "task-a || task-b"
+
+
+def test_override_task_next_operator_or_success_only():
+    task_a = Task(name="task-a", template="dummy")
+    task_b = Task(name="task-b", template="dummy")
+    task_c = Task(name="task-c", template="dummy")
+
+    with Task.set_next_defaults(operator=Operator.or_, on=TaskResult.succeeded):
+        [task_a, task_b] >> task_c
+
+    assert task_c.depends == "task-a.Succeeded || task-b.Succeeded"

--- a/tests/test_unit/test_task.py
+++ b/tests/test_unit/test_task.py
@@ -41,6 +41,16 @@ def test_override_task_next_success_or_skipped():
     assert task_b.depends == "(task-a.Succeeded || task-a.Skipped)"
 
 
+def test_override_task_next_success_or_skipped_or_daemoned():
+    task_a = Task(name="task-a", template="dummy")
+    task_b = Task(name="task-b", template="dummy")
+
+    with Task.set_next_defaults(on=TaskResult.succeeded | TaskResult.skipped | TaskResult.daemoned):
+        task_a >> task_b
+
+    assert task_b.depends == "(task-a.Succeeded || task-a.Skipped || task-a.Daemoned)"
+
+
 def test_override_task_next_success_or_skipped_list():
     task_a = Task(name="task-a", template="dummy")
     task_b = Task(name="task-b", template="dummy")


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #726, Fixes #1384
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
* This allows users to set the default `depends` relationship to use between tasks
* It also introduces `Iterable[TaskResult]` to be able to set multiple values at once. This can be done through a list or the `__or__` operator (`|`):

```py
    with Task.set_next_defaults(on=TaskResult.succeeded | TaskResult.skipped):
        [task_a, task_b] >> task_c

    assert task_c.depends == "(task-a.Skipped || task-a.Succeeded) && (task-b.Skipped || task-b.Succeeded)"
```
> This change is also applied to the `next()` function itself, which fixes #1384 

Note the `__or__` that already exists on `Task` is untouched, and is only useful to set `depends` directly with just the task name (not `.Succeeded` etc), e.g.:
```py
    task_c.depends = (task_a | task_b)

    assert task_c.depends == "(task-a || task-b)"
```
This has been added as a test.