### PR TITLE
Add "Types of Workflows" section to the walkthrough

### DIFF
--- a/docs/examples/workflows/artifacts/masked_parameter_anti_pattern.md
+++ b/docs/examples/workflows/artifacts/masked_parameter_anti_pattern.md
@@ -44,7 +44,7 @@ Plus, for local testing, you cannot actually `return` a value due to Argo Workfl
 write to a file.
 
 Instead, it is recommended to use the Hera Runner,
-[see the Artifact example using the Hera Runner](../hera-runner/basic_artifacts.md).
+[see the Artifact example using the Hera Runner](../hera-runner/runner_artifacts.md).
 
 
 === "Hera"

--- a/docs/examples/workflows/misc/cron_hello_world.md
+++ b/docs/examples/workflows/misc/cron_hello_world.md
@@ -1,0 +1,65 @@
+# Cron Hello World
+
+
+
+This example shows a minimal `CronWorkflow`, based on the [Hello World example](hello_world.md).
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.workflows import CronWorkflow, script
+
+
+    @script()
+    def hello(s: str):
+        print("Hello, {s}!".format(s=s))
+
+
+    with CronWorkflow(
+        name="hello-world-cron",
+        entrypoint="hello",
+        arguments={"s": "world"},
+        schedules=[
+            "*/2 * * * *",  # Run every 2 minutes
+        ],
+    ) as w:
+        hello()
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: CronWorkflow
+    metadata:
+      name: hello-world-cron
+    spec:
+      schedules:
+      - '*/2 * * * *'
+      workflowSpec:
+        entrypoint: hello
+        templates:
+        - name: hello
+          inputs:
+            parameters:
+            - name: s
+          script:
+            image: python:3.9
+            source: |-
+              import os
+              import sys
+              sys.path.append(os.getcwd())
+              import json
+              try: s = json.loads(r'''{{inputs.parameters.s}}''')
+              except: s = r'''{{inputs.parameters.s}}'''
+
+              print('Hello, {s}!'.format(s=s))
+            command:
+            - python
+        arguments:
+          parameters:
+          - name: s
+            value: world
+    ```
+

--- a/docs/examples/workflows/misc/hello_world.md
+++ b/docs/examples/workflows/misc/hello_world.md
@@ -2,7 +2,7 @@
 
 
 
-
+This example shows a minimal "Hello World" example.
 
 
 === "Hera"

--- a/docs/examples/workflows/misc/template_refs.md
+++ b/docs/examples/workflows/misc/template_refs.md
@@ -1,0 +1,114 @@
+# Template Refs
+
+
+
+This example shows how to use `TemplateRef` with `WorkflowTemplates` and `ClusterWorkflowTemplates`.
+
+Note, running this example will attempt to create the `WorkflowTemplate` and `ClusterWorkflowTemplate` on the cluster.
+
+
+=== "Hera"
+
+    ```python linenums="1"
+    from hera.exceptions import AlreadyExists
+    from hera.workflows import (
+        ClusterWorkflowTemplate,
+        Step,
+        Steps,
+        Workflow,
+        WorkflowsService,
+        WorkflowTemplate,
+        script,
+    )
+    from hera.workflows.models import TemplateRef
+
+
+    @script()
+    def hello(s: str):
+        print("Hello, {s}!".format(s=s))
+
+
+    with WorkflowTemplate(name="hello-world-workflow-template", namespace="argo") as wt:
+        hello()
+
+
+    with ClusterWorkflowTemplate(name="hello-world-cluster-workflow-template") as cwt:
+        hello()
+
+
+    with Workflow(
+        generate_name="use-workflow-templates-",
+        entrypoint="steps",
+        namespace="argo",
+    ) as w:
+        with Steps(name="steps"):
+            Step(
+                name="hello-template-ref",
+                template_ref=TemplateRef(
+                    name="hello-world-workflow-template",
+                    template="hello",
+                    cluster_scope=False,
+                ),
+                arguments={"s": "this is using a WorkflowTemplate"},
+            )
+            Step(
+                name="hello-cluster-template-ref",
+                template_ref=TemplateRef(
+                    name="hello-world-cluster-workflow-template",
+                    template="hello",
+                    cluster_scope=True,
+                ),
+                arguments={"s": "this is using a ClusterWorkflowTemplate"},
+            )
+
+    if __name__ == "__main__":
+        WORKFLOWS_SERVICE = WorkflowsService(
+            host="https://localhost:2746",
+            verify_ssl=False,
+        )
+        try:
+            wt.workflows_service = WORKFLOWS_SERVICE
+            wt.create()
+        except AlreadyExists:
+            print(f"{wt.name} already exists")
+
+        try:
+            cwt.workflows_service = WORKFLOWS_SERVICE
+            cwt.create()
+        except AlreadyExists:
+            print(f"{cwt.name} already exists")
+    ```
+
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: use-workflow-templates-
+      namespace: argo
+    spec:
+      entrypoint: steps
+      templates:
+      - name: steps
+        steps:
+        - - name: hello-template-ref
+            arguments:
+              parameters:
+              - name: s
+                value: this is using a WorkflowTemplate
+            templateRef:
+              name: hello-world-workflow-template
+              clusterScope: false
+              template: hello
+        - - name: hello-cluster-template-ref
+            arguments:
+              parameters:
+              - name: s
+                value: this is using a ClusterWorkflowTemplate
+            templateRef:
+              name: hello-world-cluster-workflow-template
+              clusterScope: true
+              template: hello
+    ```
+

--- a/docs/walk-through/hello-world.md
+++ b/docs/walk-through/hello-world.md
@@ -23,6 +23,18 @@ with Workflow(
 w.create()
 ```
 
+## Wait, What's a Workflow?
+
+If you're new to Argo Workflows, it helps to first understand that it runs on Kubernetes. In Kubernetes, a Custom
+Resource Definition (CRD) is how you define a new type of object. Argo Workflows adds its own CRD for `Workflow`, which
+lets you create Workflow objects in the same way you create Pods, Deployments, or other Kubernetes resources.
+
+The Workflow Controller is a Kubernetes application that watches for new or updated Workflow objects. When it sees one,
+it schedules and manages the steps of that Workflow by updating its status on the cluster. A `Workflow` is therefore a
+live object on the cluster that represents an individual (past or present) run – it contains the templates that are
+running or have run, their statuses and outputs, the amount of resources used, and more – all stored within its YAML
+specification.
+
 ## Hera Classes
 
 Hera provides many specialised classes in `hera.workflows`. You will see the Argo Workflows spec has been transformed

--- a/docs/walk-through/types-of-workflows.md
+++ b/docs/walk-through/types-of-workflows.md
@@ -1,0 +1,131 @@
+# Types of Workflows
+
+Argo Workflows provides 4
+[Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), which in turn
+are classes provided by Hera:
+
+* The `Workflow`, which we have seen throughout the examples already. It is the "live" object on the Kubernetes cluster
+  containing a current "run".
+* The `WorkflowTemplate`: a collection of modular, reusable `templates` which you use in other Workflows. It is
+  only available in the Kubernetes namespace that it is added to.
+* The `ClusterWorkflowTemplate`: the same as a `WorkflowTemplate` but available across all namespaces in the cluster.
+* The `CronWorkflow`: a `Workflow` that will repeatedly run according to a
+  [cron schedule](https://en.wikipedia.org/wiki/Cron).
+
+In Hera, these all follow the same basic structure and features of `Workflow`, being subclasses of it. We will explain some of the key differences and unique features below.
+
+## `WorkflowTemplates` and `ClusterWorkflowTemplates`
+
+`WorkflowTemplates` and `ClusterWorkflowTemplates` should be defined using a `name`, instead of a `generate_name`:
+
+```py
+from hera.workflows import (
+    ClusterWorkflowTemplate,
+    WorkflowTemplate,
+    script,
+)
+from hera.workflows.models import TemplateRef
+
+
+@script()
+def hello(s: str):
+    print("Hello, {s}!".format(s=s))
+
+
+with WorkflowTemplate(name="hello-world-workflow-template", namespace="argo") as wt:
+    hello()
+
+with ClusterWorkflowTemplate(name="hello-world-cluster-workflow-template") as cwt:
+    hello()
+```
+
+There is no practical difference when defining a `WorkflowTemplate` versus a `ClusterWorkflowTemplate`; it only matters
+for whether you want the `WorkflowTemplate` available in particular namespaces, or across all namespaces in the cluster.
+
+!!! note
+
+    Due to their similarity, when we refer to `WorkflowTemplates` throughout the rest of the documentation, we are
+    implicitly referring to `ClusterWorkflowTemplates` as well.
+
+### Using `WorkflowTemplates` and `ClusterWorkflowTemplates` Through `TemplateRefs`
+
+Once you have a `WorkflowTemplate` or `ClusterWorkflowTemplates`, you can upload it to the cluster through `w.create()`.
+Then, you can use it in other `Workflows`, `WorkflowTemplates` or `CronWorkflows` by using a
+`hera.workflows.models.TemplateRef` in a `Step` or `Task`. You will need to specify `cluster_scope=False` for
+`WorkflowTemplates`, and `cluster_scope=True` for `ClusterWorkflowTemplates`.
+
+```py
+with Workflow(
+    generate_name="use-workflow-templates-",
+    entrypoint="steps",
+    namespace="argo",
+) as w:
+    with Steps(name="steps"):
+        Step(
+            name="hello-template-ref",
+            template_ref=TemplateRef(
+                name="hello-world-workflow-template",
+                template="hello",
+                cluster_scope=False,
+            ),
+            arguments={"s": "this is using a WorkflowTemplate"},
+        )
+        Step(
+            name="hello-cluster-template-ref",
+            template_ref=TemplateRef(
+                name="hello-world-cluster-workflow-template",
+                template="hello",
+                cluster_scope=True,
+            ),
+            arguments={"s": "this is using a ClusterWorkflowTemplate"},
+        )
+```
+
+See the full runnable code in the [Template Refs example](../examples/workflows/misc/template_refs.md)!
+
+
+## `CronWorkflows`
+
+It is often useful to define a `Workflow` that will repeatedly run. We can use a `CronWorkflow` to handle this for us.
+Given a `Workflow`, we can easily convert it to a `CronWorkflow` by changing the class, changing `generate_name` to a
+suitable `name`, and then filling out the special cron fields, which at a minimum includes the `schedules` field:
+
+```py
+from hera.workflows import CronWorkflow, script
+
+
+@script()
+def hello(s: str):
+    print("Hello, {s}!".format(s=s))
+
+
+with CronWorkflow(
+    name="hello-world-cron",
+    entrypoint="hello",
+    arguments={"s": "world"},
+    schedules=[
+        "*/2 * * * *",  # Run every 2 minutes
+    ],
+) as w:
+    hello()
+```
+
+When you call `w.create()` on a `CronWorkflow`, it will not immediately run; it will only run at the times specified by
+the schedule. If you want to create a new CronWorkflow but not start running it on the schedule, you can pass
+`cron_suspend=True`, which will let you toggle it on later in the UI or CLI:
+
+```py
+with CronWorkflow(
+    name="hello-world-cron",
+    entrypoint="hello",
+    arguments={"s": "world"},
+    schedules=[
+        "*/2 * * * *",  # Run every 2 minutes
+    ],
+    cron_suspend=True,
+) as w:
+    hello()
+```
+
+Learn about all the available `CronWorkflow` fields and what they do in the
+[Argo docs](https://argo-workflows.readthedocs.io/en/latest/fields/#cronworkflowspec)!

--- a/examples/workflows/artifacts/masked_parameter_anti_pattern.py
+++ b/examples/workflows/artifacts/masked_parameter_anti_pattern.py
@@ -40,7 +40,7 @@ Plus, for local testing, you cannot actually `return` a value due to Argo Workfl
 write to a file.
 
 Instead, it is recommended to use the Hera Runner,
-[see the Artifact example using the Hera Runner](../hera-runner/basic_artifacts.md).
+[see the Artifact example using the Hera Runner](../hera-runner/runner_artifacts.md).
 """
 
 from hera.workflows import DAG, Artifact, Workflow, script

--- a/examples/workflows/misc/cron-hello-world.yaml
+++ b/examples/workflows/misc/cron-hello-world.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: hello-world-cron
+spec:
+  schedules:
+  - '*/2 * * * *'
+  workflowSpec:
+    entrypoint: hello
+    templates:
+    - name: hello
+      inputs:
+        parameters:
+        - name: s
+      script:
+        image: python:3.9
+        source: |-
+          import os
+          import sys
+          sys.path.append(os.getcwd())
+          import json
+          try: s = json.loads(r'''{{inputs.parameters.s}}''')
+          except: s = r'''{{inputs.parameters.s}}'''
+
+          print('Hello, {s}!'.format(s=s))
+        command:
+        - python
+    arguments:
+      parameters:
+      - name: s
+        value: world

--- a/examples/workflows/misc/cron_hello_world.py
+++ b/examples/workflows/misc/cron_hello_world.py
@@ -1,0 +1,19 @@
+"""This example shows a minimal `CronWorkflow`, based on the [Hello World example](hello_world.md)."""
+
+from hera.workflows import CronWorkflow, script
+
+
+@script()
+def hello(s: str):
+    print("Hello, {s}!".format(s=s))
+
+
+with CronWorkflow(
+    name="hello-world-cron",
+    entrypoint="hello",
+    arguments={"s": "world"},
+    schedules=[
+        "*/2 * * * *",  # Run every 2 minutes
+    ],
+) as w:
+    hello()

--- a/examples/workflows/misc/hello_world.py
+++ b/examples/workflows/misc/hello_world.py
@@ -1,3 +1,5 @@
+"""This example shows a minimal "Hello World" example."""
+
 from hera.workflows import Workflow, script
 
 

--- a/examples/workflows/misc/template-refs.yaml
+++ b/examples/workflows/misc/template-refs.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: use-workflow-templates-
+  namespace: argo
+spec:
+  entrypoint: steps
+  templates:
+  - name: steps
+    steps:
+    - - name: hello-template-ref
+        arguments:
+          parameters:
+          - name: s
+            value: this is using a WorkflowTemplate
+        templateRef:
+          name: hello-world-workflow-template
+          clusterScope: false
+          template: hello
+    - - name: hello-cluster-template-ref
+        arguments:
+          parameters:
+          - name: s
+            value: this is using a ClusterWorkflowTemplate
+        templateRef:
+          name: hello-world-cluster-workflow-template
+          clusterScope: true
+          template: hello

--- a/examples/workflows/misc/template_refs.py
+++ b/examples/workflows/misc/template_refs.py
@@ -1,0 +1,71 @@
+"""This example shows how to use `TemplateRef` with `WorkflowTemplates` and `ClusterWorkflowTemplates`.
+
+Note, running this example will attempt to create the `WorkflowTemplate` and `ClusterWorkflowTemplate` on the cluster."""
+
+from hera.exceptions import AlreadyExists
+from hera.workflows import (
+    ClusterWorkflowTemplate,
+    Step,
+    Steps,
+    Workflow,
+    WorkflowsService,
+    WorkflowTemplate,
+    script,
+)
+from hera.workflows.models import TemplateRef
+
+
+@script()
+def hello(s: str):
+    print("Hello, {s}!".format(s=s))
+
+
+with WorkflowTemplate(name="hello-world-workflow-template", namespace="argo") as wt:
+    hello()
+
+
+with ClusterWorkflowTemplate(name="hello-world-cluster-workflow-template") as cwt:
+    hello()
+
+
+with Workflow(
+    generate_name="use-workflow-templates-",
+    entrypoint="steps",
+    namespace="argo",
+) as w:
+    with Steps(name="steps"):
+        Step(
+            name="hello-template-ref",
+            template_ref=TemplateRef(
+                name="hello-world-workflow-template",
+                template="hello",
+                cluster_scope=False,
+            ),
+            arguments={"s": "this is using a WorkflowTemplate"},
+        )
+        Step(
+            name="hello-cluster-template-ref",
+            template_ref=TemplateRef(
+                name="hello-world-cluster-workflow-template",
+                template="hello",
+                cluster_scope=True,
+            ),
+            arguments={"s": "this is using a ClusterWorkflowTemplate"},
+        )
+
+if __name__ == "__main__":
+    WORKFLOWS_SERVICE = WorkflowsService(
+        host="https://localhost:2746",
+        verify_ssl=False,
+    )
+    try:
+        wt.workflows_service = WORKFLOWS_SERVICE
+        wt.create()
+    except AlreadyExists:
+        print(f"{wt.name} already exists")
+
+    try:
+        cwt.workflows_service = WORKFLOWS_SERVICE
+        cwt.create()
+    except AlreadyExists:
+        print(f"{cwt.name} already exists")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
     - walk-through/artifacts.md
     - walk-through/loops.md
     - walk-through/conditionals.md
+    - walk-through/types-of-workflows.md
     - walk-through/hera-developer-features.md
     - walk-through/authentication.md
     - walk-through/experimental-hera-features.md

--- a/tests/submissions/test_examples.py
+++ b/tests/submissions/test_examples.py
@@ -18,6 +18,7 @@ from tests.test_examples import CI_MODE, _get_examples
 TIME_LIMIT_SECONDS = 120
 SKIP_LINT_EXAMPLES = {
     "new_decorators_auto_template_refs",  # Uses TemplateRefs to non-existent WorkflowTemplates
+    "template_refs",  # Also uses TemplateRefs - the WorkflowTemplates are in the file though
     "parquet_pandas",
 }
 SKIP_SUBMISSION_EXAMPLES = SKIP_LINT_EXAMPLES.union(


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1092 
- [ ] ~Tests added~
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
This PR adds a "Types of Workflows" section to the walkthrough to describe `WorkflowTemplates` and `ClusterWorkflowTemplate` and how to use them with `TemplateRef`, as well as `CronWorkflows`. Also added `template_refs.py` and `cron_hello_world.py` examples.