### PR TITLE
Fix coverage warning in CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -43,7 +43,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
 
       - name: build wheel
         run: |
@@ -94,7 +94,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
 
   workflow-tests:
     name: run workflow tests


### PR DESCRIPTION
* `file` was renamed to `files`
* I don't believe it is actually required anyway as the CI was still working with the `coverage.xml` file, but updating it just in case
* CI was showing:

```
Warning: Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', [etc...]]
```