### PR TITLE
Add missing 'pending' workflow status

### DIFF
--- a/src/hera/workflows/workflow_status.py
+++ b/src/hera/workflows/workflow_status.py
@@ -9,6 +9,7 @@ from enum import Enum
 class WorkflowStatus(str, Enum):
     """Placeholder for workflow statuses."""
 
+    pending = "Pending"
     running = "Running"
     succeeded = "Succeeded"
     failed = "Failed"
@@ -23,6 +24,7 @@ class WorkflowStatus(str, Enum):
     def from_argo_status(cls, s: str) -> "WorkflowStatus":
         """Turns an Argo status into a Hera workflow status representation."""
         switch = {
+            "Pending": WorkflowStatus.pending,
             "Running": WorkflowStatus.running,
             "Succeeded": WorkflowStatus.succeeded,
             "Failed": WorkflowStatus.failed,

--- a/tests/test_unit/test_workflow.py
+++ b/tests/test_unit/test_workflow.py
@@ -15,6 +15,7 @@ from hera.workflows.parameter import Parameter
 from hera.workflows.script import script
 from hera.workflows.service import WorkflowsService
 from hera.workflows.workflow import NAME_LIMIT, Workflow
+from hera.workflows.workflow_status import WorkflowStatus
 
 
 def test_workflow_name_validators():
@@ -152,3 +153,20 @@ def test_reassign_workflow_arguments():
     built_workflow = w.build()
 
     assert built_workflow.spec.arguments.parameters == [ModelParameter(name="another-param", value="another-value")]
+
+
+def test_workflow_status():
+    assert WorkflowStatus.from_argo_status("Pending") == WorkflowStatus.pending
+    assert WorkflowStatus.from_argo_status("Running") == WorkflowStatus.running
+    assert WorkflowStatus.from_argo_status("Succeeded") == WorkflowStatus.succeeded
+    assert WorkflowStatus.from_argo_status("Failed") == WorkflowStatus.failed
+    assert WorkflowStatus.from_argo_status("Error") == WorkflowStatus.error
+    assert WorkflowStatus.from_argo_status("Terminated") == WorkflowStatus.terminated
+
+    with pytest.raises(KeyError) as e:
+        WorkflowStatus.from_argo_status("NotARealStatus")
+
+    assert (
+        "Unrecognized status NotARealStatus. Available Argo statuses are: ['Pending', 'Running', 'Succeeded', 'Failed', 'Error', 'Terminated']"
+        in str(e.value)
+    )


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1562
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, queuing many workflows can result in some being in the "pending" state, which was not enumerated in the `WorkflowStatus` class. This PR adds the pending state and some tests for coverage.