### PR TITLE
Update resource examples and add large_artifacts_in_init_container example

### DIFF
--- a/docs/examples/workflows/artifacts/large_artifacts_in_init_container.md
+++ b/docs/examples/workflows/artifacts/large_artifacts_in_init_container.md
@@ -1,0 +1,116 @@
+# Large Artifacts In Init Container
+
+
+
+This example shows how to use `pod_spec_patch` to update the cpu/memory requests for the init container.
+
+This is useful if you want to load a large artifact, but the init container does not have enough memory to load it. This
+problem is described in the
+[Argo Artifacts Walkthrough](https://argo-workflows.readthedocs.io/en/stable/walk-through/artifacts/).
+
+In Hera, the `resources` field of the template only sets the `main` container resources. We can use a `pod_spec_patch`
+to set the init container resources.
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    import json
+
+    from hera.workflows import (
+        Artifact,
+        NoneArchiveStrategy,
+        Resources,
+        Steps,
+        Workflow,
+        script,
+    )
+
+
+    @script(
+        outputs=Artifact(name="out-art", path="/tmp/file", archive=NoneArchiveStrategy()),
+        resources=Resources(memory_request="10Ki"),
+    )
+    def writer():
+        with open("/tmp/file", "w") as f:
+            f.write("Hello, world!")
+
+
+    @script(
+        inputs=Artifact(name="in-art", path="/tmp/file"),
+        resources=Resources(memory_request="10Ki"),
+        pod_spec_patch=json.dumps({"initContainers": [{"name": "init", "resources": {"requests": {"memory": "10Ki"}}}]}),
+    )
+    def consumer():
+        with open("/tmp/file", "r") as f:
+            print(f.readlines())  # prints `Hello, world!` to `stdout`
+
+
+    with Workflow(generate_name="artifact-", entrypoint="steps") as w:
+        with Steps(name="steps"):
+            w_ = writer()
+            c = consumer(arguments={"in-art": w_.get_artifact("out-art")})
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: artifact-
+    spec:
+      entrypoint: steps
+      templates:
+      - name: steps
+        steps:
+        - - name: writer
+            template: writer
+        - - name: consumer
+            template: consumer
+            arguments:
+              artifacts:
+              - name: in-art
+                from: '{{steps.writer.outputs.artifacts.out-art}}'
+      - name: writer
+        outputs:
+          artifacts:
+          - name: out-art
+            path: /tmp/file
+            archive:
+              none: {}
+        script:
+          image: python:3.9
+          source: |-
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            with open('/tmp/file', 'w') as f:
+                f.write('Hello, world!')
+          command:
+          - python
+          resources:
+            requests:
+              memory: 10Ki
+      - name: consumer
+        podSpecPatch: '{"initContainers": [{"name": "init", "resources": {"requests":
+          {"memory": "10Ki"}}}]}'
+        inputs:
+          artifacts:
+          - name: in-art
+            path: /tmp/file
+        script:
+          image: python:3.9
+          source: |-
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            with open('/tmp/file', 'r') as f:
+                print(f.readlines())
+          command:
+          - python
+          resources:
+            requests:
+              memory: 10Ki
+    ```
+

--- a/docs/examples/workflows/misc/container_with_resources.md
+++ b/docs/examples/workflows/misc/container_with_resources.md
@@ -16,7 +16,7 @@
             image="alpine:3.7",
             command=["sh", "-c"],
             args=["echo Hello, world!"],
-            resources=Resources(cpu_request=1, memory_request="5Gi", ephemeral_request="5Gi"),
+            resources=Resources(cpu_request=1, memory_request="10Ki", ephemeral_request="10Ki"),
         )
     ```
 
@@ -41,7 +41,7 @@
           resources:
             requests:
               cpu: '1'
-              ephemeral-storage: 5Gi
-              memory: 5Gi
+              ephemeral-storage: 10Ki
+              memory: 10Ki
     ```
 

--- a/examples/workflows/artifacts/large-artifacts-in-init-container.yaml
+++ b/examples/workflows/artifacts/large-artifacts-in-init-container.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artifact-
+spec:
+  entrypoint: steps
+  templates:
+  - name: steps
+    steps:
+    - - name: writer
+        template: writer
+    - - name: consumer
+        template: consumer
+        arguments:
+          artifacts:
+          - name: in-art
+            from: '{{steps.writer.outputs.artifacts.out-art}}'
+  - name: writer
+    outputs:
+      artifacts:
+      - name: out-art
+        path: /tmp/file
+        archive:
+          none: {}
+    script:
+      image: python:3.9
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        with open('/tmp/file', 'w') as f:
+            f.write('Hello, world!')
+      command:
+      - python
+      resources:
+        requests:
+          memory: 10Ki
+  - name: consumer
+    podSpecPatch: '{"initContainers": [{"name": "init", "resources": {"requests":
+      {"memory": "10Ki"}}}]}'
+    inputs:
+      artifacts:
+      - name: in-art
+        path: /tmp/file
+    script:
+      image: python:3.9
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        with open('/tmp/file', 'r') as f:
+            print(f.readlines())
+      command:
+      - python
+      resources:
+        requests:
+          memory: 10Ki

--- a/examples/workflows/artifacts/large_artifacts_in_init_container.py
+++ b/examples/workflows/artifacts/large_artifacts_in_init_container.py
@@ -1,0 +1,45 @@
+"""This example shows how to use `pod_spec_patch` to update the cpu/memory requests for the init container.
+
+This is useful if you want to load a large artifact, but the init container does not have enough memory to load it. This
+problem is described in the
+[Argo Artifacts Walkthrough](https://argo-workflows.readthedocs.io/en/stable/walk-through/artifacts/).
+
+In Hera, the `resources` field of the template only sets the `main` container resources. We can use a `pod_spec_patch`
+to set the init container resources.
+"""
+
+import json
+
+from hera.workflows import (
+    Artifact,
+    NoneArchiveStrategy,
+    Resources,
+    Steps,
+    Workflow,
+    script,
+)
+
+
+@script(
+    outputs=Artifact(name="out-art", path="/tmp/file", archive=NoneArchiveStrategy()),
+    resources=Resources(memory_request="10Ki"),
+)
+def writer():
+    with open("/tmp/file", "w") as f:
+        f.write("Hello, world!")
+
+
+@script(
+    inputs=Artifact(name="in-art", path="/tmp/file"),
+    resources=Resources(memory_request="10Ki"),
+    pod_spec_patch=json.dumps({"initContainers": [{"name": "init", "resources": {"requests": {"memory": "10Ki"}}}]}),
+)
+def consumer():
+    with open("/tmp/file", "r") as f:
+        print(f.readlines())  # prints `Hello, world!` to `stdout`
+
+
+with Workflow(generate_name="artifact-", entrypoint="steps") as w:
+    with Steps(name="steps"):
+        w_ = writer()
+        c = consumer(arguments={"in-art": w_.get_artifact("out-art")})

--- a/examples/workflows/misc/container-with-resources.yaml
+++ b/examples/workflows/misc/container-with-resources.yaml
@@ -16,5 +16,5 @@ spec:
       resources:
         requests:
           cpu: '1'
-          ephemeral-storage: 5Gi
-          memory: 5Gi
+          ephemeral-storage: 10Ki
+          memory: 10Ki

--- a/examples/workflows/misc/container_with_resources.py
+++ b/examples/workflows/misc/container_with_resources.py
@@ -6,5 +6,5 @@ with Workflow(generate_name="container-with-resources-", entrypoint="c") as w:
         image="alpine:3.7",
         command=["sh", "-c"],
         args=["echo Hello, world!"],
-        resources=Resources(cpu_request=1, memory_request="5Gi", ephemeral_request="5Gi"),
+        resources=Resources(cpu_request=1, memory_request="10Ki", ephemeral_request="10Ki"),
     )

--- a/examples/workflows/misc/dynamic-resources.yaml
+++ b/examples/workflows/misc/dynamic-resources.yaml
@@ -28,11 +28,9 @@ spec:
           parameters:
           - name: cpu
             value: '{{item.cpu}}'
-          - name: mem
-            value: '{{item.mem}}'
   - name: compute-resources
     script:
-      image: python:3.10
+      image: python:3.9
       source: |-
         import os
         import sys
@@ -42,7 +40,7 @@ spec:
         import sys
         resources = []
         for i in range(1, 4):
-            resources.append({'cpu': i, 'mem': '{v}Mi'.format(v=i * 100)})
+            resources.append({'cpu': i, 'mem': '{v}Ki'.format(v=i * 10)})
         json.dump(resources, sys.stdout)
       command:
       - python
@@ -55,7 +53,7 @@ spec:
       - name: cpu
       - name: mem
     script:
-      image: python:3.10
+      image: python:3.9
       source: |-
         import os
         import sys
@@ -79,9 +77,9 @@ spec:
       - name: cpu
         default: '1'
       - name: mem
-        default: 100Mi
+        default: 100Ki
     script:
-      image: python:3.10
+      image: python:3.9
       source: |-
         import os
         import sys

--- a/examples/workflows/misc/dynamic_resources.py
+++ b/examples/workflows/misc/dynamic_resources.py
@@ -3,6 +3,10 @@
 This is useful when you write workflows in a business context that requires processing some data dynamically. For
 example, if you have a step that performs QC checks on some data, and only a subset of the data passes the checks, then
 you can compute the resources dynamically based on the amount of data you need to process in follow up steps.
+
+!!! Warning
+    You cannot use `resources` in the script decorator to set dynamic resources using string-templated input
+    parameters, as Argo validates the value so it will fail linting.
 """
 
 import json
@@ -10,7 +14,7 @@ import json
 from hera.workflows import DAG, Workflow, script
 
 
-@script(image="python:3.10")
+@script()
 def compute_resources() -> None:
     """Computes the resources necessary by the following job, which could be anything."""
     import json
@@ -18,21 +22,26 @@ def compute_resources() -> None:
 
     resources = []
     for i in range(1, 4):
-        resources.append({"cpu": i, "mem": "{v}Mi".format(v=i * 100)})
+        resources.append({"cpu": i, "mem": "{v}Ki".format(v=i * 10)})
 
     json.dump(resources, sys.stdout)
 
 
 @script(
-    image="python:3.10",
     pod_spec_patch=json.dumps(
         {
             "containers": [
                 {
                     "name": "main",
                     "resources": {
-                        "limits": {"cpu": "{{inputs.parameters.cpu}}", "memory": "{{inputs.parameters.mem}}"},
-                        "requests": {"cpu": "{{inputs.parameters.cpu}}", "memory": "{{inputs.parameters.mem}}"},
+                        "limits": {
+                            "cpu": "{{inputs.parameters.cpu}}",
+                            "memory": "{{inputs.parameters.mem}}",
+                        },
+                        "requests": {
+                            "cpu": "{{inputs.parameters.cpu}}",
+                            "memory": "{{inputs.parameters.mem}}",
+                        },
                     },
                 }
             ]
@@ -45,22 +54,27 @@ def resource_consumer(cpu: int, mem: str) -> None:
 
 
 @script(
-    image="python:3.10",
     pod_spec_patch=json.dumps(
         {
             "containers": [
                 {
                     "name": "main",
                     "resources": {
-                        "limits": {"cpu": "{{inputs.parameters.cpu}}", "memory": "{{inputs.parameters.mem}}"},
-                        "requests": {"cpu": "{{inputs.parameters.cpu}}", "memory": "{{inputs.parameters.mem}}"},
+                        "limits": {
+                            "cpu": "{{inputs.parameters.cpu}}",
+                            "memory": "{{inputs.parameters.mem}}",
+                        },
+                        "requests": {
+                            "cpu": "{{inputs.parameters.cpu}}",
+                            "memory": "{{inputs.parameters.mem}}",
+                        },
                     },
                 }
             ]
         }
     ),
 )
-def another_resource_consumer(cpu: int = 1, mem: str = "100Mi") -> None:
+def another_resource_consumer(cpu: int = 1, mem: str = "100Ki") -> None:
     """Perform some computation."""
     print("received cpu {cpu} and mem {mem}".format(cpu=cpu, mem=mem))
 
@@ -79,4 +93,7 @@ with Workflow(
         # the output of `generate_resources` to the inputs. Instead, it creates the kwargs for you, and lets you take
         # control of the mapping! This is because Hera cannot know whether you intend to map only 1 param, or all of
         # them, so it empowers you to set it!
-        c >> another_resource_consumer(with_param=c.result, arguments={"cpu": "{{item.cpu}}", "mem": "{{item.mem}}"})
+        c >> another_resource_consumer(
+            with_param=c.result,
+            arguments={"cpu": "{{item.cpu}}"},
+        )

--- a/src/hera/workflows/validators.py
+++ b/src/hera/workflows/validators.py
@@ -5,7 +5,9 @@ from typing import Optional
 
 
 def validate_name(name: str, max_length: Optional[int] = None, generate_name: bool = False) -> str:
-    """Validates a name according to standard argo/kubernetes limitations.
+    """DEPRECATED: Validates a name according to standard argo/kubernetes limitations.
+
+    Unused throughout the Hera codebase. To be removed in a future version of Hera.
 
     Parameters
     ----------


### PR DESCRIPTION
* The large_artifacts_in_init_container shows another realistic pod_spec_patch scenario, inspired by the [Argo Workflows walkthrough](https://argo-workflows.readthedocs.io/en/stable/walk-through/artifacts)
* Added a warning/explanation to dynamic_resources as to why we don't set `resources` and instead use `pod_spec_patch`
* Reduced the resource requests throughout examples to prep for running all examples on cluster
* Mark the unused `validate_name` function as deprecated

Was doing some investigation into #818 to understand `pod_spec_patch` better and decided to update the examples