### PR TITLE
fix(cli): omit default workflow params in generated Python

### DIFF
--- a/src/hera/_cli/generate/python.py
+++ b/src/hera/_cli/generate/python.py
@@ -11,6 +11,7 @@ from pydantic import RootModel
 
 from hera._cli.base import GeneratePython
 from hera._cli.generate.util import YAML_EXTENSIONS, convert_code, expand_paths, write_output
+from hera.shared import global_config
 from hera.shared._pydantic import APIBaseModel
 from hera.shared._type_util import (
     get_annotated_metadata,
@@ -195,6 +196,8 @@ class WorkflowPythonBuilder:
 
                             body.append(self._build_statement(template))
                     else:
+                        if self._should_skip_workflow_kwarg(attr, value, hera_workflow_class):
+                            continue
                         value = self._build_expression(value)
                         keywords.append(
                             ast.keyword(
@@ -219,6 +222,14 @@ class WorkflowPythonBuilder:
             optional_vars=ast.Name(id="w", ctx=ast.Store()),
         )
         return ast.With(items=[with_item], body=body)
+
+    def _should_skip_workflow_kwarg(self, attr: str, value: Any, hera_workflow_class: Type[Workflow]) -> bool:
+        """Return whether a workflow constructor kwarg is redundant in generated code."""
+        if attr == "kind":
+            return value == hera_workflow_class.__name__
+        if attr == "api_version":
+            return value == global_config.api_version
+        return False
 
     def _build_expression(
         self,

--- a/tests/cli/test_generate_python.py
+++ b/tests/cli/test_generate_python.py
@@ -77,41 +77,33 @@ def test_yaml_converter(file_name: str, tmp_path: Path):
 single_workflow_output = """\
 from hera.workflows import Workflow
 
-with Workflow(api_version="argoproj.io/v1alpha1", kind="Workflow", name="single") as w:
+with Workflow(name="single") as w:
     pass
 """
 
 workflow_template_output = """\
 from hera.workflows import WorkflowTemplate
 
-with WorkflowTemplate(
-    api_version="argoproj.io/v1alpha1",
-    kind="WorkflowTemplate",
-    name="workflow-template",
-) as w:
+with WorkflowTemplate(name="workflow-template") as w:
     pass
 """
 
 cluster_workflow_template_output = """\
 from hera.workflows import ClusterWorkflowTemplate
 
-with ClusterWorkflowTemplate(
-    api_version="argoproj.io/v1alpha1",
-    kind="ClusterWorkflowTemplate",
-    name="cluster-workflow-template",
-) as w:
+with ClusterWorkflowTemplate(name="cluster-workflow-template") as w:
     pass
 """
 
 multiple_workflow_output = """\
 from hera.workflows import Workflow
 
-with Workflow(api_version="argoproj.io/v1alpha1", kind="Workflow", name="one") as w:
+with Workflow(name="one") as w:
     pass
 
 from hera.workflows import Workflow
 
-with Workflow(api_version="argoproj.io/v1alpha1", kind="Workflow", name="two") as w:
+with Workflow(name="two") as w:
     pass
 """
 
@@ -131,6 +123,29 @@ def test_single_workflow(capsys):
 
     output = get_stdout(capsys)
     assert output == single_workflow_output
+
+
+@pytest.mark.cli
+def test_non_default_api_version_is_preserved(capsys, tmp_path: Path):
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text(
+        """\
+apiVersion: argoproj.io/v1beta1
+kind: Workflow
+metadata:
+  name: single
+spec: {}
+"""
+    )
+
+    runner.invoke(str(yaml_path))
+
+    output = get_stdout(capsys)
+    assert output == (
+        "from hera.workflows import Workflow\n\n"
+        'with Workflow(api_version="argoproj.io/v1beta1", name="single") as w:\n'
+        "    pass\n"
+    )
 
 
 @pytest.mark.cli


### PR DESCRIPTION
- [x] Part of #1446
- [x] Tests added
- [ ] Documentation/examples added
- [x] Good commit messages and/or PR title

Description of PR
This trims redundant args from `hera generate python` output.

Right now a tiny workflow like `tests/cli/examples/single_workflow.yaml` turns into:
```python
from hera.workflows import Workflow

with Workflow(api_version="argoproj.io/v1alpha1", kind="Workflow", name="single") as w:
    pass
```

That works, but its kinda noisy. Hera already fills those defaults for us.

This PR skips `kind` when it matches the generated Hera class, and skips `api_version` when it matches the default config. Non default `apiVersion` still stays in the output, so roundtrip behavior is fine.

Repro:
```bash
. /tmp/hera-pr-venv/bin/activate
PYTHONPATH=src python - <<'PY'
from pathlib import Path
from hera._cli.generate.python import load_yaml_workflows, workflow_to_python
model = next(load_yaml_workflows(Path('tests/cli/examples/single_workflow.yaml')))
print(workflow_to_python(model))
PY
```

Checks run:
```bash
. /tmp/hera-pr-venv/bin/activate
PYTHONPATH=src pytest tests/cli/test_generate_python.py -q
```
