### PR TITLE
fix: converters reject signed resource values to match validator behavior

### DIFF
--- a/src/hera/workflows/converters.py
+++ b/src/hera/workflows/converters.py
@@ -35,7 +35,7 @@ def _convert_decimal_units(value: str) -> float:
     Returns:
         float: Float value of the given decimal units.
     """
-    pattern = r"^\s*([+-]?\d+(?:\.\d+)?)([mkMGTPE]?)\s*$"
+    pattern = r"^\s*(\d+(?:\.\d+)?)([mkMGTPE]?)\s*$"
     matches = re.match(pattern, value)
 
     if matches:
@@ -60,7 +60,7 @@ def _convert_binary_units(value: str) -> float:
     Returns:
         float: Float value of the given binary units.
     """
-    pattern = r"^\s*([+-]?\d+(?:\.\d+)?)([KMGTPE]i)?\s*$"
+    pattern = r"^\s*(\d+(?:\.\d+)?)([KMGTPE]i)?\s*$"
     matches = re.match(pattern, value)
 
     if matches:

--- a/src/hera/workflows/resources.py
+++ b/src/hera/workflows/resources.py
@@ -19,7 +19,7 @@ def _merge_dicts(a: Dict, b: Dict, path=None):
             elif a[key] == b[key]:
                 pass  # same leaf value
             else:
-                raise Exception("Conflict at `%s`" % ".".join(path + [str(key)]))
+                raise ValueError("Conflict at `%s`" % ".".join(path + [str(key)]))
         else:
             a[key] = b[key]
     return a

--- a/tests/test_unit/test_converters.py
+++ b/tests/test_unit/test_converters.py
@@ -37,6 +37,9 @@ def test_convert_binary_units(value, expected):
         "abc",
         "1.5Ki",
         "1.5Mi",
+        "-500m",
+        "-1",
+        "+500m",
     ],
 )
 def test_convert_decimal_units_invalid(value):
@@ -51,6 +54,9 @@ def test_convert_decimal_units_invalid(value):
         "abc",
         "500m",
         "2k",
+        "-512Mi",
+        "-1Gi",
+        "+512Mi",
     ],
 )
 def test_convert_binary_units_invalid(value):


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, `_convert_decimal_units` and `_convert_binary_units` accept signed values like `-500m` or `+1Gi` due to `[+-]?` in their regex patterns. The validators (`_validate_decimal_units`, `_validate_binary_units`) correctly reject these, so there's a mismatch - same input, different outcome depending on which function you hit first.

This PR removes `[+-]?` from both converter patterns so they're consistent with validators. Also fixes `_merge_dicts` raising bare `Exception` instead of `ValueError`.

Reproduce:

```python
from hera.workflows.converters import _convert_decimal_units, _convert_binary_units
from hera.workflows.validators import _validate_decimal_units

_validate_decimal_units("-500m")   # raises ValueError (correct)
_convert_decimal_units("-500m")    # returns -0.5 (bug)

_convert_binary_units("-512Mi")    # returns -536870912.0 (bug)
```

Negative resource values aren't valid in Kubernetes anyway, so rejecting them in both layers makes sense.