### PR TITLE
feat(cli): generate dict-format arguments in Python output

### DIFF
--- a/src/hera/_cli/generate/python.py
+++ b/src/hera/_cli/generate/python.py
@@ -25,6 +25,7 @@ from hera.workflows.dag import DAG
 from hera.workflows.data import Data
 from hera.workflows.http_template import HTTP
 from hera.workflows.models import (
+    Arguments as _ModelArguments,
     ClusterWorkflowTemplate as _ModelClusterWorkflowTemplate,
     CronWorkflow as _ModelCronWorkflow,
     Metadata,
@@ -49,6 +50,9 @@ ModelWorkflow = Union[
 ]
 
 DEFAULT_EXTENSION = ".py"
+
+DICT_ARGUMENTS_CLASSES = frozenset({Workflow, WorkflowTemplate, ClusterWorkflowTemplate, CronWorkflow, Step, Task})
+"""The `hera.workflows` classes whose `arguments` field accepts the `{name: value}` dict shorthand."""
 
 
 def generate_python(options: GeneratePython):
@@ -198,7 +202,7 @@ class WorkflowPythonBuilder:
                     else:
                         if self._should_skip_workflow_kwarg(attr, value, hera_workflow_class):
                             continue
-                        value = self._build_expression(value)
+                        value = self._build_kwarg_expression(attr, value, hera_workflow_class)
                         keywords.append(
                             ast.keyword(
                                 arg=attr,
@@ -251,6 +255,41 @@ class WorkflowPythonBuilder:
             return (4, arg)
 
         return sorted(keywords, key=keyword_order)
+
+    def _build_kwarg_expression(self, attr: str, value: Any, hera_class: Any) -> ast.expr:
+        """Build the expression for a single constructor kwarg of `hera_class`."""
+        if attr == "arguments" and hera_class in DICT_ARGUMENTS_CLASSES:
+            dict_expression = self._try_build_arguments_dict(value)
+            if dict_expression is not None:
+                return dict_expression
+
+        return self._build_expression(value)
+
+    def _try_build_arguments_dict(self, value: Any) -> Optional[ast.Dict]:
+        """Build the `{name: value}` shorthand for `arguments`, or `None` if it would not round-trip.
+
+        `ArgumentsMixin` expands `{"foo": "bar"}` to a `Parameter(name="foo", value="bar")` and nothing
+        else, so the shorthand is only equivalent when there are no artifacts and every parameter sets
+        exactly `name` and `value`. Anything richer (`valueFrom`, `default`, `enum`, artifacts, ...)
+        falls back to an explicit `Arguments(...)` call.
+        """
+        if not isinstance(value, _ModelArguments) or value.artifacts or not value.parameters:
+            return None
+
+        keys: List[Optional[ast.expr]] = []
+        values: List[ast.expr] = []
+        seen: Set[str] = set()
+        for parameter in value.parameters:
+            if parameter.value is None or parameter.model_dump(exclude_none=True, exclude={"name", "value"}):
+                return None
+            if parameter.name in seen:
+                # Duplicate names would silently collapse into a single dict entry.
+                return None
+            seen.add(parameter.name)
+            keys.append(ast.Constant(value=parameter.name))
+            values.append(ast.Constant(value=parameter.value))
+
+        return ast.Dict(keys=keys, values=values)
 
     def _build_expression(
         self,
@@ -504,7 +543,7 @@ class WorkflowPythonBuilder:
         keywords: List[ast.keyword] = []
         for field in hera_class_fields:
             if field in template_keys and getattr(model_class_obj, field) is not None:
-                val = self._build_expression(getattr(model_class_obj, field))
+                val = self._build_kwarg_expression(field, getattr(model_class_obj, field), hera_class)
                 keywords.append(
                     ast.keyword(
                         arg=field,

--- a/tests/cli/test_generate_python.py
+++ b/tests/cli/test_generate_python.py
@@ -184,6 +184,126 @@ spec:
 
 
 @pytest.mark.cli
+def test_name_value_arguments_are_generated_as_a_dict(capsys, tmp_path: Path):
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text(
+        """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ci-example-
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: revision
+        value: cfe12d6
+  templates:
+    - name: main
+      steps:
+        - - name: build
+            template: echo
+            arguments:
+              parameters:
+                - name: revision
+                  value: "{{workflow.parameters.revision}}"
+    - name: fan-out
+      dag:
+        tasks:
+          - name: test
+            template: echo
+            arguments:
+              parameters:
+                - name: revision
+                  value: "{{workflow.parameters.revision}}"
+                - name: verbose
+                  value: "true"
+    - name: echo
+      container:
+        image: alpine:latest
+"""
+    )
+
+    runner.invoke(str(yaml_path))
+
+    output = get_stdout(capsys)
+    assert 'arguments={"revision": "cfe12d6"}' in output
+    assert 'arguments={"revision": "{{workflow.parameters.revision}}"}' in output
+    assert (
+        "            arguments={\n"
+        '                "revision": "{{workflow.parameters.revision}}",\n'
+        '                "verbose": "true",\n'
+        "            },\n"
+    ) in output
+    # The `Arguments` model class is no longer needed, so it should not be imported.
+    assert "Arguments" not in output
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    "arguments_yaml",
+    [
+        pytest.param(
+            """\
+    parameters:
+      - name: revision
+        valueFrom:
+          configMapKeyRef:
+            name: revision-config
+            key: revision
+""",
+            id="value-from",
+        ),
+        pytest.param(
+            """\
+    parameters:
+      - name: revision
+        value: cfe12d6
+        default: HEAD
+""",
+            id="default",
+        ),
+        pytest.param(
+            """\
+    parameters:
+      - name: revision
+        value: cfe12d6
+    artifacts:
+      - name: source
+        path: /src
+""",
+            id="artifacts",
+        ),
+    ],
+)
+def test_arguments_that_would_not_round_trip_keep_the_arguments_class(capsys, tmp_path: Path, arguments_yaml: str):
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text(
+        """\
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ci-example-
+spec:
+  entrypoint: main
+  arguments:
+"""
+        + arguments_yaml
+        + """\
+  templates:
+    - name: main
+      container:
+        image: alpine:latest
+"""
+    )
+
+    runner.invoke(str(yaml_path))
+
+    output = get_stdout(capsys)
+    assert "arguments=Arguments(" in output
+
+
+@pytest.mark.cli
 def test_workflow_template(capsys):
     runner.invoke("tests/cli/examples/workflow_template.yaml")
 


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Part of #1446
- [x] Tests added
- [ ] Documentation/examples added
- [x] Good commit messages and/or PR title

**Description of PR**

`hera generate python` always spells `arguments` out as an `Arguments(parameters=[Parameter(...)])` call, even when the parameters are plain name/value pairs. Hera itself takes a dict there, so the generated code doesn't look like code anyone would write by hand.

`examples/workflows/upstream/ci.upstream.yaml` today:

```python
with Workflow(
    entrypoint="ci-example",
    generate_name="ci-example-",
    arguments=Arguments(parameters=[Parameter(name="revision", value="cfe12d6")]),
    ...
) as w:
    with Steps(...) as steps:
        Step(
            name="build",
            template="build-golang-example",
            arguments=Arguments(
                parameters=[
                    Parameter(name="revision", value="{{inputs.parameters.revision}}")
                ]
            ),
        )
```

After:

```python
with Workflow(
    entrypoint="ci-example",
    generate_name="ci-example-",
    arguments={"revision": "cfe12d6"},
    ...
) as w:
    with Steps(...) as steps:
        Step(
            name="build",
            template="build-golang-example",
            arguments={"revision": "{{inputs.parameters.revision}}"},
        )
```

`ArgumentsMixin._build_arguments` turns `{"revision": "cfe12d6"}` into `Parameter(name="revision", value="cfe12d6")` and then `.as_argument()`/`.as_input()`, both of which emit a model `Parameter` with only `name` and `value` set. So the shorthand is byte-identical on the way back out, but only for that exact shape — `_try_build_arguments_dict` therefore returns `None` (and we fall back to `Arguments(...)`) if there are artifacts, if any parameter sets anything beyond `name`/`value` (`valueFrom`, `default`, `enum`, `globalName`, ...), or if two parameters share a name and would collapse into one dict key.

It's also gated on the six `hera.workflows` dataclasses that actually accept the shorthand — `Workflow`, `WorkflowTemplate`, `ClusterWorkflowTemplate`, `CronWorkflow`, `Step`, `Task`. `LifecycleHook` and `Submit` have an `arguments` field too but are model-only, so a blanket special case in `_build_expression` would generate invalid code for them.

One side effect worth flagging: `_sort_keywords` buckets by AST node type, so `arguments` moves from the "nested call" bucket to the "collections" bucket. Across the 211 upstream examples, 21 of them show `arguments` sorting slightly later than before (e.g. `Step(name=..., template_ref=..., arguments={...})` instead of `Step(name=..., arguments=..., template_ref=...)`). Cosmetic, and round-trip-neutral. `Arguments` also drops out of the generated import block when it's no longer used.

Repro:

```bash
.venv/bin/python -m hera generate python examples/workflows/upstream/ci.upstream.yaml
```

Tests added in `tests/cli/test_generate_python.py`: one covering the dict output for `Workflow`, `Step` and `Task` (plus asserting `Arguments` is no longer imported), and a parametrized negative test covering `valueFrom`, `default` and `artifacts`, which must keep emitting `Arguments(...)`. The first fails on `main` and passes with this change.

Checks run:

```bash
.venv/bin/python -m pytest tests/cli --no-cov -q          # 243 passed, 11 xfailed
.venv/bin/ruff check . && .venv/bin/ruff format . --check
.venv/bin/mypy -p hera
```

The `test_yaml_converter` round trip over every `*.upstream.yaml` still passes unchanged (the 11 xfails are the pre-existing `SKIP_FILES`), and no `examples/` golden files needed regenerating.
