### PR TITLE
Fix: Remove duplicate 'Volume' suffix from third-party volume class n…

### DIFF
--- a/docs/api/workflows/supporting_classes/third_party_volumes.md
+++ b/docs/api/workflows/supporting_classes/third_party_volumes.md
@@ -5,10 +5,10 @@
         head_level: 3
         show_root_heading: False
         members:
-        - AWSElasticBlockStoreVolumeVolume
-        - AzureDiskVolumeVolume
-        - AzureFileVolumeVolume
-        - CephFSVolumeVolume
+        - AWSElasticBlockStoreVolume
+        - AzureDiskVolume
+        - AzureFileVolume
+        - CephFSVolume
         - CinderVolume
         - CSIVolume
         - FCVolume

--- a/src/hera/workflows/__init__.py
+++ b/src/hera/workflows/__init__.py
@@ -52,10 +52,10 @@ from hera.workflows.template_set import TemplateSet
 from hera.workflows.user_container import UserContainer
 from hera.workflows.volume import (
     AccessMode,
-    AWSElasticBlockStoreVolumeVolume,
-    AzureDiskVolumeVolume,
-    AzureFileVolumeVolume,
-    CephFSVolumeVolume,
+    AWSElasticBlockStoreVolume,
+    AzureDiskVolume,
+    AzureFileVolume,
+    CephFSVolume,
     CinderVolume,
     ConfigMapVolume,
     CSIVolume,
@@ -88,17 +88,17 @@ from hera.workflows.workflow_status import WorkflowStatus
 from hera.workflows.workflow_template import WorkflowTemplate
 
 __all__ = [
-    "AWSElasticBlockStoreVolumeVolume",
+    "AWSElasticBlockStoreVolume",
     "AccessMode",
     "ArchiveStrategy",
     "Artifact",
     "ArtifactLoader",
     "ArtifactoryArtifact",
     "AzureArtifact",
-    "AzureDiskVolumeVolume",
-    "AzureFileVolumeVolume",
+    "AzureDiskVolume",
+    "AzureFileVolume",
     "CSIVolume",
-    "CephFSVolumeVolume",
+    "CephFSVolume",
     "CinderVolume",
     "ClusterWorkflowTemplate",
     "ConfigMapEnv",

--- a/src/hera/workflows/volume.py
+++ b/src/hera/workflows/volume.py
@@ -108,7 +108,7 @@ class _BaseVolume(_ModelVolumeMount):
         )
 
 
-class AWSElasticBlockStoreVolumeVolume(_BaseVolume, _ModelAWSElasticBlockStoreVolumeSource):
+class AWSElasticBlockStoreVolume(_BaseVolume, _ModelAWSElasticBlockStoreVolumeSource):
     """Representation of AWS elastic block store volume."""
 
     def _build_volume(self) -> _ModelVolume:
@@ -121,7 +121,7 @@ class AWSElasticBlockStoreVolumeVolume(_BaseVolume, _ModelAWSElasticBlockStoreVo
         )
 
 
-class AzureDiskVolumeVolume(_BaseVolume, _ModelAzureDiskVolumeSource):
+class AzureDiskVolume(_BaseVolume, _ModelAzureDiskVolumeSource):
     """Representation of an Azure disk volume."""
 
     def _build_volume(self) -> _ModelVolume:
@@ -139,7 +139,7 @@ class AzureDiskVolumeVolume(_BaseVolume, _ModelAzureDiskVolumeSource):
         )
 
 
-class AzureFileVolumeVolume(_BaseVolume, _ModelAzureFileVolumeSource):
+class AzureFileVolume(_BaseVolume, _ModelAzureFileVolumeSource):
     """Representation of an Azure file that can be mounted as a volume."""
 
     def _build_volume(self) -> _ModelVolume:
@@ -152,7 +152,7 @@ class AzureFileVolumeVolume(_BaseVolume, _ModelAzureFileVolumeSource):
         )
 
 
-class CephFSVolumeVolume(_BaseVolume, _ModelCephFSVolumeSource):
+class CephFSVolume(_BaseVolume, _ModelCephFSVolumeSource):
     """Representation of a Ceph file system volume."""
 
     def _build_volume(self) -> _ModelVolume:


### PR DESCRIPTION
…ames

**Pull Request Checklist**
- [x] Fixes #1416
- [ ] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

### Changelog
- Removed duplicate 'Volume' suffix from four third-party volume classes:
  - `AWSElasticBlockStoreVolumeVolume` → `AWSElasticBlockStoreVolume`
  - `AzureDiskVolumeVolume` → `AzureDiskVolume`
  - `AzureFileVolumeVolume` → `AzureFileVolume`
  - `CephFSVolumeVolume` → `CephFSVolume`
