### PR TITLE
Migrate to mkdocstrings 2.0

### DIFF
--- a/docs/api/workflows/supporting_classes/first_party_volumes.md
+++ b/docs/api/workflows/supporting_classes/first_party_volumes.md
@@ -2,7 +2,7 @@
 
 ::: hera.workflows.volume
     options:
-        head_level: 3
+        heading_level: 3
         show_root_heading: False
         members:
         - EmptyDirVolume

--- a/docs/api/workflows/supporting_classes/third_party_volumes.md
+++ b/docs/api/workflows/supporting_classes/third_party_volumes.md
@@ -2,7 +2,7 @@
 
 ::: hera.workflows.volume
     options:
-        head_level: 3
+        heading_level: 3
         show_root_heading: False
         members:
         - AWSElasticBlockStoreVolume

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-include-markdown-plugin
 mkdocs-click
 mkdocstrings[python]
 mkdocs-awesome-pages-plugin
+ruff

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,7 +192,7 @@ plugins:
             show_labels: false
             show_root_toc_entry: false
           paths: [src]
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
   - search:
       lang: en


### PR DESCRIPTION
Fixes build breakages in rtd. Maybe we should add bounds in `docs/requirements.txt`? Not too bothered.