### PR TITLE
fix(cli): handle empty and missing-kind YAML documents

### DIFF
--- a/src/hera/_cli/generate/python.py
+++ b/src/hera/_cli/generate/python.py
@@ -78,20 +78,37 @@ def generate_python(options: GeneratePython):
 
 def load_yaml_workflows(path: Path) -> Generator[ModelWorkflow, None, None]:
     """Load the YAML file containing a Workflow(s)."""
-    for yaml_workflow in yaml.safe_load_all(path.read_text()):
-        if isinstance(yaml_workflow, dict):
-            if yaml_workflow["kind"] == "Workflow":
-                yield _ModelWorkflow.model_validate(yaml_workflow)
-            elif yaml_workflow["kind"] == "WorkflowTemplate":
-                yield _ModelWorkflowTemplate.model_validate(yaml_workflow)
-            elif yaml_workflow["kind"] == "ClusterWorkflowTemplate":
-                yield _ModelClusterWorkflowTemplate.model_validate(yaml_workflow)
-            elif yaml_workflow["kind"] == "CronWorkflow":
-                yield _ModelCronWorkflow.model_validate(yaml_workflow)
+    loader = yaml.SafeLoader(path.read_text())
+    try:
+        while loader.check_data():
+            node = loader.get_node()
+            # Empty documents have an implicit null scalar with no source content.
+            # Explicit null values remain invalid workflows.
+            if (
+                isinstance(node, yaml.ScalarNode)
+                and node.tag == "tag:yaml.org,2002:null"
+                and node.start_mark.index == node.end_mark.index
+            ):
+                continue
+            yaml_workflow = loader.construct_document(node)
+            if isinstance(yaml_workflow, dict):
+                kind = yaml_workflow.get("kind")
+                if kind == "Workflow":
+                    yield _ModelWorkflow.model_validate(yaml_workflow)
+                elif kind == "WorkflowTemplate":
+                    yield _ModelWorkflowTemplate.model_validate(yaml_workflow)
+                elif kind == "ClusterWorkflowTemplate":
+                    yield _ModelClusterWorkflowTemplate.model_validate(yaml_workflow)
+                elif kind == "CronWorkflow":
+                    yield _ModelCronWorkflow.model_validate(yaml_workflow)
+                elif kind is None:
+                    raise ValueError("Invalid YAML workflow: missing kind")
+                else:
+                    raise ValueError(f"Unrecognised Workflow kind: {kind}")
             else:
-                raise ValueError(f"Unrecognised Workflow kind: {yaml_workflow['kind']}")
-        else:
-            raise ValueError(f"Invalid YAML workflow: {yaml_workflow}")
+                raise ValueError(f"Invalid YAML workflow: {yaml_workflow}")
+    finally:
+        loader.dispose()
 
 
 def workflow_to_python(model: ModelWorkflow) -> str:

--- a/tests/cli/test_generate_python.py
+++ b/tests/cli/test_generate_python.py
@@ -352,3 +352,71 @@ def test_recursive_flatten_source_folder_to_output_folder_with_name_clash_append
 
     assert (output_folder / "single_workflow.py").exists()
     assert (output_folder / "single_workflow.py").read_text() == "\n".join([single_workflow_output] * 2)
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("prefix", "separator", "suffix"),
+    [
+        ("---\n---\n", "---\n", ""),
+        ("", "---\n", "---\n"),
+        ("", "---\n---\n---\n", ""),
+        ("---\n# empty\n---\n", "---\n# empty\n---\n", "---\n# empty\n...\n"),
+    ],
+    ids=["leading", "trailing", "consecutive", "comments"],
+)
+def test_empty_yaml_documents_between_workflows(capsys, tmp_path: Path, prefix: str, separator: str, suffix: str):
+    workflows = Path("tests/cli/examples/multiple_workflow.yaml").read_text().split("---\n")
+    yaml_path = tmp_path / "workflows.yaml"
+    yaml_path.write_text(prefix + separator.join(workflows) + suffix)
+
+    runner.invoke(str(yaml_path))
+
+    assert get_stdout(capsys) == multiple_workflow_output
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize("content", ["", "# empty\n", "---\n", "---\n---\n...\n"])
+def test_empty_yaml_documents_only(capsys, tmp_path: Path, content: str):
+    yaml_path = tmp_path / "empty.yaml"
+    yaml_path.write_text(content)
+
+    runner.invoke(str(yaml_path))
+    assert get_stdout(capsys) == ""
+
+    output_path = tmp_path / "empty.py"
+    runner.invoke(str(yaml_path), "--to", str(output_path))
+    assert output_path.read_text() == ""
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("null", "Invalid YAML workflow: None"),
+        ("~", "Invalid YAML workflow: None"),
+        ('!!null ""', "Invalid YAML workflow: None"),
+        ('""', "Invalid YAML workflow: "),
+        ("false", "Invalid YAML workflow: False"),
+        ("0", "Invalid YAML workflow: 0"),
+        ("[]", "Invalid YAML workflow: []"),
+        ("kind: ConfigMap", "Unrecognised Workflow kind: ConfigMap"),
+    ],
+)
+def test_nonempty_invalid_yaml_documents(tmp_path: Path, content: str, message: str):
+    yaml_path = tmp_path / "invalid.yaml"
+    yaml_path.write_text(content)
+
+    with pytest.raises(ValueError) as exc:
+        runner.invoke(str(yaml_path))
+    assert str(exc.value) == message
+
+
+@pytest.mark.cli
+@pytest.mark.parametrize("content", ["{}", "metadata:\n  name: no-kind"])
+def test_yaml_document_missing_kind(tmp_path: Path, content: str):
+    yaml_path = tmp_path / "invalid.yaml"
+    yaml_path.write_text(content)
+
+    with pytest.raises(ValueError, match="Invalid YAML workflow: missing kind"):
+        runner.invoke(str(yaml_path))


### PR DESCRIPTION
## Summary

- Ignore implicit empty YAML documents created by leading, consecutive, or trailing separators.
- Raise a clear `ValueError` when a YAML mapping does not declare `kind`, instead of exposing a `KeyError`.
- Preserve validation for explicit nulls, scalars, lists, and unsupported kinds.

## Validation

- `pytest -k cli`: 260 passed, 2 skipped, 11 xfailed
- Focused YAML-generator regressions: 18 passed
- `ruff check` and `ruff format --check` on changed files
- `git diff --check`

The non-CLI suite has six pre-existing/environmental failures in upstream-example round-trips and a missing `pip` executable; the generator path is not involved.