### PR TITLE
Update build os for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
 


### PR DESCRIPTION
Email from RTD saying they are deprecating the `ubuntu-20.04` image.

Deprecation timeline

    March 30, 2026: Publish deprecation announcement.
    Before June 1, 2026: Email maintainers of active projects still using ubuntu-20.04.
    June 1, 2026: Remove the ubuntu-20.04 build image.
