### PR TITLE
fix(cli): sort generated Python kwargs for readability

### DIFF
--- a/src/hera/_cli/generate/python.py
+++ b/src/hera/_cli/generate/python.py
@@ -217,7 +217,7 @@ class WorkflowPythonBuilder:
             context_expr=ast.Call(
                 func=ast.Name(id=hera_workflow_class.__name__, ctx=ast.Load()),
                 args=[],
-                keywords=keywords,
+                keywords=self._sort_keywords(keywords),
             ),
             optional_vars=ast.Name(id="w", ctx=ast.Store()),
         )
@@ -230,6 +230,27 @@ class WorkflowPythonBuilder:
         if attr == "api_version":
             return value == global_config.api_version
         return False
+
+    def _sort_keywords(self, keywords: List[ast.keyword]) -> List[ast.keyword]:
+        """Sort generated kwargs for readability.
+
+        This mirrors the requested ordering from issue #1446:
+        `name` first, then scalar values, then nested calls, then collections.
+        """
+
+        def keyword_order(keyword: ast.keyword) -> tuple[int, str]:
+            arg = keyword.arg or ""
+            if arg == "name":
+                return (0, arg)
+            if isinstance(keyword.value, ast.Constant):
+                return (1, arg)
+            if isinstance(keyword.value, ast.Call):
+                return (2, arg)
+            if isinstance(keyword.value, (ast.List, ast.Dict)):
+                return (3, arg)
+            return (4, arg)
+
+        return sorted(keywords, key=keyword_order)
 
     def _build_expression(
         self,
@@ -279,7 +300,7 @@ class WorkflowPythonBuilder:
             return ast.Call(
                 func=ast.Name(id=model_name, ctx=ast.Load()),
                 args=[],
-                keywords=keywords,
+                keywords=self._sort_keywords(keywords),
             )
 
         raise ValueError(f"Unsupported type: {type(value)} for value {value}")
@@ -379,7 +400,7 @@ class WorkflowPythonBuilder:
             value=ast.Call(
                 func=ast.Name(id=hera_template_class.__name__, ctx=ast.Load()),
                 args=[],
-                keywords=keywords,
+                keywords=self._sort_keywords(keywords),
             )
         )
 
@@ -462,7 +483,7 @@ class WorkflowPythonBuilder:
                     context_expr=ast.Call(
                         func=ast.Name(id=hera_template_class.__name__, ctx=ast.Load()),
                         args=[],
-                        keywords=keywords,
+                        keywords=self._sort_keywords(keywords),
                     ),
                     optional_vars=ast.Name(id=invocator_type, ctx=ast.Store()),
                 )
@@ -495,6 +516,6 @@ class WorkflowPythonBuilder:
             value=ast.Call(
                 func=ast.Name(id=hera_class.__name__, ctx=ast.Load()),
                 args=[],
-                keywords=keywords,
+                keywords=self._sort_keywords(keywords),
             )
         )

--- a/tests/cli/test_generate_python.py
+++ b/tests/cli/test_generate_python.py
@@ -143,9 +143,44 @@ spec: {}
     output = get_stdout(capsys)
     assert output == (
         "from hera.workflows import Workflow\n\n"
-        'with Workflow(api_version="argoproj.io/v1beta1", name="single") as w:\n'
+        'with Workflow(name="single", api_version="argoproj.io/v1beta1") as w:\n'
         "    pass\n"
     )
+
+
+@pytest.mark.cli
+def test_generated_kwargs_keep_name_and_scalars_before_nested_structures(capsys, tmp_path: Path):
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text(
+        """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: http-template-condition-
+spec:
+  entrypoint: main
+  templates:
+    - name: http-status-is-201
+      inputs:
+        parameters:
+          - name: url
+      http:
+        successCondition: "response.statusCode == 201"
+        url: "{{inputs.parameters.url}}"
+"""
+    )
+
+    runner.invoke(str(yaml_path))
+
+    output = get_stdout(capsys)
+    assert (
+        "HTTP(\n"
+        '        name="http-status-is-201",\n'
+        '        success_condition="response.statusCode == 201",\n'
+        '        url="{{inputs.parameters.url}}",\n'
+        '        inputs=Inputs(parameters=[Parameter(name="url")]),\n'
+        "    )\n"
+    ) in output
 
 
 @pytest.mark.cli


### PR DESCRIPTION
Pull Request Checklist
- [x] Part of #1446
- [x] Tests added
- [ ] Documentation/examples added
- [x] Good commit messages and/or PR title

Description of PR
Part of #1446.

`hera generate python` already emits valid code, but the arg order is kinda noisy rn. Nested bits like `inputs` can show up before `name` and simple scalar fields, so the generated code is harder to scan.

This keeps behavior the same and just sorts generated kwargs for readability. `name` goes first, then scalar values, then nested calls, then lists and dicts. Small QoL fix, cleans things up nicely.

Repro:
```bash
.venv/bin/python -m hera generate python examples/workflows/upstream/http-success-condition.upstream.yaml
```

Before:
```python
HTTP(
    inputs=Inputs(parameters=[Parameter(name="url")]),
    name="http-status-is-201",
    success_condition="response.statusCode == 201",
    url="{{inputs.parameters.url}}",
)
```

After:
```python
HTTP(
    name="http-status-is-201",
    success_condition="response.statusCode == 201",
    url="{{inputs.parameters.url}}",
    inputs=Inputs(parameters=[Parameter(name="url")]),
)
```

Checks run:
```bash
.venv/bin/python -m pytest tests/cli/test_generate_python.py --no-cov -q
```
