### PR TITLE
Set upper bound for poetry due to dulwich dependency breaking py3.9

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry
+          python -m pip install "poetry<=2.2.0" twine
       - name: Bump version number
         run: poetry version ${{ github.event.release.tag_name }}
       - name: Build and publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry twine
+          python -m pip install "poetry<=2.2.0" twine
       - name: Bump version number
         run: poetry version ${{ github.event.release.tag_name }}
       - name: Build and publish


### PR DESCRIPTION
See https://github.com/python-poetry/poetry/issues/10615

Reproduced, fixed and tested locally with `pipx install "poetry<=2.2.0"`