### PR TITLE
fix: squash wrapped Argo expressions in YAML output

### DIFF
--- a/src/hera/_yaml.py
+++ b/src/hera/_yaml.py
@@ -23,6 +23,60 @@ else:
     _yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
 
 
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def _is_block_scalar(line: str) -> bool:
+    stripped = line.rstrip()
+    return (
+        stripped.endswith(": |")
+        or stripped.endswith(": |-")
+        or stripped.endswith(": |+")
+        or stripped.endswith(": >")
+        or stripped.endswith(": >-")
+        or stripped.endswith(": >+")
+    )
+
+
+def _squash_wrapped_expressions(yaml_str: str) -> str:
+    lines = yaml_str.splitlines()
+    if not lines:
+        return yaml_str
+
+    squashed = []
+    block_scalar_indent = None
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        if block_scalar_indent is not None:
+            if line == "" or _line_indent(line) > block_scalar_indent:
+                squashed.append(line)
+                i += 1
+                continue
+            block_scalar_indent = None
+
+        if _is_block_scalar(line):
+            block_scalar_indent = _line_indent(line)
+            squashed.append(line)
+            i += 1
+            continue
+
+        while line.count("{{") > line.count("}}") and i + 1 < len(lines):
+            i += 1
+            line += " " + lines[i].lstrip()
+
+        squashed.append(line)
+        i += 1
+
+    result = "\n".join(squashed)
+    if yaml_str.endswith("\n"):
+        result += "\n"
+    return result
+
+
 def dump(*args, **kwargs) -> str:
     """Builds the Workflow as an Argo schema Workflow object and returns it as yaml string."""
     if not _yaml:
@@ -31,4 +85,4 @@ def dump(*args, **kwargs) -> str:
     # Set some default options if not provided by the user
     kwargs.setdefault("default_flow_style", False)
     kwargs.setdefault("sort_keys", False)
-    return _yaml.dump(*args, **kwargs)
+    return _squash_wrapped_expressions(_yaml.dump(*args, **kwargs))

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -18,6 +18,61 @@ def test_dump_multiline_string():
     )
 
 
+def test_dump_does_not_wrap_long_strings_by_default():
+    result = _yaml.dump(
+        {"args": "ref={{= sprig.trunc(7, workflow.parameters.gh-ref) }}, push={{ workflow.parameters.push }}"}
+    )
+    assert (
+        result == "args: ref={{= sprig.trunc(7, workflow.parameters.gh-ref) }}, push={{ workflow.parameters.push }}\n"
+    )
+
+
+def test_dump_squashes_multiple_wrapped_expressions_on_one_line():
+    result = _yaml._squash_wrapped_expressions(
+        dedent(
+            """\
+            test-case-3: {{some
+                brackets}} {{more
+                brackets}}
+            """
+        )
+    )
+    assert result == "test-case-3: {{some brackets}} {{more brackets}}\n"
+
+
+def test_dump_squashes_each_wrapped_expression_line_independently():
+    result = _yaml._squash_wrapped_expressions(
+        dedent(
+            """\
+            test-case-4: {{some
+                brackets}}
+                {{more
+                brackets}}
+            """
+        )
+    )
+    assert result == "test-case-4: {{some brackets}}\n    {{more brackets}}\n"
+
+
+def test_dump_does_not_modify_block_scalars():
+    result = _yaml._squash_wrapped_expressions(
+        dedent(
+            """\
+            description: |
+              {{some
+              brackets}}
+            """
+        )
+    )
+    assert result == dedent(
+        """\
+        description: |
+          {{some
+          brackets}}
+        """
+    )
+
+
 def test_yaml_missing():
     with patch("hera._yaml._yaml", new=None):
         with pytest.raises(ImportError) as e:


### PR DESCRIPTION
Pull Request Checklist
- [x] Fixes #1504
- [x] Tests added
- [ ] Documentation/examples added
- [x] Good commit messages and/or PR title

Description of PR
PyYAML wraps long plain scalars at 80 chars, so Hera can split `{{ ... }}` across lines. This is pretty easy to hit in `workflows.argoproj.io/description`, and Argo UI ends up choking on it.

This PR squashes wrapped `{{ ... }}` spans after dumping YAML, line by line. Block scalars stay as-is, so multiline descriptions still work fine.

Repro:
```py
from hera.workflows import WorkflowTemplate
from hera.workflows import models as m

wt = WorkflowTemplate(
    name="test-yaml-wrapping",
    workflow_metadata=m.WorkflowMetadata(
        annotations={
            "workflows.argoproj.io/description": "ref={{= sprig.trunc(7, workflow.parameters.gh-ref) }}, push={{ workflow.parameters.push }}"
        }
    ),
)

print(wt.to_yaml())
```

Before:
```yaml
workflows.argoproj.io/description: ref={{= sprig.trunc(7, workflow.parameters.gh-ref) }}, push={{ workflow.parameters.push
  }}
```

After:
```yaml
workflows.argoproj.io/description: ref={{= sprig.trunc(7, workflow.parameters.gh-ref) }}, push={{ workflow.parameters.push }}
```
