### PR TITLE
Add optional artifact support in Hera runner

### DIFF
--- a/docs/examples/workflows/artifacts/artifact_loaders.md
+++ b/docs/examples/workflows/artifacts/artifact_loaders.md
@@ -2,7 +2,12 @@
 
 
 
+This example shows the various ways to use the `ArtifactLoader` enum to automatically load your Artifacts
 
+You can load them as a `Path` of the file location, a `str` of the file contents, or any JSON type of the deserialised file contents.
+
+Making the type of the function parameter `Optional` will make the `Artifact` itself optional, so the Hera Runner will load it only
+if it exists.
 
 
 === "Hera"
@@ -10,7 +15,7 @@
     ```python linenums="1"
     import json
     from pathlib import Path
-    from typing import Annotated, Dict
+    from typing import Annotated, Dict, Optional
 
     from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
 
@@ -27,12 +32,16 @@
         a_file_as_path: Annotated[Path, Artifact(name="my-artifact-path", loader=None)],
         a_file_as_str: Annotated[str, Artifact(name="my-artifact-as-str", loader=ArtifactLoader.file)],
         a_file_as_json: Annotated[Dict, Artifact(name="my-artifact-as-json", loader=ArtifactLoader.json)],
+        a_file_as_json_optional: Annotated[
+            Optional[Dict], Artifact(name="my-optional-artifact", loader=ArtifactLoader.json)
+        ] = None,
     ):
         assert a_file_as_path.read_text() == a_file_as_str
         assert json.loads(a_file_as_str) == a_file_as_json
         print(a_file_as_path)
         print(a_file_as_str)
         print(a_file_as_json)
+        print(a_file_as_json_optional)
 
 
     with Workflow(generate_name="artifact-loaders-", entrypoint="my-steps") as w:
@@ -105,6 +114,9 @@
             path: /tmp/hera-inputs/artifacts/my-artifact-as-str
           - name: my-artifact-as-json
             path: /tmp/hera-inputs/artifacts/my-artifact-as-json
+          - name: my-optional-artifact
+            optional: true
+            path: /tmp/hera-inputs/artifacts/my-optional-artifact
         script:
           image: python:3.9
           source: '{{inputs.parameters}}'

--- a/examples/workflows/artifacts/artifact-loaders.yaml
+++ b/examples/workflows/artifacts/artifact-loaders.yaml
@@ -53,6 +53,9 @@ spec:
         path: /tmp/hera-inputs/artifacts/my-artifact-as-str
       - name: my-artifact-as-json
         path: /tmp/hera-inputs/artifacts/my-artifact-as-json
+      - name: my-optional-artifact
+        optional: true
+        path: /tmp/hera-inputs/artifacts/my-optional-artifact
     script:
       image: python:3.9
       source: '{{inputs.parameters}}'

--- a/examples/workflows/artifacts/artifact_loaders.py
+++ b/examples/workflows/artifacts/artifact_loaders.py
@@ -1,6 +1,14 @@
+"""This example shows the various ways to use the `ArtifactLoader` enum to automatically load your Artifacts
+
+You can load them as a `Path` of the file location, a `str` of the file contents, or any JSON type of the deserialised file contents.
+
+Making the type of the function parameter `Optional` will make the `Artifact` itself optional, so the Hera Runner will load it only
+if it exists.
+"""
+
 import json
 from pathlib import Path
-from typing import Annotated, Dict
+from typing import Annotated, Dict, Optional
 
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Steps, Workflow, script
 
@@ -17,12 +25,16 @@ def artifact_loaders(
     a_file_as_path: Annotated[Path, Artifact(name="my-artifact-path", loader=None)],
     a_file_as_str: Annotated[str, Artifact(name="my-artifact-as-str", loader=ArtifactLoader.file)],
     a_file_as_json: Annotated[Dict, Artifact(name="my-artifact-as-json", loader=ArtifactLoader.json)],
+    a_file_as_json_optional: Annotated[
+        Optional[Dict], Artifact(name="my-optional-artifact", loader=ArtifactLoader.json)
+    ] = None,
 ):
     assert a_file_as_path.read_text() == a_file_as_str
     assert json.loads(a_file_as_str) == a_file_as_json
     print(a_file_as_path)
     print(a_file_as_str)
     print(a_file_as_json)
+    print(a_file_as_json_optional)
 
 
 with Workflow(generate_name="artifact-loaders-", entrypoint="my-steps") as w:

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -123,7 +123,7 @@ def construct_io_from_annotation(python_name: str, annotation: Any) -> "Union[Pa
     if isinstance(io, Parameter):
         set_enum_based_on_type(io, annotation)
     else:  # isinstance(io, Artifact)
-        is_optional_annotation = is_optional(annotation)
+        is_optional_annotation = origin_type_issupertype(annotation, NoneType)
         if io.optional is True and not is_optional_annotation:
             # Assume user wants optional
             raise ValueError("Artifact annotation must be `Optional` for optional Artifacts.")
@@ -147,12 +147,6 @@ def get_unsubscripted_type(t: Any) -> Any:
     return t
 
 
-def is_optional(annotation: Any) -> bool:
-    unwrapped_type = unwrap_annotation(annotation)
-    origin_type = get_unsubscripted_type(unwrapped_type)
-    return (origin_type is Union or origin_type is UnionType) and NoneType in get_args(unwrapped_type)
-
-
 def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]]) -> bool:
     """Return True if annotation is a subtype of type_.
 
@@ -169,7 +163,13 @@ def origin_type_issubtype(annotation: Any, type_: Union[type, Tuple[type, ...]])
 
 
 def origin_type_issupertype(annotation: Any, type_: type) -> bool:
-    """Return True if annotation is a supertype of type_."""
+    """Return True if annotation is a supertype of type_.
+
+    Useful for checking if annotation is an optional type:
+
+    >>> origin_type_issupertype(Optional[str], NoneType)
+    True
+    """
     unwrapped_type = unwrap_annotation(annotation)
     origin_type = get_unsubscripted_type(unwrapped_type)
     if origin_type is Union or origin_type is UnionType:

--- a/src/hera/shared/_type_util.py
+++ b/src/hera/shared/_type_util.py
@@ -111,7 +111,6 @@ def construct_io_from_annotation(python_name: str, annotation: Any) -> "Union[Pa
     For a function parameter, python_name should be the parameter name.
     For a Pydantic Input or Output class, python_name should be the field name.
     """
-    from hera.workflows.artifact import Artifact
     from hera.workflows.parameter import Parameter
 
     if workflow_annotation := get_workflow_annotation(annotation):
@@ -123,7 +122,7 @@ def construct_io_from_annotation(python_name: str, annotation: Any) -> "Union[Pa
     io.name = io.name or python_name
     if isinstance(io, Parameter):
         set_enum_based_on_type(io, annotation)
-    elif isinstance(io, Artifact):
+    else:  # isinstance(io, Artifact)
         is_optional_annotation = is_optional(annotation)
         if io.optional is True and not is_optional_annotation:
             # Assume user wants optional

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -12,14 +12,11 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
 
 if sys.version_info >= (3, 10):
     from inspect import get_annotations
-    from types import NoneType
     from typing import Concatenate, ParamSpec
 else:
     from typing_extensions import Concatenate, ParamSpec
 
     from hera.shared._inspect import get_annotations
-
-    NoneType = type(None)
 
 
 from hera.shared import BaseMixin, global_config

--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -120,6 +120,9 @@ def get_annotated_artifact_value(param_name: str, artifact_annotation: Artifact)
         artifact_annotation.path = artifact_annotation._get_default_inputs_path()
 
     path = Path(artifact_annotation.path)
+    if artifact_annotation.optional and not path.exists():
+        return None
+
     if artifact_annotation.loads is not None:
         return artifact_annotation.loads(path.read_text())
 

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_new.py
@@ -1,6 +1,6 @@
 """Regression test: compare the new Annotated style inputs declaration with the old version."""
 
-from typing import Annotated
+from typing import Annotated, Optional
 
 from hera.shared import global_config
 from hera.workflows import Workflow, script
@@ -11,8 +11,8 @@ global_config.experimental_features["script_annotations"] = True
 
 
 @script()
-def read_artifact(my_artifact: Annotated[str, Artifact(name="my_artifact", path="/tmp/file", optional=True)]) -> str:
-    return my_artifact
+def read_artifact(my_artifact: Annotated[Optional[str], Artifact(name="my_artifact", path="/tmp/file")]):
+    pass
 
 
 with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:

--- a/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_old.py
+++ b/tests/script_annotations_inputs_regression/script_annotations_artifacts_optional_old.py
@@ -6,8 +6,8 @@ from hera.workflows.steps import Steps
 
 
 @script(inputs=[Artifact(name="my_artifact", path="/tmp/file", optional=True)])
-def read_artifact(my_artifact) -> str:
-    return my_artifact
+def read_artifact(my_artifact):
+    pass
 
 
 with Workflow(generate_name="test-artifacts-", entrypoint="my-steps") as w:

--- a/tests/test_unit/test_script_annotations_util.py
+++ b/tests/test_unit/test_script_annotations_util.py
@@ -129,6 +129,12 @@ def test_get_annotated_input_param_error_param_name():
     "file_contents,artifact,expected_return",
     [
         pytest.param('{"json": "object"}', Artifact(loader=ArtifactLoader.json), {"json": "object"}, id="json-load"),
+        pytest.param(
+            '{"json": "object"}',
+            Artifact(optional=True, loader=ArtifactLoader.json),
+            {"json": "object"},
+            id="json-load-optional",
+        ),
         pytest.param('{"json": "object"}', Artifact(loader=ArtifactLoader.file), '{"json": "object"}', id="file-load"),
     ],
 )
@@ -140,8 +146,15 @@ def test_get_annotated_artifact_value_inputs_with_loaders(
 ):
     file_path = tmp_path / "contents.txt"
     file_path.write_text(file_contents)
-    artifact.path = file_path
+    artifact.path = str(file_path)
     assert get_annotated_artifact_value("param_name", artifact) == expected_return
+
+
+def test_get_annotated_artifact_value_optional_artifact_missing(tmp_path: Path):
+    artifact = Artifact(optional=True, loader=ArtifactLoader.json)
+    file_path = tmp_path / "contents.txt"
+    artifact.path = str(file_path)
+    assert get_annotated_artifact_value("param_name", artifact) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_shared_type_utils.py
+++ b/tests/test_unit/test_shared_type_utils.py
@@ -105,12 +105,31 @@ def test_get_workflow_annotation_should_raise_error(annotation):
         [Annotated[str, Artifact(name="a_str")], Artifact(name="a_str")],
         [Annotated[int, Gt(10), Artifact(name="a_int")], Artifact(name="a_int")],
         [Annotated[int, Artifact(name="a_int"), Gt(30)], Artifact(name="a_int")],
+        [
+            Annotated[Optional[int], Artifact(name="an_optional_int"), Gt(30)],
+            Artifact(name="an_optional_int", optional=True),  # Hera will add `optional=True` based on the annotation
+        ],
         # this can happen when user uses already annotated types.
         [Annotated[Annotated[int, Gt(10)], Artifact(name="a_int")], Artifact(name="a_int")],
     ],
 )
 def test_construct_io_from_annotation(annotation, expected):
     assert construct_io_from_annotation("python_name", annotation) == expected
+
+
+@pytest.mark.parametrize(
+    "type_,optional,expected_error",
+    (
+        [Optional[int], False, "Artifact annotation does not match Artifact.optional."],
+        [int, True, "Artifact annotation must be `Optional` for optional Artifacts."],
+    ),
+)
+def test_construct_io_from_annotation_invalid_artifact(type_, optional, expected_error):
+    with pytest.raises(
+        ValueError,
+        match=expected_error,
+    ):
+        construct_io_from_annotation("python_name", Annotated[type_, Artifact(name="bad_optional", optional=optional)])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1253 
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
This PR neatly fixes the bug described in #1253 with `if artifact_annotation.optional and not path.exists():`. This has been tested on a local install of Argo Workflows.

This uncovered the problem that if an `optional=True` Artifact is actually `None` at runtime, the type must be `Optional`:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for artifact_loaders
a_file_as_json_optional
  Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/dict_type
```

Therefore, this PR also adds enhancements so that:

1. the type annotation must be `Optional` if the Artifact is optional
2. if the type is `Optional` then users don't actually have to set `optional=True`

I have also added validation to ensure users do not mix optional/non-optional manually, as this could create runtime validation errors later if the Artifact does not exist (when type is not `Optional` but it is `None` at runtime).