### PR TITLE
fix: isolate reused templates between workflows

### DIFF
--- a/src/hera/workflows/_context.py
+++ b/src/hera/workflows/_context.py
@@ -4,6 +4,7 @@ This module provides the functionality necessary to support the implementation b
 clauses for workflows and DAGs.
 """
 
+import copy
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import List, Optional
@@ -105,7 +106,7 @@ class _HeraContext:
                     found = True
                     break
             if not found:
-                pieces[0]._add_sub(node.template)
+                pieces[0]._add_sub(copy.deepcopy(node.template))
 
         # Add template to the current context (steps/parallel/dag/etc)
         pieces[-1]._add_sub(node)

--- a/src/hera/workflows/_meta_mixins.py
+++ b/src/hera/workflows/_meta_mixins.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import functools
 import inspect
 import sys
@@ -402,7 +403,7 @@ class CallableTemplateMixin(BaseMixin):
                 #   times, which can happen if "calling" the same script multiple times to add it to the workflow,
                 #   or initializing a second `Container` exactly like the first.
                 if isinstance(self, Script):
-                    _context.add_sub_node(self)
+                    _context.add_sub_node(copy.deepcopy(self))
                     return None
 
                 raise InvalidTemplateCall(

--- a/tests/test_unit/test_context.py
+++ b/tests/test_unit/test_context.py
@@ -240,3 +240,44 @@ def test_wrong_subtype_under_steps_context():
         with Workflow(generate_name="test-"):
             with Steps(name="test"):
                 Task(name="task", template=Container(name="container"))
+
+
+def test_reused_script_template_is_copied_per_workflow_when_called_under_steps():
+    @script()
+    def hello():
+        print("hello")
+
+    def build_workflow() -> Workflow:
+        with Workflow(generate_name="test-", entrypoint="steps") as w:
+            with Steps(name="steps"):
+                hello()
+        return w
+
+    first = build_workflow()
+    second = build_workflow()
+
+    assert first.templates[1] is not second.templates[1]
+
+    first.templates[1].name = "mutated"
+
+    assert second.templates[1].name == "hello"
+
+
+def test_reused_script_template_is_copied_per_workflow_when_called_under_workflow():
+    @script()
+    def hello():
+        print("hello")
+
+    def build_workflow() -> Workflow:
+        with Workflow(generate_name="test-") as w:
+            hello()
+        return w
+
+    first = build_workflow()
+    second = build_workflow()
+
+    assert first.templates[0] is not second.templates[0]
+
+    first.templates[0].name = "mutated"
+
+    assert second.templates[0].name == "hello"


### PR DESCRIPTION
Pull Request Checklist
- [x] Fixes #1148
- [x] Tests added
- [ ] Documentation/examples added
- [x] Good commit messages and/or PR title

Description of PR
Bug is real, pretty easy to hit in normal unit tests.
Two workflows built from the same `@script` can share one template object. If one test mutates `wf.templates[...]`, the next workflow can pick up that mutated state too. Kinda nasty.

This PR deep copies reusable templates when Hera attaches them to a workflow, so each workflow gets its own template instance.

Repro:
```py
wf1 = hello_world_example_wf()
wf2 = hello_world_example_wf()
wf1.templates[1].resources = None
assert wf2.templates[1].resources is not None
```
Before this fix, that assert fails.
