### PR TITLE
Use `Optional` for 3.9 compatibility

### DIFF
--- a/src/hera/_cli/generate/python.py
+++ b/src/hera/_cli/generate/python.py
@@ -237,7 +237,7 @@ class WorkflowPythonBuilder:
                 ctx=ast.Load(),
             )
         if isinstance(value, dict):
-            keys: List[ast.expr | None] = []
+            keys: List[Optional[ast.expr]] = []
             values = []
             for k, v in value.items():
                 keys.append(self._build_expression(k))


### PR DESCRIPTION
Not sure why it wasn't picked up in the #1465 CI checks, but the newer union syntax broke it for other PRs.
