### PR TITLE
Fix YAML dump quoting for y/Y/n/N boolean aliases

### DIFF
--- a/src/hera/_yaml.py
+++ b/src/hera/_yaml.py
@@ -9,14 +9,25 @@ try:
 except ImportError:
     _yaml = None
 else:
+    # YAML 1.1 (used by Argo/kubectl) parses unquoted y/Y/n/N as booleans, but PyYAML
+    # leaves them unquoted on dump. Longer forms (yes, no, on, off, ...) are already
+    # quoted by PyYAML; only the single-letter forms need forcing here.
+    _YAML_1_1_BOOL_LITERALS = frozenset({"y", "Y", "n", "N"})
 
     def str_presenter(dumper, data):
-        """Configures yaml for dumping multiline strings.
+        """Represent string scalars so the dumped YAML stays safe for Argo/kubectl.
 
-        Ref: https://github.com/yaml/pyyaml/issues/240
+        - Multiline strings use block scalar style (``|``).
+        - Single-letter YAML 1.1 boolean literals (``y``, ``Y``, ``n``, ``N``) are
+          single-quoted so Argo/kubectl do not parse them as booleans.
+
+        Refs: https://github.com/yaml/pyyaml/issues/240
+              https://github.com/yaml/pyyaml/issues/791
         """
         if data.count("\n") > 0:  # check for multiline string
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+        if data in _YAML_1_1_BOOL_LITERALS:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
     _yaml.add_representer(str, str_presenter)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -27,6 +27,34 @@ def test_dump_does_not_wrap_long_strings_by_default():
     )
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "y",
+        "Y",
+        "yes",
+        "Yes",
+        "YES",
+        "on",
+        "On",
+        "ON",
+        "n",
+        "N",
+        "no",
+        "No",
+        "NO",
+        "off",
+        "Off",
+        "OFF",
+    ],
+)
+def test_dump_quotes_yaml_1_1_bool_aliases(value):
+    result = _yaml.dump({"name": value})
+
+    assert f"name: {value}" not in result.splitlines(), f"Argo/kubectl YAML 1.1 parses unquoted {value!r} as a boolean"
+    assert f"name: '{value}'" in result.splitlines()
+
+
 def test_dump_squashes_multiple_wrapped_expressions_on_one_line():
     result = _yaml._squash_wrapped_expressions(
         dedent(


### PR DESCRIPTION
Fixes #1597


**Pull Request Checklist**
- [x] Fixes #1597
- [x] Tests added
- [x] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, Hera's YAML export via `hera._yaml.dump()` / `Workflow.to_yaml()` can emit single-letter string values `y`, `Y`, `n`, and `N` without quotes. PyYAML leaves these unquoted on dump, but Argo Workflows and `kubectl` use YAML 1.1 semantics and parse them as booleans instead of strings.

For example:

```py
from hera import _yaml

_yaml.dump({"name": "y"})  # -> "name: y\n"
```

When applied with `kubectl` or submitted to Argo, `name` is interpreted as boolean `true`, not the string `"y"`.

This PR fixes the issue by extending Hera's custom PyYAML string representer in `src/hera/_yaml.py` (originally added in #935) to single-quote `y`, `Y`, `n`, and `N` when dumping strings. Longer YAML 1.1 boolean aliases (`yes`, `no`, `on`, `off`, etc.) are already quoted by PyYAML and do not need special handling.

Changes:
- Quote single-letter YAML 1.1 boolean aliases in the `str_presenter` hook
- Add parametrized regression tests in `tests/test_yaml.py`

Python `bool` values continue to dump as `true`/`false`; multiline strings still use block scalar style (`|`).

Fixes #1597

See also https://github.com/yaml/pyyaml/issues/791

## Test plan

- [x] `pytest tests/test_yaml.py`
- [x] `make ci` (lint, tests, type hints, CLI, codegen check)

