### PR TITLE
Allow initialisation of templates in Steps/DAG contexts

### DIFF
--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -110,6 +110,14 @@ class Parallel(
     _node_names = PrivateAttr(default_factory=set)
 
     def _add_sub(self, node: Any):
+        if isinstance(node, Templatable):
+            from hera.workflows.workflow import Workflow
+
+            # We must be under a workflow context due to checks in _HeraContext.add_sub_node
+            assert _context.pieces and isinstance(_context.pieces[0], Workflow)
+            _context.pieces[0]._add_sub(node)
+            return
+
         if not isinstance(node, Step):
             raise InvalidType(type(node))
         if node.name in self._node_names:
@@ -180,6 +188,14 @@ class Steps(
         return steps or None
 
     def _add_sub(self, node: Any):
+        if isinstance(node, Templatable):
+            from hera.workflows.workflow import Workflow
+
+            # We must be under a workflow context due to checks in _HeraContext.add_sub_node
+            assert _context.pieces and isinstance(_context.pieces[0], Workflow)
+            _context.pieces[0]._add_sub(node)
+            return
+
         if not isinstance(node, (Step, Parallel)):
             raise InvalidType(type(node))
         if isinstance(node, Step):

--- a/tests/test_unit/test_context.py
+++ b/tests/test_unit/test_context.py
@@ -2,7 +2,7 @@ import pytest
 
 from hera.workflows import DAG, Step, Steps, WorkflowTemplate, script
 from hera.workflows.container import Container
-from hera.workflows.exceptions import NodeNameConflict
+from hera.workflows.exceptions import InvalidType, NodeNameConflict
 from hera.workflows.steps import Parallel
 from hera.workflows.task import Task
 from hera.workflows.workflow import Workflow
@@ -238,3 +238,17 @@ def test_initialise_container_not_referenced_directly_within_dag_context_is_allo
     assert len(w.templates[0].tasks) == 1
 
     assert isinstance(w.templates[1], Container)
+
+
+def test_wrong_subtype_under_dag_context():
+    with pytest.raises(InvalidType):
+        with Workflow(generate_name="test-"):
+            with DAG(name="test"):
+                Step(name="step", template=Container(name="container"))
+
+
+def test_wrong_subtype_under_steps_context():
+    with pytest.raises(InvalidType):
+        with Workflow(generate_name="test-"):
+            with Steps(name="test"):
+                Task(name="task", template=Container(name="container"))


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1254 
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
This relaxes the strictness of initialising Hera templates within the Steps/DAG contexts, allowing users to call factory functions or simply pass a new template directly to `template` for a given Step/Task.

New edge case handling for referencing initialised templates by name has also been added and tested, to avoid weird behaviour that users wouldn't expect (but they shouldn't write weird code in the first place...).

Note, in future we could [relax the behaviour](https://github.com/argoproj-labs/hera/blob/e78afcc510412ab7fcda8f02281a854f6feca210/src/hera/workflows/_context.py#L106-L107) further to allow `Steps` to be initalised outside of Workflow context. TBD if this would be a useful feature or will create more confusion - the context manager behaviour is intended to help guide users to write clearer workflows.