### PR TITLE
fix(cli): create parent directories for nested output paths

### DIFF
--- a/src/hera/_cli/generate/util.py
+++ b/src/hera/_cli/generate/util.py
@@ -66,12 +66,12 @@ def write_output(
     dest_is_file = output_path.suffix.lower() in extensions or output_path.exists() and output_path.is_file()
 
     if dest_is_file:
-        output_path.parent.mkdir(exist_ok=True)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         output = join_delimiter.join(input_paths_to_output.values())
         output_path.write_text(output)
     else:
-        output_path.mkdir(exist_ok=True)
+        output_path.mkdir(parents=True, exist_ok=True)
 
         for dest_path, content in input_paths_to_output.items():
             dest = (output_path / dest_path).with_suffix(default_extension)

--- a/tests/cli/test_generate_yaml.py
+++ b/tests/cli/test_generate_yaml.py
@@ -164,10 +164,12 @@ def test_scan_folder(capsys):
 
 
 @pytest.mark.cli
+@pytest.mark.parametrize("relative_path", ["my_dir/foo.yaml", "build/manifests/foo.yaml"])
 def test_source_file_to_single_file(
     tmp_path: Path,
+    relative_path: str,
 ):
-    output_file = tmp_path / "my_dir/foo.yaml"
+    output_file = tmp_path / relative_path
     assert not output_file.parent.exists()  # ensure folder created
 
     runner.invoke("tests/cli/examples/single_workflow.py", "--to", str(output_file))
@@ -191,13 +193,16 @@ def test_source_folder_to_single_file(
 
 
 @pytest.mark.cli
+@pytest.mark.parametrize("relative_path", [".", "build/manifests"])
 def test_source_file_to_output_folder(
     tmp_path: Path,
+    relative_path: str,
 ):
-    runner.invoke("tests/cli/examples/single_workflow.py", "--to", str(tmp_path))
+    output_folder = tmp_path / relative_path
+    runner.invoke("tests/cli/examples/single_workflow.py", "--to", str(output_folder))
 
-    assert (tmp_path / "single_workflow.yaml").exists()
-    assert (tmp_path / "single_workflow.yaml").read_text() == single_workflow_output
+    assert (output_folder / "single_workflow.yaml").exists()
+    assert (output_folder / "single_workflow.yaml").read_text() == single_workflow_output
 
 
 @pytest.mark.cli


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Tests added
- [ ] Documentation/examples added
- [x] Descriptive commit message and PR title

**Description of PR**

`hera generate yaml ... --to build/manifests/workflow.yaml` raises `FileNotFoundError` if `build` does not exist. A nested directory destination such as `--to build/manifests` fails similarly. The shared `write_output` helper creates only the last directory, although it already creates parents for individual files inside a directory destination.

Use `parents=True` for both destination-creation calls. This also applies to Python generation through the same helper. Extend existing CLI tests to cover nested output files and folders while retaining their existing shallow/existing-directory cases and exact output-content assertions.

Validation: the two added nested-path cases fail before the source fix and pass afterward. The full CLI suite passes (241 passed, 11 existing xfails). Repository-wide Ruff formatting and lint checks pass. Mypy reports the existing covariant `FuncRCov` issue in `workflows/script.py:549`, also recorded on the unchanged `ee518f5` baseline. Full on-cluster tests and code generation were not run; this change does not affect workflow schemas or environment setup.
