### PR TITLE
fix: keep `None` defaults on Pydantic Input/Output fields

### DIFF
--- a/src/hera/shared/_pydantic.py
+++ b/src/hera/shared/_pydantic.py
@@ -23,6 +23,20 @@ def get_fields(cls: Type[V1BaseModel] | Type[V2BaseModel]) -> Dict[str, FieldInf
         return cls.__fields__  # type: ignore
 
 
+def field_has_default(field_info: FieldInfo) -> bool:
+    """Whether the given field has a static default value, with V1 fallback.
+
+    Pydantic V1 sets `ModelField.default` to `None` for required fields, so `default` alone cannot
+    distinguish a required field from one that genuinely defaults to `None`. Fields using a
+    `default_factory` are reported as having no static default in both V1 and V2.
+    """
+    if hasattr(field_info, "is_required"):  # Pydantic V2 `FieldInfo`
+        required = field_info.is_required()
+    else:  # Pydantic V1 `ModelField`
+        required = bool(field_info.required)  # type: ignore[attr-defined]
+    return not required and field_info.default_factory is None
+
+
 def model_dump(obj: V1BaseModel | V2BaseModel) -> Dict[str, Any]:
     """Call model_dump, with V1 fallback."""
     if isinstance(obj, V1BaseModel):
@@ -48,6 +62,7 @@ class APIBaseModel(V2BaseModel):
 __all__ = [
     "APIBaseModel",
     "FieldInfo",
+    "field_has_default",
     "get_field_annotations",
     "get_fields",
     "model_dump",

--- a/src/hera/workflows/io/_io_mixins.py
+++ b/src/hera/workflows/io/_io_mixins.py
@@ -8,9 +8,8 @@ else:
 
 from pydantic import BaseModel as V2BaseModel
 from pydantic.v1 import BaseModel as V1BaseModel
-from pydantic_core import PydanticUndefined
 
-from hera.shared._pydantic import FieldInfo, get_field_annotations, get_fields, model_dump
+from hera.shared._pydantic import FieldInfo, field_has_default, get_field_annotations, get_fields, model_dump
 from hera.shared._type_util import construct_io_from_annotation, get_workflow_annotation
 from hera.shared.serialization import MISSING, serialize
 from hera.workflows.artifact import Artifact
@@ -49,7 +48,7 @@ class InputMixin:
                     )
                 if object_override:
                     param.default = serialize(getattr(object_override, field))
-                elif field_info.default is not None and field_info.default != PydanticUndefined:  # type: ignore
+                elif field_has_default(field_info):
                     # Serialize the value (usually done in Parameter's validator)
                     param.default = serialize(field_info.default)  # type: ignore
                 parameters.append(param)
@@ -118,10 +117,8 @@ class OutputMixin:
             if field in {"exit_code", "result"}:
                 continue
             if isinstance(annotation, Parameter):
-                if annotation.default is None:
-                    default = field_info.default
-                    if default is not None and default != PydanticUndefined:
-                        annotation.default = serialize(default)
+                if annotation.default is None and field_has_default(field_info):
+                    annotation.default = serialize(field_info.default)
 
                 if add_missing_path and annotation.value_from is None:
                     annotation.value_from = ValueFrom(path=f"/tmp/hera-outputs/parameters/{annotation.name}")
@@ -141,10 +138,9 @@ class OutputMixin:
             return output
 
         # Create a Parameter from basic type annotations
-        default = get_fields(cast(Type[V1BaseModel] | Type[V2BaseModel], cls))[field_name].default
-        if default is None or default == PydanticUndefined:
-            default = MISSING
-        return Parameter(name=field_name, default=default)  # type: ignore
+        field_info = get_fields(cast(Type[V1BaseModel] | Type[V2BaseModel], cls))[field_name]
+        default = field_info.default if field_has_default(field_info) else MISSING
+        return Parameter(name=field_name, default=default)
 
     def _get_as_invocator_output(self) -> List[Union[Artifact, Parameter]]:
         """Get the Output model as the output of a dag/steps template.

--- a/tests/script_annotations/pydantic_io_v1.py
+++ b/tests/script_annotations/pydantic_io_v1.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Annotated, List
+from typing import Annotated, List, Optional
 
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Workflow, script
 
@@ -92,6 +92,23 @@ def pydantic_io_within_generic(
     pass
 
 
+class NoneDefaultInput(Input):
+    my_optional_str: Optional[str] = None
+    my_optional_int: Optional[int] = None
+    my_required_str: str
+
+
+class NoneDefaultOutput(Output):
+    my_optional_output: Optional[str] = None
+
+
+@script(constructor="runner")
+def pydantic_io_none_defaults(
+    my_input: NoneDefaultInput,
+) -> NoneDefaultOutput:
+    pass
+
+
 with Workflow(generate_name="pydantic-io-") as w:
     pydantic_io_params()
     pydantic_io_params_unrelated_annotation()
@@ -99,3 +116,4 @@ with Workflow(generate_name="pydantic-io-") as w:
     pydantic_io()
     pydantic_io_with_defaults()
     pydantic_io_within_generic()
+    pydantic_io_none_defaults()

--- a/tests/script_annotations/pydantic_io_v2.py
+++ b/tests/script_annotations/pydantic_io_v2.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, List
+from typing import Annotated, List, Optional
 
 from hera.workflows import Artifact, ArtifactLoader, Parameter, Workflow, script
 from hera.workflows.io.v2 import (
@@ -84,6 +84,23 @@ def pydantic_io_within_generic(
     pass
 
 
+class NoneDefaultInput(Input):
+    my_optional_str: Optional[str] = None
+    my_optional_int: Optional[int] = None
+    my_required_str: str
+
+
+class NoneDefaultOutput(Output):
+    my_optional_output: Optional[str] = None
+
+
+@script(constructor="runner")
+def pydantic_io_none_defaults(
+    my_input: NoneDefaultInput,
+) -> NoneDefaultOutput:
+    pass
+
+
 with Workflow(generate_name="pydantic-io-") as w:
     pydantic_io_params()
     pydantic_io_params_unrelated_annotation()
@@ -91,3 +108,4 @@ with Workflow(generate_name="pydantic-io-") as w:
     pydantic_io()
     pydantic_io_with_defaults()
     pydantic_io_within_generic()
+    pydantic_io_none_defaults()

--- a/tests/test_script_annotations.py
+++ b/tests/test_script_annotations.py
@@ -325,6 +325,25 @@ def test_configmap(global_config_fixture):
             },
             id="runnerinput-within-generic",
         ),
+        pytest.param(
+            "pydantic_io_none_defaults",
+            {
+                "parameters": [
+                    {"name": "my_optional_str", "default": "null"},
+                    {"name": "my_optional_int", "default": "null"},
+                    {"name": "my_required_str"},
+                ],
+            },
+            {
+                "parameters": [
+                    {
+                        "name": "my_optional_output",
+                        "valueFrom": {"path": "/tmp/hera-outputs/parameters/my_optional_output"},
+                    },
+                ],
+            },
+            id="runnerinput-none-default",
+        ),
     ],
 )
 def test_script_pydantic_io(pydantic_mode, function_name, expected_input, expected_output):

--- a/tests/test_unit/test_pydantic_io_mixins.py
+++ b/tests/test_unit/test_pydantic_io_mixins.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Annotated
+from typing import Annotated, List, Optional
 
 from pydantic import Field
 
@@ -21,6 +21,30 @@ def test_get_parameters_unannotated():
         Parameter(name="foo"),
         Parameter(name="bar", default="a default"),
     ]
+
+
+def test_get_parameters_with_none_default():
+    class Foo(Input):
+        foo: Optional[str] = None
+        bar: Optional[int] = None
+        baz: Optional[str]
+
+    # `None` is a real default, so `foo` and `bar` get one (serialized to the string "null"),
+    # while `baz` has no default and stays a required input parameter.
+    assert Foo._get_parameters() == [
+        Parameter(name="foo", default=None),
+        Parameter(name="bar", default=None),
+        Parameter(name="baz"),
+    ]
+    assert [p.default for p in Foo._get_parameters()] == ["null", "null", None]
+
+
+def test_get_parameters_with_default_factory():
+    class Foo(Input):
+        foo: List[str] = Field(default_factory=list)
+
+    # A `default_factory` has no static value to serialize into the template
+    assert Foo._get_parameters() == [Parameter(name="foo")]
 
 
 def test_get_parameters_with_pydantic_annotations():
@@ -335,6 +359,27 @@ def test_get_outputs_no_path_unannotated():
         Parameter(name="fum", default=5),
         Parameter(name="bar", default="a default"),
     ]
+
+
+def test_get_outputs_no_path_with_none_default():
+    class Foo(Output):
+        foo: Optional[str] = None
+        bar: Optional[str]
+
+    assert Foo._get_outputs() == [
+        Parameter(name="foo", default=None),
+        Parameter(name="bar"),
+    ]
+    assert [p.default for p in Foo._get_outputs()] == ["null", None]
+
+
+def test_get_output_with_none_default():
+    class Foo(Output):
+        foo: Optional[str] = None
+        bar: Optional[str]
+
+    assert Foo._get_output("foo") == Parameter(name="foo", default=None)
+    assert Foo._get_output("bar") == Parameter(name="bar")
 
 
 def test_get_outputs_no_path_with_pydantic_annotations():


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, a `None` default on a Pydantic `Input`/`Output` field is silently dropped, so the generated template input parameter has no `default` and Argo treats it as required. The plain `@script` function path handles the same declaration correctly, so the two paths disagree on the most idiomatic way to write an optional parameter.

```py
class MyInput(Input):
    required_str: str
    with_default: int = 5
    optional_none: Optional[str] = None

@script(constructor="runner")
def pydantic_io(my_input: MyInput) -> MyOutput: ...

@script(constructor="runner")
def plain_fn(required_str: str, with_default: int = 5, optional_none: Optional[str] = None): ...
```

Before:

```yaml
  - name: pydantic-io
    inputs:
      parameters:
      - name: required_str
      - name: with_default
        default: '5'
      - name: optional_none        # <- no default, so Argo requires a value
  - name: plain-fn
    inputs:
      parameters:
      - name: required_str
      - name: with_default
        default: '5'
      - name: optional_none
        default: 'null'
```

After, both templates emit `default: 'null'` for `optional_none`.

So every call site now has to pass `optional_none` explicitly, even though the model itself validates fine without it — an input parameter with neither a `default` nor a supplied argument does not pass Argo's template validation. (I only verified the generated YAML locally, not against a live cluster.) If a template with that shape is invoked anyway, the runner raises `KeyError: 'optional_none'` at `kwargs[field]` in `map_field` (`src/hera/workflows/_runner/script_annotations_util.py:194`).

**Mechanism**

`src/hera/workflows/io/_io_mixins.py:52`:

```py
elif field_info.default is not None and field_info.default != PydanticUndefined:  # type: ignore
    # Serialize the value (usually done in Parameter's validator)
    param.default = serialize(field_info.default)  # type: ignore
```

The `default is not None` half of that guard is Pydantic V1 compatibility, not intent: a *required* V1 `ModelField` has `default is None` and `required is True`, whereas a required V2 `FieldInfo` has `default is PydanticUndefined`. Testing `default is not None` covers the V1 case but also swallows genuine `None` defaults in both versions. The same guard is repeated in `OutputMixin._get_outputs` (`:123`) and `OutputMixin._get_output` (`:145`).

This PR adds a `field_has_default` shim next to the existing `get_fields`/`model_dump` shims in `src/hera/shared/_pydantic.py`, which asks each Pydantic version the question it can actually answer (`FieldInfo.is_required()` in V2, `ModelField.required` in V1), and uses it at all three sites. Note that dropping the `None` check alone is not enough — it breaks three existing `pydantic_mode=1` cases in `tests/test_script_annotations.py`, because V1 then reports every required field as having a `None` default.

Fields declared with a `default_factory` keep their current behaviour of contributing no static default (`field_has_default` returns `False` for them), so `x: List[str] = Field(default_factory=list)` is unchanged; there is a test pinning that.

**Test plan**

Added:
- `tests/test_unit/test_pydantic_io_mixins.py`: `test_get_parameters_with_none_default`, `test_get_parameters_with_default_factory`, `test_get_outputs_no_path_with_none_default`, `test_get_output_with_none_default`
- `tests/script_annotations/pydantic_io_v{1,2}.py`: a `NoneDefaultInput`/`NoneDefaultOutput` pair and a `pydantic_io_none_defaults` script, plus a `runnerinput-none-default` case in `test_script_pydantic_io`, so the end-to-end build is asserted under both `pydantic_mode=1` and `pydantic_mode=2`

With the source change reverted and the tests kept:

```
FAILED tests/test_unit/test_pydantic_io_mixins.py::test_get_parameters_with_none_default
FAILED tests/test_unit/test_pydantic_io_mixins.py::test_get_outputs_no_path_with_none_default
FAILED tests/test_unit/test_pydantic_io_mixins.py::test_get_output_with_none_default
FAILED tests/test_script_annotations.py::test_script_pydantic_io[runnerinput-none-default-1]
FAILED tests/test_script_annotations.py::test_script_pydantic_io[runnerinput-none-default-2]
5 failed, 53 passed
```

With the fix:

```
58 passed
```

Gates run locally (Python 3.12, Pydantic 2):

```
ruff format . --check   888 files already formatted
ruff check .            All checks passed!
mypy -p hera            1 pre-existing error in src/hera/workflows/script.py:549, unchanged by this PR
pytest -m "not on_cluster"   1171 passed, 12 xfailed
```

No golden example YAML changed, so `make regenerate-test-data` was not needed.

**One thing worth flagging**

After this change, `optional_none: Optional[str] = None` emits `default: 'null'`, and the runner hands the function the *string* `"null"` rather than `None`, because `origin_type_issubtype(Optional[str], (str, NoneType))` short-circuits JSON decoding in `_runner/util.py`. `Optional[int] = None` round-trips to `None` correctly. That asymmetry already exists on the plain `@script` function path today — this PR makes the Pydantic IO path match it rather than introducing it — but if you would rather the `Optional[str]` case were handled too, I am happy to do that in a follow-up.
