### PR TITLE
fix: quote strings that go-yaml resolves as numbers in YAML output

### DIFF
--- a/src/hera/_yaml.py
+++ b/src/hera/_yaml.py
@@ -1,3 +1,4 @@
+import re
 from types import ModuleType
 from typing import Optional
 
@@ -14,19 +15,35 @@ else:
     # quoted by PyYAML; only the single-letter forms need forcing here.
     _YAML_1_1_BOOL_LITERALS = frozenset({"y", "Y", "n", "N"})
 
+    # go-yaml (used by Argo/kubectl) resolves more plain scalars as numbers than PyYAML does:
+    # exponents without a dot or a signed exponent (1e3, 1e-5, 1.5e3), signed dot-floats (+.5),
+    # 0o/0X prefixes, leading-zero decimals (08) and underscores anywhere (1_0e3). PyYAML leaves
+    # these unquoted on dump, so they would change type on the way to Argo. The patterns mirror
+    # strconv.ParseInt(s, 0, 64) and go-yaml's yamlStyleFloat, applied after removing underscores.
+    _GO_YAML_INT = re.compile(r"[-+]?(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|0[0-7]*|[1-9][0-9]*)")
+    _GO_YAML_FLOAT = re.compile(r"[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][-+]?[0-9]+)?")
+
+    def _is_go_yaml_number(data: str) -> bool:
+        if not data or data[0] not in "-+.0123456789":
+            return False
+        plain = data.replace("_", "")
+        return bool(_GO_YAML_INT.fullmatch(plain) or _GO_YAML_FLOAT.fullmatch(plain))
+
     def str_presenter(dumper, data):
         """Represent string scalars so the dumped YAML stays safe for Argo/kubectl.
 
         - Multiline strings use block scalar style (``|``).
         - Single-letter YAML 1.1 boolean literals (``y``, ``Y``, ``n``, ``N``) are
           single-quoted so Argo/kubectl do not parse them as booleans.
+        - Strings that go-yaml would resolve as a number (``1e-5``, ``0o17``, ``08``, ...)
+          are single-quoted so Argo/kubectl keep them as strings.
 
         Refs: https://github.com/yaml/pyyaml/issues/240
               https://github.com/yaml/pyyaml/issues/791
         """
         if data.count("\n") > 0:  # check for multiline string
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
-        if data in _YAML_1_1_BOOL_LITERALS:
+        if data in _YAML_1_1_BOOL_LITERALS or _is_go_yaml_number(data):
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -55,6 +55,58 @@ def test_dump_quotes_yaml_1_1_bool_aliases(value):
     assert f"name: '{value}'" in result.splitlines()
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1e3",
+        "1E3",
+        "1e+3",
+        "1e-3",
+        "1e-5",
+        "1.5e3",
+        "1.e3",
+        "+1e3",
+        "-1e3",
+        "1e03",
+        "+.5",
+        "-.5",
+        "0X1F",
+        "0o17",
+        "0O17",
+        "08",
+        "1_0e3",
+    ],
+)
+def test_dump_quotes_strings_that_go_yaml_resolves_as_numbers(value):
+    result = _yaml.dump({"name": value})
+
+    assert f"name: {value}" not in result.splitlines(), f"Argo/kubectl parses unquoted {value!r} as a number"
+    assert f"name: '{value}'" in result.splitlines()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1e",
+        "e3",
+        ".e3",
+        "1e3.5",
+        "0x",
+        "0o",
+        "v1.2.3",
+        "1.2.3",
+        "3.12-alpine",
+        "10.0.0.1",
+        "abc",
+        "1.2.3-rc1",
+    ],
+)
+def test_dump_leaves_non_numeric_strings_unquoted(value):
+    result = _yaml.dump({"name": value})
+
+    assert f"name: {value}" in result.splitlines()
+
+
 def test_dump_squashes_multiple_wrapped_expressions_on_one_line():
     result = _yaml._squash_wrapped_expressions(
         dedent(


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #1607
- [x] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**

Currently, `hera._yaml.dump()` / `Workflow.to_yaml()` leave some strings unquoted that go-yaml (Argo, `kubectl`) parses as numbers. PyYAML quotes what its own YAML 1.1 resolver recognises, but go-yaml also resolves exponents without a dot or a signed exponent (`1e3`, `1e-5`, `1.5e3`), signed dot-floats (`+.5`), `0o`/`0X` prefixes, leading-zero decimals (`08`) and underscores anywhere (`1_0e3`). A parameter or env value like `"1e-5"` is therefore emitted as `value: 1e-5`, which the schema-carrying Argo CRDs reject (`must be of type string`) and the minimal CRDs store as the float `1e-05`.

This PR extends the `str_presenter` from #1598 to single-quote strings that go-yaml would read as a number. The check mirrors go-yaml's resolver: `strconv.ParseInt(s, 0, 64)` and its `yamlStyleFloat` regex, applied after removing underscores, and only for scalars starting with a digit, sign or dot (the only prefixes go-yaml tries numbers for). Quoting is always safe, so erring on the side of quoting does not change any value.

Repro:

```py
from hera import _yaml

print(_yaml.dump({"value": "1e-5"}))
print(_yaml.dump({"value": "0o17"}))
```

Before:

```yaml
value: 1e-5
value: 0o17
```

After:

```yaml
value: '1e-5'
value: '0o17'
```

Verified the gap with a small Go program using `gopkg.in/yaml.v2` and `sigs.k8s.io/yaml`: every value in the new test is resolved as a number by go-yaml, and every value in the negative test stays a string. Also applied a Hera-generated `WorkflowTemplate` with `value: "1e-5"` to a kind cluster with the Argo v4.1.2 CRDs: rejected before this change, accepted and stored as a string after it. `make ci` passes locally (Python 3.14).

