### PR TITLE
Graduate pydantic io feature

### DIFF
--- a/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_artifacts.md
@@ -105,8 +105,6 @@ DAG itself by referencing it in an `Output` class.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: concat
         inputs:
           artifacts:
@@ -133,8 +131,6 @@ DAG itself by referencing it in an `Output` class.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: worker
         dag:
           tasks:

--- a/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_inner_dag.md
@@ -95,8 +95,6 @@ This example shows how to run an inner DAG within another DAG.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: concat
         inputs:
           parameters:
@@ -115,8 +113,6 @@ This example shows how to run an inner DAG within another DAG.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: worker
         dag:
           tasks:

--- a/docs/examples/workflows/experimental/new_dag_decorator_params.md
+++ b/docs/examples/workflows/experimental/new_dag_decorator_params.md
@@ -138,8 +138,6 @@ This example shows how parameters can be passed into, within and out of a DAG.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: concat
         inputs:
           parameters:
@@ -161,8 +159,6 @@ This example shows how parameters can be passed into, within and out of a DAG.
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: worker
         dag:
           tasks:

--- a/docs/examples/workflows/experimental/new_decorators_basic_script.md
+++ b/docs/examples/workflows/experimental/new_decorators_basic_script.md
@@ -59,8 +59,6 @@ and be available to subsequent tasks (if it were in a DAG).
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       arguments:
         parameters:
         - name: user

--- a/docs/examples/workflows/experimental/new_decorators_fanout_loop.md
+++ b/docs/examples/workflows/experimental/new_decorators_fanout_loop.md
@@ -85,9 +85,6 @@ This lets you perform fanouts using `with_items`, set conditions using `when` an
           - examples.workflows.experimental.new_decorators_fanout_loop:print_message
           command:
           - python
-          env:
-          - name: hera__script_pydantic_io
-            value: ''
       - name: print-int
         inputs:
           parameters:
@@ -105,9 +102,6 @@ This lets you perform fanouts using `with_items`, set conditions using `when` an
           - examples.workflows.experimental.new_decorators_fanout_loop:print_int
           command:
           - python
-          env:
-          - name: hera__script_pydantic_io
-            value: ''
       - name: loop-example
         steps:
         - - name: print-str-message-loop-with-items

--- a/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
+++ b/docs/examples/workflows/experimental/new_steps_decorator_with_parallel_steps.md
@@ -102,8 +102,6 @@ This example shows the use of the new `steps` decorator, including parallel step
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: concat
         inputs:
           parameters:
@@ -123,8 +121,6 @@ This example shows the use of the new `steps` decorator, including parallel step
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: worker
         steps:
         - - name: setup-step

--- a/docs/examples/workflows/experimental/template_sets.md
+++ b/docs/examples/workflows/experimental/template_sets.md
@@ -60,8 +60,6 @@ to a Workflow at submission time. This can be useful if you just want to distrib
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: my-dag
         dag:
           tasks:

--- a/docs/examples/workflows/scripts/script_runner_io.md
+++ b/docs/examples/workflows/scripts/script_runner_io.md
@@ -17,7 +17,6 @@ This example shows the use of Pydantic Input/Output to create the input and outp
     from hera.workflows.archive import NoneArchiveStrategy
     from hera.workflows.io import Input, Output
 
-    global_config.experimental_features["script_pydantic_io"] = True
     global_config.set_class_defaults(Script, constructor="runner")
     global_config.set_class_defaults(Script, image="my-image-with-deps")
 
@@ -106,14 +105,12 @@ This example shows the use of Pydantic Input/Output to create the input and outp
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_runner_io:writer
+          - examples.workflows.scripts.script_runner_io:writer
           command:
           - python
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
       - name: pydantic-io
         inputs:
           artifacts:
@@ -139,13 +136,11 @@ This example shows the use of Pydantic Input/Output to create the input and outp
           - -m
           - hera.workflows.runner
           - -e
-          - examples.workflows.experimental.script_runner_io:pydantic_io
+          - examples.workflows.scripts.script_runner_io:pydantic_io
           command:
           - python
           env:
           - name: hera__outputs_directory
             value: /tmp/hera-outputs
-          - name: hera__script_pydantic_io
-            value: ''
     ```
 

--- a/docs/user-guides/experimental-features.md
+++ b/docs/user-guides/experimental-features.md
@@ -16,22 +16,6 @@ usually announce changes in [the Hera slack channel](https://cloud-native.slack.
 
 ## Currently supported experimental features:
 
-### Script IO Models
-
-Hera provides Pydantic models for you to create subclasses from, which allow you to more easily declare script template
-inputs. Any fields that you declare in your subclass of `Input` will become input parameters or artifacts, while
-`Output` fields will become output parameters artifacts. The fields that you declare can be `Annotated` as a `Parameter`
-or `Artifact`, as any fields with a basic type will become `Parameters`. Turning on the `script_pydantic_io` flag will
-automatically enable the `script_annotations` experimental feature.
-
-To enable Hera input/output models, you must set the `experimental_feature` flag `script_pydantic_io`
-
-```py
-global_config.experimental_features["script_pydantic_io"] = True
-```
-
-Read the full guide on script pydantic IO in [the script user guide](../user-guides/script-runner-io.md).
-
 ### Decorators for main template types
 
 Decorators for dags, steps and containers are provided alongside a new script decorator, letting your declare Workflows via Python functions alone.
@@ -74,3 +58,12 @@ writing scripts with parameters and artifacts that require additional fields suc
 `name`.
 
 Read the full guide on script annotations in [the script user guide](../user-guides/script-annotations.md).
+
+### Script IO Models (since x.xx)
+
+Hera provides Pydantic models for you to create subclasses from, which allow you to more easily declare script template
+inputs. Any fields that you declare in your subclass of `Input` will become input parameters or artifacts, while
+`Output` fields will become output parameters artifacts. The fields that you declare can be `Annotated` as a `Parameter`
+or `Artifact`, as any fields with a basic type will become `Parameters`.
+
+Read the full guide on script pydantic IO in [the script user guide](../user-guides/script-runner-io.md).

--- a/docs/user-guides/experimental-features.md
+++ b/docs/user-guides/experimental-features.md
@@ -59,7 +59,7 @@ writing scripts with parameters and artifacts that require additional fields suc
 
 Read the full guide on script annotations in [the script user guide](../user-guides/script-annotations.md).
 
-### Script IO Models (since x.xx)
+### Script IO Models (since 6.0)
 
 Hera provides Pydantic models for you to create subclasses from, which allow you to more easily declare script template
 inputs. Any fields that you declare in your subclass of `Input` will become input parameters or artifacts, while

--- a/docs/user-guides/script-runner-io.md
+++ b/docs/user-guides/script-runner-io.md
@@ -150,4 +150,4 @@ def pydantic_io() -> MyOutput:
     return MyOutput(exit_code=1, result="Test!", param_int=42, artifact_int=my_input.param_int)
 ```
 
-See the full Pydantic IO example [here](../examples/workflows/scripts/script_runner_io.py)!
+See the full Pydantic IO example [here](../examples/workflows/scripts/script_runner_io.md)!

--- a/docs/user-guides/script-runner-io.md
+++ b/docs/user-guides/script-runner-io.md
@@ -57,13 +57,6 @@ the equivalent workflows below:
         )
     ```
 
-Using the IO classes requires use of the Hera Runner and the `"script_pydantic_io"` experimental feature flag to be
-enabled:
-
-```py
-global_config.experimental_features["script_pydantic_io"] = True
-```
-
 ## Pydantic V1 or V2?
 
 Importing `Input` and `Output` from the `hera.workflows.io` submodule automatically matches the version of your Pydantic
@@ -157,4 +150,4 @@ def pydantic_io() -> MyOutput:
     return MyOutput(exit_code=1, result="Test!", param_int=42, artifact_int=my_input.param_int)
 ```
 
-See the full Pydantic IO example [here](../examples/workflows/experimental/script_runner_io.md)!
+See the full Pydantic IO example [here](../examples/workflows/scripts/script_runner_io.py)!

--- a/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-artifacts.yaml
@@ -25,8 +25,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: concat
     inputs:
       artifacts:
@@ -53,8 +51,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: worker
     dag:
       tasks:

--- a/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-inner-dag.yaml
@@ -24,8 +24,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: concat
     inputs:
       parameters:
@@ -44,8 +42,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: worker
     dag:
       tasks:

--- a/examples/workflows/experimental/new-dag-decorator-params.yaml
+++ b/examples/workflows/experimental/new-dag-decorator-params.yaml
@@ -31,8 +31,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: concat
     inputs:
       parameters:
@@ -54,8 +52,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: worker
     dag:
       tasks:

--- a/examples/workflows/experimental/new-decorators-basic-script.yaml
+++ b/examples/workflows/experimental/new-decorators-basic-script.yaml
@@ -22,8 +22,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   arguments:
     parameters:
     - name: user

--- a/examples/workflows/experimental/new-decorators-fanout-loop.yaml
+++ b/examples/workflows/experimental/new-decorators-fanout-loop.yaml
@@ -22,9 +22,6 @@ spec:
       - examples.workflows.experimental.new_decorators_fanout_loop:print_message
       command:
       - python
-      env:
-      - name: hera__script_pydantic_io
-        value: ''
   - name: print-int
     inputs:
       parameters:
@@ -42,9 +39,6 @@ spec:
       - examples.workflows.experimental.new_decorators_fanout_loop:print_int
       command:
       - python
-      env:
-      - name: hera__script_pydantic_io
-        value: ''
   - name: loop-example
     steps:
     - - name: print-str-message-loop-with-items

--- a/examples/workflows/experimental/new-steps-decorator-with-parallel-steps.yaml
+++ b/examples/workflows/experimental/new-steps-decorator-with-parallel-steps.yaml
@@ -27,8 +27,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: concat
     inputs:
       parameters:
@@ -48,8 +46,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: worker
     steps:
     - - name: setup-step

--- a/examples/workflows/experimental/template-sets.yaml
+++ b/examples/workflows/experimental/template-sets.yaml
@@ -19,8 +19,6 @@ spec:
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: my-dag
     dag:
       tasks:

--- a/examples/workflows/scripts/script-runner-io.yaml
+++ b/examples/workflows/scripts/script-runner-io.yaml
@@ -35,14 +35,12 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_runner_io:writer
+      - examples.workflows.scripts.script_runner_io:writer
       command:
       - python
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''
   - name: pydantic-io
     inputs:
       artifacts:
@@ -68,11 +66,9 @@ spec:
       - -m
       - hera.workflows.runner
       - -e
-      - examples.workflows.experimental.script_runner_io:pydantic_io
+      - examples.workflows.scripts.script_runner_io:pydantic_io
       command:
       - python
       env:
       - name: hera__outputs_directory
         value: /tmp/hera-outputs
-      - name: hera__script_pydantic_io
-        value: ''

--- a/examples/workflows/scripts/script_runner_io.py
+++ b/examples/workflows/scripts/script_runner_io.py
@@ -9,7 +9,6 @@ from hera.workflows import Artifact, ArtifactLoader, Parameter, Script, Steps, W
 from hera.workflows.archive import NoneArchiveStrategy
 from hera.workflows.io import Input, Output
 
-global_config.experimental_features["script_pydantic_io"] = True
 global_config.set_class_defaults(Script, constructor="runner")
 global_config.set_class_defaults(Script, image="my-image-with-deps")
 

--- a/src/hera/shared/_global_config.py
+++ b/src/hera/shared/_global_config.py
@@ -14,9 +14,9 @@ TBase = TypeVar("TBase", bound="BaseMixin")
 TypeTBase = Type[TBase]
 
 Hook = Callable[[TBase], TBase]
-"""`Hook` is a callable that takes a Hera objects and returns the same, optionally mutated, object. 
+"""`Hook` is a callable that takes a Hera objects and returns the same, optionally mutated, object.
 
-This can be a Workflow, a Script, a Container, etc - any Hera object. 
+This can be a Workflow, a Script, a Container, etc - any Hera object.
 """
 
 _HookMap = Dict[TypeTBase, List[Hook]]
@@ -179,15 +179,12 @@ class BaseMixin:
 GlobalConfig = global_config = _GlobalConfig()
 register_pre_build_hook = global_config.register_pre_build_hook
 
-_SCRIPT_PYDANTIC_IO_FLAG = "script_pydantic_io"
 _DECORATOR_SYNTAX_FLAG = "decorator_syntax"
 
 # A dictionary where each key is a flag that has a list of flags which supersede it, hence
 # the given flag key can also be switched on by any of the flags in the list. Using simple flat lists
 # for now, otherwise with many superseding flags we may want to have a recursive structure.
-_SUPERSEDING_FLAGS: Dict[str, List] = {
-    _SCRIPT_PYDANTIC_IO_FLAG: [_DECORATOR_SYNTAX_FLAG],
-}
+_SUPERSEDING_FLAGS: Dict[str, List] = {}
 
 
 def _flag_enabled(flag: str) -> bool:

--- a/src/hera/workflows/_runner/script_annotations_util.py
+++ b/src/hera/workflows/_runner/script_annotations_util.py
@@ -221,14 +221,10 @@ def _save_annotated_return_outputs(
     if len(function_outputs) != len(output_annotations):
         raise ValueError("The number of outputs does not match the annotation")
 
-    if os.environ.get("hera__script_pydantic_io", None) is not None:
-        return_obj = None
+    return_obj = None
 
     for output_value, dest in zip(function_outputs, output_annotations):
         if isinstance(output_value, (OutputV1, OutputV2)):
-            if os.environ.get("hera__script_pydantic_io", None) is None:
-                raise ValueError("hera__script_pydantic_io environment variable is not set")
-
             return_obj = output_value
 
             for field, value in model_dump(output_value).items():
@@ -253,7 +249,7 @@ def _save_annotated_return_outputs(
             path = _get_outputs_path(dest[1])
             _write_to_path(path, output_value, _get_dumper_function(dest[1]))
 
-    if os.environ.get("hera__script_pydantic_io", None) is not None:
+    if return_obj is not None:
         return return_obj
 
     return None
@@ -285,9 +281,6 @@ def _save_dummy_outputs(
     """
     for dest in output_annotations:
         if isinstance(dest, type) and issubclass(dest, (OutputV1, OutputV2)):
-            if os.environ.get("hera__script_pydantic_io", None) is None:
-                raise ValueError("hera__script_pydantic_io environment variable is not set")
-
             for field in get_fields(dest):
                 if field in {"exit_code", "result"}:
                     continue

--- a/src/hera/workflows/io/v1.py
+++ b/src/hera/workflows/io/v1.py
@@ -53,8 +53,7 @@ if sys.version_info < (3, 14):
 
         Input is a Pydantic model which users can create a subclass of. When a subclass
         of Input is used as a function parameter type, Hera will take the fields of the
-        user's subclass to create template input parameters and artifacts. See the example
-        for the script_pydantic_io experimental feature.
+        user's subclass to create template input parameters and artifacts.
         """
 
     class Output(OutputMixin, _DeclaringEnabledModel):
@@ -62,8 +61,7 @@ if sys.version_info < (3, 14):
 
         Output is a Pydantic model which users can create a subclass of. When a subclass
         of Output is used as a function return type, Hera will take the fields of the
-        user's subclass to create template output parameters and artifacts. See the example
-        for the script_pydantic_io experimental feature.
+        user's subclass to create template output parameters and artifacts.
         """
 
         exit_code: int = 0

--- a/src/hera/workflows/io/v2.py
+++ b/src/hera/workflows/io/v2.py
@@ -47,8 +47,7 @@ class Input(InputMixin, _DeclaringEnabledModel):
 
     Input is a Pydantic model which users can create a subclass of. When a subclass
     of Input is used as a function parameter type, the Hera Runner will take the fields
-    of the user's subclass to create template input parameters and artifacts. See the example
-    for the script_pydantic_io experimental feature.
+    of the user's subclass to create template input parameters and artifacts.
     """
 
 
@@ -57,8 +56,7 @@ class Output(OutputMixin, _DeclaringEnabledModel):
 
     Output is a Pydantic model which users can create a subclass of. When a subclass
     of Output is used as a function return type, the Hera Runner will take the fields
-    of the user's subclass to create template output parameters and artifacts. See the example
-    for the script_pydantic_io experimental feature.
+    of the user's subclass to create template output parameters and artifacts.
     """
 
     exit_code: int = 0

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -36,10 +36,6 @@ from typing_extensions import ParamSpec, get_args, get_origin
 
 from hera.expr import g
 from hera.shared import BaseMixin, global_config
-from hera.shared._global_config import (
-    _SCRIPT_PYDANTIC_IO_FLAG,
-    _flag_enabled,
-)
 from hera.shared._pydantic import _PYDANTIC_VERSION
 from hera.shared._type_util import (
     construct_io_from_annotation,
@@ -385,16 +381,6 @@ def _get_outputs_from_return_annotation(
             if param_or_artifact := get_workflow_annotation(annotation):
                 append_annotation(param_or_artifact)
     elif isinstance(return_annotation, type) and issubclass(return_annotation, (OutputV1, OutputV2)):
-        if not _flag_enabled(_SCRIPT_PYDANTIC_IO_FLAG):
-            raise ValueError(
-                (
-                    "Unable to instantiate {} since it is an experimental feature."
-                    " Please turn on experimental features by setting "
-                    '`hera.shared.global_config.experimental_features["{}"] = True`.'
-                    " Note that experimental features are unstable and subject to breaking changes."
-                ).format(return_annotation, _SCRIPT_PYDANTIC_IO_FLAG)
-            )
-
         output_class = return_annotation
         for output in output_class._get_outputs():
             append_annotation(output)
@@ -452,16 +438,6 @@ def _get_inputs_from_callable(source: Callable) -> Tuple[List[Parameter], List[A
             and inspect.isclass(unwrap_annotation(func_param.annotation))
             and issubclass(unwrap_annotation(func_param.annotation), (InputV1, InputV2))
         ):
-            if not _flag_enabled(_SCRIPT_PYDANTIC_IO_FLAG):
-                raise ValueError(
-                    (
-                        "Unable to instantiate {} since it is an experimental feature."
-                        " Please turn on experimental features by setting "
-                        '`hera.shared.global_config.experimental_features["{}"] = True`.'
-                        " Note that experimental features are unstable and subject to breaking changes."
-                    ).format(func_param.annotation, _SCRIPT_PYDANTIC_IO_FLAG)
-                )
-
             if len(inspect.signature(source).parameters) != 1:
                 raise SyntaxError("Only one function parameter can be specified when using an Input.")
 
@@ -891,8 +867,6 @@ class RunnerScriptConstructor(ScriptConstructor):
             script_env.append(EnvVar(name="hera__outputs_directory", value=self.outputs_directory))
         if self.pydantic_mode:
             script_env.append(EnvVar(name="hera__pydantic_mode", value=str(self.pydantic_mode)))
-        if _flag_enabled(_SCRIPT_PYDANTIC_IO_FLAG):
-            script_env.append(EnvVar(name="hera__script_pydantic_io", value=""))
 
         if script_env:
             if not script.env:

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -418,8 +418,8 @@ def _get_inputs_from_callable(source: Callable) -> Tuple[List[Parameter], List[A
     """Return all inputs from the function.
 
     This includes all basic Python function parameters, and all parameters with a Parameter or Artifact annotation.
-    For the Pydantic IO experimental feature, any input parameter which is a subclass of Input, the fields of the
-    class will be used as inputs, rather than the class itself.
+    For the Pydantic IO feature, any input parameter which is a subclass of Input, the fields of the class will be used
+    as inputs, rather than the class itself.
 
     Note, the given Parameter/Artifact names in annotations of different inputs could clash, which will raise a ValueError.
     """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -675,7 +675,6 @@ def test_runner_pydantic_inputs_params(
     # GIVEN
     entrypoint = entrypoint.replace("pydantic_io_vX", f"pydantic_io_v{pydantic_mode}")
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     # WHEN
     output = _runner(entrypoint, kwargs_list)
@@ -718,7 +717,6 @@ def test_runner_pydantic_output_params(
     # GIVEN
     entrypoint = entrypoint.replace("pydantic_io_vX", f"pydantic_io_v{pydantic_mode}")
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
@@ -781,7 +779,6 @@ def test_runner_pydantic_input_artifacts(
     importlib.reload(module)
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     # WHEN
     output = _runner(entrypoint, [])
@@ -837,7 +834,6 @@ def test_runner_pydantic_output_artifacts(
     monkeypatch.setattr(artifact_module, "_DEFAULT_ARTIFACT_INPUT_DIRECTORY", f"{tmp_path}/")
     monkeypatch.setattr(test_module, "ARTIFACT_PATH", str(tmp_path))
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
@@ -886,7 +882,6 @@ def test_runner_pydantic_output_with_exit_code(
     entrypoint = entrypoint.replace("pydantic_io_vX", f"pydantic_io_v{pydantic_mode}")
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
@@ -941,7 +936,6 @@ def test_run_pydantic_output_with_exit_code(
     mock_parse_args.return_value = args
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     module = importlib.import_module(entrypoint.split(":")[0])
     importlib.reload(module)
@@ -995,7 +989,6 @@ def test_runner_pydantic_output_with_result(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
@@ -1047,7 +1040,6 @@ def test_runner_pydantic_with_invalid_annotations(
 ):
     # GIVEN
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
 
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -453,28 +453,6 @@ def test_script_pydantic_multiple_inputs(global_config_fixture):
     assert "Only one function parameter can be specified when using an Input" in str(e.value)
 
 
-def test_script_pydantic_without_experimental_flag(global_config_fixture):
-    """Test that artifacts with same annotated name raises ValueError."""
-    # GIVEN
-    global_config_fixture.experimental_features["script_annotations"] = True
-    global_config_fixture.experimental_features["script_pydantic_io"] = False
-    # Force a reload of the test module, as the runner performs "importlib.import_module", which
-    # may fetch a cached version
-    import tests.script_annotations.pydantic_io_v1 as module
-
-    importlib.reload(module)
-    workflow = importlib.import_module(module.__name__).w
-
-    # WHEN / THEN
-    with pytest.raises(ValueError) as e:
-        workflow.to_dict()
-
-    assert (
-        "Unable to instantiate <class 'tests.script_annotations.pydantic_io_v1.ParamOnlyInput'> since it is an experimental feature."
-        in str(e.value)
-    )
-
-
 @pytest.mark.parametrize(
     "module_name",
     [

--- a/tests/test_serialisers.py
+++ b/tests/test_serialisers.py
@@ -62,7 +62,6 @@ def test_parameter_loading(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("parameter_serialisers_vX", f"parameter_serialisers_v{pydantic_mode}")
 
     # WHEN
@@ -84,7 +83,6 @@ def test_loading_wrong_type(
         error = V2ValidationError
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = "tests.script_runner.parameter_serialisers_vX:load_wrong_type"
     entrypoint = entrypoint.replace("parameter_serialisers_vX", f"parameter_serialisers_v{pydantic_mode}")
     kwargs_list = [{"name": "my-parameter", "value": json.dumps({"a": "hello ", "b": "world"})}]
@@ -139,7 +137,6 @@ def test_parameter_dumping(
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("parameter_serialisers_vX", f"parameter_serialisers_v{pydantic_mode}")
 
     # WHEN
@@ -205,7 +202,6 @@ def test_artifact_loading(
     monkeypatch.setattr("hera.workflows.artifact._DEFAULT_ARTIFACT_INPUT_DIRECTORY", f"{tmp_path}/")
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("artifact_serialisers_vX", f"artifact_serialisers_v{pydantic_mode}")
 
     # WHEN
@@ -245,7 +241,6 @@ def test_artifact_byte_loading(
     monkeypatch.setattr("hera.workflows.artifact._DEFAULT_ARTIFACT_INPUT_DIRECTORY", f"{tmp_path}/")
 
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("artifact_serialisers_vX", f"artifact_serialisers_v{pydantic_mode}")
 
     # WHEN
@@ -315,7 +310,6 @@ def test_artifact_dumping(
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("artifact_serialisers_vX", f"artifact_serialisers_v{pydantic_mode}")
 
     # WHEN
@@ -362,7 +356,6 @@ def test_artifact_byte_dumping(
     outputs_directory = str(tmp_path / "tmp/hera-outputs")
     monkeypatch.setenv("hera__outputs_directory", outputs_directory)
     monkeypatch.setenv("hera__pydantic_mode", str(pydantic_mode))
-    monkeypatch.setenv("hera__script_pydantic_io", "")
     entrypoint = entrypoint.replace("artifact_serialisers_vX", f"artifact_serialisers_v{pydantic_mode}")
 
     # WHEN

--- a/tests/test_unit/test_script.py
+++ b/tests/test_unit/test_script.py
@@ -4,7 +4,6 @@ from typing import Annotated, Dict, List, Optional, Union, cast
 
 import pytest
 
-from hera.shared._global_config import _GlobalConfig
 from hera.workflows._mixins import EnvT
 from hera.workflows.artifact import Artifact
 from hera.workflows.env import Env
@@ -250,8 +249,6 @@ def test_script_returning_annotated_generic():
 
 
 def test_script_returning_pydantic_type(global_config_fixture):
-    global_config_fixture.experimental_features["script_pydantic_io"] = True
-
     class MyOutput(Output):
         foo: str
         bar: int
@@ -424,40 +421,6 @@ class TestRunnerScriptEnv:
     def test_runner_script_pydantic_mode_env_var(self, user_env: EnvT, expected_env: Optional[List[ModelEnvVar]]):
         # GIVEN
         constructor = RunnerScriptConstructor(pydantic_mode=1)
-
-        built_workflow = self.build_workflow(user_env, constructor)
-
-        script_template = cast(ScriptTemplate, built_workflow.spec.templates[0].script)
-        assert script_template is not None
-        assert script_template.env == expected_env
-
-    @pytest.mark.parametrize(
-        "user_env,expected_env",
-        (
-            [
-                None,
-                [
-                    ModelEnvVar(name="hera__script_pydantic_io", value=""),
-                ],
-            ],
-            [
-                Env(name="my_env_var", value=42),
-                [
-                    ModelEnvVar(name="my_env_var", value="42"),
-                    ModelEnvVar(name="hera__script_pydantic_io", value=""),
-                ],
-            ],
-        ),
-    )
-    def test_runner_script_pydantic_io_env_var(
-        self,
-        global_config_fixture: _GlobalConfig,
-        user_env: EnvT,
-        expected_env: Optional[List[ModelEnvVar]],
-    ):
-        # GIVEN
-        global_config_fixture.experimental_features["script_pydantic_io"] = True
-        constructor = RunnerScriptConstructor()
 
         built_workflow = self.build_workflow(user_env, constructor)
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] ~~Fixes #<!--issue number goes here-->~~
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Graduating pydantic io feature

- no longer need to set the `global_config.experimental_features["script_pydantic_io"]` flag
- removes `hera__script_pydantic_io` generation, and checks
- re-generate documentation and examples
- for the priority between pydantic io and basic annotation code paths, we already check pydantic one first.
